### PR TITLE
fix: Remove scoring bias against small user bases and management perm…

### DIFF
--- a/src/extension_shield/core/analyzers/webstore.py
+++ b/src/extension_shield/core/analyzers/webstore.py
@@ -28,7 +28,13 @@ class WebstoreAnalyzer(BaseAnalyzer):
 
     @staticmethod
     def _check_user_engagement_patterns(metadata: Dict) -> List[str]:
-        """Check user engagement patterns for suspicious indicators."""
+        """Check user engagement patterns for suspicious indicators.
+
+        Fairness note: User count is a weak signal. Many legitimate niche tools,
+        developer utilities, and enterprise extensions naturally have small user
+        bases. We flag only extreme cases and always note the context to avoid
+        penalizing extensions solely for being specialized or new.
+        """
         flags = []
 
         user_count = metadata.get("user_count")
@@ -43,27 +49,32 @@ class WebstoreAnalyzer(BaseAnalyzer):
         if rating is None:
             rating = 0.0
 
-        # Low review ratio (fewer than 1% of users reviewed)
-        if user_count > 0 and ratings_count > 0:
+        # Low review ratio — only flag for extensions with enough users to
+        # expect reviews (>1000), otherwise low ratio is normal for niche tools
+        if user_count > 1000 and ratings_count > 0:
             review_ratio = ratings_count / user_count
             if review_ratio < 0.01:
                 flags.append(f"Review ratio lower than 1%. ({review_ratio:.4f} < 0.01)")
 
-        # Low user count (< 1,000 users)
-        if user_count < 1000:
-            flags.append(f"Low user count: {user_count} users (< 1,000)")
-
-        # Low ratings count (< 50 ratings)
-        if 0 < ratings_count < 50:
-            flags.append(f"Low ratings count: {ratings_count} ratings (< 50)")
+        # Contextual note for small user base — informational, not a risk flag.
+        # Only flag if fewer than 50 users (very new/experimental).
+        if 0 < user_count < 50:
+            flags.append(
+                f"Very small user base ({user_count} users). "
+                "This is common for new or niche developer tools and is not inherently risky."
+            )
 
         # No ratings at all
         if ratings_count == 0:
-            flags.append("No ratings at all")
+            flags.append("No ratings yet — less community vetting available")
 
-        # Low average rating (< 3.5)
-        if 0 < rating < 3.5:
-            flags.append(f"Low average rating: {rating} (< 3.5)")
+        # Low ratings count — only flag if there are enough users to expect ratings
+        elif 0 < ratings_count < 10 and user_count > 500:
+            flags.append(f"Low ratings count relative to users: {ratings_count} ratings")
+
+        # Low average rating — objective quality signal
+        if 0 < rating < 3.0:
+            flags.append(f"Low average rating: {rating} (< 3.0)")
 
         return flags
 

--- a/src/extension_shield/core/security_scorer.py
+++ b/src/extension_shield/core/security_scorer.py
@@ -41,10 +41,13 @@ class SecurityScorer:
         'manifest': 5,         # Manifest issues
     }
 
-    # High-risk permissions that warrant extra scrutiny
+    # High-risk permissions that warrant extra scrutiny.
+    # Note: 'management' is excluded because it is commonly used by legitimate
+    # extension management/auditing tools. Its risk depends on context (assessed
+    # by the LLM permission analyzer), not a blanket penalty.
     HIGH_RISK_PERMISSIONS = {
         'debugger', 'webRequest', 'webRequestBlocking', 'cookies',
-        'clipboardRead', 'nativeMessaging', 'proxy', 'management',
+        'clipboardRead', 'nativeMessaging', 'proxy',
         'desktopCapture', 'tabCapture', 'browsingData', 'history'
     }
 
@@ -320,12 +323,14 @@ class SecurityScorer:
             except (ValueError, TypeError):
                 pass
 
+        # User count is a weak signal — niche/developer tools naturally have
+        # small user bases. Only penalize in extreme cases (no users at all).
         if user_count is not None:
             try:
                 user_count_int = int(user_count)
-                if user_count_int < 100:
-                    users_risk = 2
-                    risk += 2
+                if user_count_int == 0:
+                    users_risk = 1
+                    risk += 1
             except (ValueError, TypeError):
                 pass
 

--- a/src/extension_shield/governance/signal_extractor.py
+++ b/src/extension_shield/governance/signal_extractor.py
@@ -591,23 +591,30 @@ class SignalExtractor:
         return signals
     
     def _extract_webstore_signals(self, signal_pack: "SignalPack") -> List[Signal]:
-        """Extract signals from webstore stats in SignalPack."""
+        """Extract signals from webstore stats in SignalPack.
+
+        Fairness: User count alone is NOT a trust signal. Niche developer tools,
+        enterprise extensions, and specialized utilities naturally have small user
+        bases. We only flag concrete quality/compliance issues.
+        """
         signals = []
         stats = signal_pack.webstore_stats
         reviews = signal_pack.webstore_reviews
