### PR TITLE
Update contact email in Code of Conduct

### DIFF
--- a/docs/CODE_OF_CONDUCT.md
+++ b/docs/CODE_OF_CONDUCT.md
@@ -65,7 +65,7 @@ This Code of Conduct applies within all community spaces, and also applies when 
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the project maintainers responsible for enforcement at [conduct@extensionshield.com](mailto:conduct@extensionshield.com). All complaints will be reviewed and investigated promptly and fairly.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the project maintainers responsible for enforcement at [support@extensionshield.com](mailto:support@extensionshield.com). All complaints will be reviewed and investigated promptly and fairly.
 
 All project maintainers are obligated to respect the privacy and security of the reporter of any incident.
 
@@ -73,6 +73,8 @@ All project maintainers are obligated to respect the privacy and security of the
 
 ## Attribution
 
-This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).
+This Code of Conduct is adapted from the  
+[Contributor Covenant, version 2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).
+
 
 Back to [README](../README.md).


### PR DESCRIPTION
* Updated the Contact email in the Enforcement Section.
* Edited the email section with the proper mailto link format.
* The attribution clean hyperlink text, for example: Contributor Covenant, version 2.1 formatting