### PR TITLE
fix(security): resolve high-severity flatted vulnerability for npm au…

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -5490,9 +5490,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.1.tgz",
+      "integrity": "sha512-IxfVbRFVlV8V/yRaGzk0UVIcsKKHMSfYw66T/u4nTwlWteQePsxe//LjudR1AMX4tZW3WFCh3Zqa/sjlqpbURQ==",
       "dev": true,
       "license": "ISC"
     },


### PR DESCRIPTION
…dit CI

- Bump flatted 3.3.3 → 3.4.1 (GHSA-25h7-pfq9-p65f, unbounded recursion DoS)
- npm audit --audit-level=high now passes; Security Audit workflow succeeds
- Leaves 4 moderate (esbuild/vitest) for future non-breaking fix