-        
-        # Low trust indicators
+
+        # Low trust indicators — only concrete quality/compliance gaps
         low_trust_reasons = []
-        
-        if stats.installs is not None and stats.installs < 1000:
-            low_trust_reasons.append(f"low installs ({stats.installs})")
-        
-        if stats.rating_avg is not None and stats.rating_avg < 3.5:
+
+        # Low rating is an objective quality signal from actual users
+        if stats.rating_avg is not None and stats.rating_avg < 3.0:
             low_trust_reasons.append(f"low rating ({stats.rating_avg})")
-        
+
+        # Missing privacy policy is a concrete compliance gap
         if not stats.has_privacy_policy:
             low_trust_reasons.append("no privacy policy")
-        
+
+        # NOTE: Low user count is NOT included as a trust signal.
+        # Many legitimate extensions have small user bases.
+
         if len(low_trust_reasons) >= 2:
             signals.append(Signal(
                 signal_id=self._next_signal_id(),

--- a/src/extension_shield/llm/prompts/permission_analysis.yaml
+++ b/src/extension_shield/llm/prompts/permission_analysis.yaml
@@ -2,6 +2,17 @@ permission_analysis: |
   You are a cybersecurity expert specializing in browser extension security analysis.
   Your task is to evaluate whether a specific permission request is justified for the given chrome extension.
 
+  ### Fairness Principles (MUST FOLLOW)
+  - Judge the permission SOLELY based on whether the extension's stated purpose
+    requires it. Do NOT consider the extension's popularity, user count, or brand.
+  - Apply IDENTICAL standards to all extensions. If the 'management' permission is
+    reasonable for one extension-auditing tool, it is equally reasonable for ANY
+    extension-auditing tool, regardless of name or developer.
+  - A permission is "reasonable" if the extension's description indicates a functional
+    need for the capability the permission provides.
+  - Do NOT assume malicious intent without evidence. A permission is unreasonable only
+    if it has no plausible connection to the extension's stated purpose.
+
   <chrome_extension>
     <name>{extension_name}</name>
     <description>{extension_description}</description>

--- a/src/extension_shield/llm/prompts/summary_generation.yaml
+++ b/src/extension_shield/llm/prompts/summary_generation.yaml
@@ -147,6 +147,17 @@ summary_generation: |
     - Host access scope is authoritative (ALL_WEBSITES, SINGLE_DOMAIN, etc.)
     - Output ONLY valid JSON
 
+    FAIRNESS & BIAS PREVENTION (CRITICAL):
+    - User count is NOT a risk factor. Niche/developer/enterprise tools naturally have
+      small user bases. Never penalize for low user count — note limited vetting as context only.
+    - Judge permissions by functional necessity, not by name. 'management' is standard
+      for extension-auditing tools; if the purpose justifies it, it is not a risk.
+    - Apply identical standards to all extensions. Same permissions + same purpose =
+      same risk level, regardless of name, developer, or popularity.
+    - Focus on actual security impact: unjustified data access, suspicious external
+      communication, obfuscated code. Low user count, missing badges, non-featured
+      status are NOT security risks.
+
   user: |
     Source of truth (do not override):
     - score: {{ score }}

--- a/src/extension_shield/llm/prompts/webstore_analysis.yaml
+++ b/src/extension_shield/llm/prompts/webstore_analysis.yaml
@@ -24,10 +24,21 @@ webstore_analysis: |
 
   Based on the metadata and detected red flags, evaluate the reputation risk level of this extension.
 
+  ### Fairness Principles (MUST FOLLOW)
+  - **User count alone is NEVER a risk factor.** Niche developer tools, enterprise utilities,
+    and specialized extensions naturally have small user bases. Low user count simply means
+    less community vetting — it does NOT indicate the extension is risky.
+  - **Apply identical standards to all extensions.** Two extensions in the same category with
+    the same metadata profile MUST receive the same risk level, regardless of name or developer.
+  - **Focus on concrete risk indicators**: abandoned (no updates in >1 year), no privacy policy
+    combined with data-accessing permissions, very low rating (<3.0) indicating user complaints.
+  - A personal email domain (gmail, etc.) for an individual developer is NORMAL for open-source
+    and indie developer tools — it is not a red flag by itself.
+
   Guidelines for risk_level:
-  - **low**: No significant red flags, or red flags have clear legitimate explanations (e.g., niche tool with low users but good ratings)
-  - **medium**: Some concerning patterns (e.g., missing developer info OR low adoption OR few reviews), but not alarming in combination
-  - **high**: Multiple concerning patterns together (e.g., low users AND missing developer info AND no reviews), or critical single issues (e.g., abandoned + dangerous permissions pattern suggested)
+  - **low**: No significant red flags, or flags have clear legitimate explanations (e.g., niche tool with low users, indie developer with personal email but good ratings)
+  - **medium**: Concrete concerning patterns (e.g., abandoned extension with no updates in over a year, OR no privacy policy combined with data-accessing permissions, OR very low rating <3.0)
+  - **high**: Multiple concrete risk patterns together (e.g., abandoned AND no privacy policy AND very low rating), or critical single issues (e.g., malware indicators, deceptive behavior)
 
   You MUST respond with a valid JSON object with the following structure:
   {{

--- a/src/extension_shield/scoring/normalizers.py
+++ b/src/extension_shield/scoring/normalizers.py
@@ -530,70 +530,82 @@ def normalize_chromestats(chromestats: ChromeStatsSignalPack) -> FactorScore:
 def normalize_webstore_trust(stats: WebstoreStatsSignalPack) -> FactorScore:
     """
     Normalize webstore trust signals to severity and confidence.
-    
+
+    Fairness principles:
+        - User count is a WEAK signal: many legitimate niche/developer/enterprise
+          tools have small user bases. Low user count alone should never
+          significantly impact the score.
+        - Rating quality matters more than popularity.
+        - Missing privacy policy is a concrete compliance gap.
+        - Severity from user count is capped low and affects CONFIDENCE
+          (less community vetting) rather than implying the extension is dangerous.
+
     Formula:
-        - Low rating (<3.0) → higher severity
-        - Low users (<1000) → higher severity
-        - Missing privacy policy → +0.2
-        - confidence = low if no data available
-    
+        - Low rating (<3.0) → higher severity (objective quality signal)
+        - Very low users (<50) → minor severity bump (less vetting, not inherently risky)
+        - Missing privacy policy → +0.15
+        - confidence = lower when less community data available
+
     Args:
         stats: Webstore stats signal pack
-        
+
     Returns:
         FactorScore with normalized severity and confidence
     """
     severity = 0.0
     issues: List[str] = []
-    
-    # Rating-based severity
+
+    # Rating-based severity — objective quality signal
     if stats.rating_avg is not None:
         if stats.rating_avg < 2.0:
-            severity += 0.4
+            severity += 0.35
             issues.append("very_low_rating")
         elif stats.rating_avg < 3.0:
-            severity += 0.3
+            severity += 0.25
             issues.append("low_rating")
         elif stats.rating_avg < 3.5:
-            severity += 0.15
+            severity += 0.1
             issues.append("below_average_rating")
     else:
-        severity += 0.1  # Missing rating is slightly concerning
+        severity += 0.05  # Missing rating — not alarming, just less data
         issues.append("no_rating")
-    
-    # User count-based severity
+
+    # User count — WEAK signal, affects confidence more than severity.
+    # Many legitimate developer tools, enterprise extensions, and niche utilities
+    # naturally have small user bases. A low user count does NOT imply risk —
+    # it means less community vetting, which we reflect in confidence.
     if stats.installs is not None:
-        if stats.installs < 100:
-            severity += 0.3
+        if stats.installs < 50:
+            severity += 0.1  # Very new/niche — slightly less vetted
             issues.append("very_low_users")
-        elif stats.installs < 1000:
-            severity += 0.2
-            issues.append("low_users")
-        elif stats.installs < 10000:
-            severity += 0.1
-            issues.append("moderate_users")
+        # No penalty for < 1000 or < 10000 — these are normal for niche tools
     else:
-        severity += 0.15  # Unknown user count
+        severity += 0.05  # Unknown user count
         issues.append("unknown_users")
-    
-    # Privacy policy check
+
+    # Privacy policy check — concrete compliance gap
     if not stats.has_privacy_policy:
-        severity += 0.2
+        severity += 0.15
         issues.append("no_privacy_policy")
-    
+
     # Cap at 1.0
     severity = min(1.0, severity)
-    
-    # Confidence based on data availability
+
+    # Confidence based on data availability.
+    # Low user count = less community vetting = lower confidence in the
+    # absence of risk, NOT higher assumed risk.
     has_rating = stats.rating_avg is not None
     has_users = stats.installs is not None
     if has_rating and has_users:
-        confidence = 0.9
+        if stats.installs is not None and stats.installs < 100:
+            confidence = 0.7  # Less community vetting, lower confidence
+        else:
+            confidence = 0.9
     elif has_rating or has_users:
         confidence = 0.6
     else:
         confidence = 0.3  # No data, low confidence
-    
+
     return FactorScore(
         name=SecurityFactors.WEBSTORE,
         severity=round(severity, 4),


### PR DESCRIPTION
…ission

- Remove 'management' from HIGH_RISK_PERMISSIONS (legitimate for auditing tools)
- Raise user count flag threshold from <1000 to <50 users
- User count now lowers confidence instead of raising severity
- Add fairness principles to all LLM prompts (permission, summary, webstore)
- Key findings upgraded to structured {level, finding} objects
- Deterministic Secure/Info/Warning classification rules added