### PR TITLE
Fix signed-in scan history visibility

### DIFF
--- a/frontend/src/pages/ScanHistoryPage.jsx
+++ b/frontend/src/pages/ScanHistoryPage.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useMemo, useRef } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { useAuth } from "../context/AuthContext";
 import databaseService from "../services/databaseService";
@@ -14,16 +14,19 @@ import { getScanResultsRoute } from "../utils/slug";
 import SEOHead from "../components/SEOHead";
 import "./ScanHistoryPage.scss";
 
-// Tooltip component for signal chips
+const SHOW_TABLE_WITHOUT_SIGN_IN = false;
+const HISTORY_LIMIT = 100;
+const RECENT_LIMIT = 100;
+const REQUEST_TIMEOUT_MS = 5000;
+
 const SignalTooltip = ({ type, children }) => {
   const tooltips = {
     security: "Security: Technical vulnerabilities, SAST findings, and code quality analysis",
     privacy: "Privacy: Data collection risks, permissions analysis, and exfiltration detection",
     governance: "Governance: Policy compliance, behavioral consistency, and regulatory adherence",
-    // Legacy tooltips for backward compatibility
     code: "Code Analysis: SAST scanning, entropy detection, and obfuscation checks",
     perms: "Permissions: Analysis of requested browser permissions and access levels",
-    intel: "Threat Intel: VirusTotal scan results and malware detection flags"
+    intel: "Threat Intel: VirusTotal scan results and malware detection flags",
   };
 
   return (
@@ -33,18 +36,16 @@ const SignalTooltip = ({ type, children }) => {
   );
 };
 
-// Signal chip component
 const SignalChip = ({ type, signal }) => {
-  const labels = { 
-    security: "Security", 
-    privacy: "Privacy", 
-    governance: "Gov",  // Shortened for space
-    // Legacy labels for backward compatibility
-    code: "Code", 
-    perms: "Perms", 
-    intel: "Intel" 
+  const labels = {
+    security: "Security",
+    privacy: "Privacy",
+    governance: "Gov",
+    code: "Code",
+    perms: "Perms",
+    intel: "Intel",
   };
-  
+
   const icons = {
     security: (
       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
@@ -66,7 +67,6 @@ const SignalChip = ({ type, signal }) => {
         <path d="M10 9H8" />
       </svg>
     ),
-    // Legacy icons for backward compatibility
     code: (
       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
         <polyline points="16,18 22,12 16,6" />
@@ -84,43 +84,96 @@ const SignalChip = ({ type, signal }) => {
         <line x1="12" y1="8" x2="12" y2="12" />
         <line x1="12" y1="16" x2="12.01" y2="16" />
       </svg>
-    )
+    ),
   };
-
-  const colorClass = getSignalColorClass(signal?.level);
-  const displayLabel = getSignalDisplayLabel(signal);
 
   return (
     <SignalTooltip type={type}>
-      <div className={`signal-chip ${colorClass}`}>
+      <div className={`signal-chip ${getSignalColorClass(signal?.level)}`}>
         <span className="signal-icon">{icons[type] || icons.code}</span>
         <span className="signal-label">{labels[type] || labels.code}</span>
-        <span className="signal-value">{displayLabel}</span>
+        <span className="signal-value">{getSignalDisplayLabel(signal)}</span>
       </div>
     </SignalTooltip>
   );
 };
 
-// Risk badge component
 const RiskBadge = ({ level, score }) => {
   const colorClass = getRiskColorClass(level);
+
+  const getBorderColor = () => {
+    if (score === null || score === undefined) return "rgba(107, 114, 128, 0.3)";
+    if (score >= 75) return "#10B981";
+    if (score >= 50) return "#F59E0B";
+    return "#EF4444";
+  };
+
+  const getTextColor = () => {
+    if (score === null || score === undefined) return "#6B7280";
+    if (score >= 75) return "#10B981";
+    if (score >= 50) return "#F59E0B";
+    return "#EF4444";
+  };
+
   return (
-    <div className={`risk-badge ${colorClass}`}>
+    <div
+      className={`risk-badge ${colorClass}`}
+      style={{
+        borderColor: getBorderColor(),
+        color: getTextColor(),
+      }}
+    >
       <span className="risk-level">{getRiskDisplayLabel(level)}</span>
     </div>
   );
 };
 
-// =============================================================================
-// Set to false to require login for scan history (production). When true, shows
-// limited public table without sign-in.
-// =============================================================================
-const SHOW_TABLE_WITHOUT_SIGN_IN = false;
+const withTimeout = (promise, timeoutMs = REQUEST_TIMEOUT_MS) =>
+  Promise.race([
+    promise,
+    new Promise((_, reject) => {
+      setTimeout(() => reject(new Error("Request timeout")), timeoutMs);
+    }),
+  ]);
 
-/**
- * ScanHistoryPage Component
- * Displays viewing history of scanned extensions with same design as Scanner page.
- */
+const mergeUniqueScans = (...scanSets) => {
+  const merged = [];
+  const seen = new Set();
+
+  scanSets.flat().forEach((scan) => {
+    const extensionId = scan?.extension_id || scan?.extensionId;
+    if (!extensionId || seen.has(extensionId)) return;
+    seen.add(extensionId);
+    merged.push(scan);
+  });
+
+  return merged;
+};
+
+const formatUserCount = (count) => {
+  if (!count) return "—";
+  const num = typeof count === "string" ? parseInt(count.replace(/,/g, ""), 10) : count;
+  if (num >= 1000000) return `${(num / 1000000).toFixed(1)}M`;
+  if (num >= 1000) return `${(num / 1000).toFixed(1)}K`;
+  return num.toString();
+};
+
+const formatTimeAgo = (timestamp) => {
+  if (!timestamp) return "—";
+  const now = new Date();
+  const scanTime = new Date(timestamp);
+  const diffMs = now - scanTime;
+  const diffMins = Math.floor(diffMs / 60000);
+  const diffHours = Math.floor(diffMs / 3600000);
+  const diffDays = Math.floor(diffMs / 86400000);
+
+  if (diffMins < 1) return "Just now";
+  if (diffMins < 60) return `${diffMins}m ago`;
+  if (diffHours < 24) return `${diffHours}h ago`;
+  if (diffDays < 7) return `${diffDays}d ago`;
+  return scanTime.toLocaleDateString();
+};
+
 const ScanHistoryPage = () => {
   const [allScans, setAllScans] = useState([]);
   const [loading, setLoading] = useState(true);
@@ -130,15 +183,6 @@ const ScanHistoryPage = () => {
   const [currentPage, setCurrentPage] = useState(1);
   const [rowsPerPage, setRowsPerPage] = useState(25);
   const [hoveredRow, setHoveredRow] = useState(null);
-  const [copiedId, setCopiedId] = useState(null);
-  const [dashboardStats, setDashboardStats] = useState({
-    totalScans: { value: 0, sparkline: [0] },
-    highRisk: { value: 0, sparkline: [0] },
-    totalFiles: { value: 0, sparkline: [0] },
-    totalVulnerabilities: { value: 0, sparkline: [0] },
-    avgSecurityScore: 0,
-    riskDistribution: { high: 0, medium: 0, low: 0 }
-  });
   const tableWrapperRef = useRef(null);
   const navigate = useNavigate();
   const { isAuthenticated, openSignInModal, accessToken } = useAuth();
@@ -146,7 +190,6 @@ const ScanHistoryPage = () => {
   const supabaseConfigured = Boolean(import.meta.env.VITE_SUPABASE_URL);
   const canLoadHistory = isAuthenticated || !supabaseConfigured || SHOW_TABLE_WITHOUT_SIGN_IN;
 
-  // Debounce search for server-side API calls (searches Postgres)
   useEffect(() => {
     const t = setTimeout(() => setDebouncedSearch(searchTerm), 300);
     return () => clearTimeout(t);
@@ -154,7 +197,7 @@ const ScanHistoryPage = () => {
 
   useEffect(() => {
     let isMounted = true;
-    
+
     const loadHistory = async () => {
       if (!canLoadHistory) {
         if (isMounted) {
@@ -165,65 +208,34 @@ const ScanHistoryPage = () => {
       }
 
       setLoading(true);
-      
-      // Safety timeout
-      const safetyTimeout = setTimeout(() => {
-        if (isMounted) {
-          setLoading(false);
-        }
-      }, 3000);
 
       try {
-        // Request timeout wrapper
-        const timeoutPromise = new Promise((_, reject) =>
-          setTimeout(() => reject(new Error('Request timeout')), 5000)
-        );
+        let scans = [];
 
-        let history;
         if (isAuthenticated) {
-          // Authenticated: use user-scoped /api/history (user_scan_history joined with scan_results)
-          // Pass accessToken for Bearer auth; backend returns 401 if missing → we get []
-          history = await Promise.race([
-            databaseService.getScanHistory(100, accessToken),
-            timeoutPromise
+          const [history, recentScans] = await Promise.all([
+            withTimeout(databaseService.getScanHistory(HISTORY_LIMIT, accessToken)).catch(() => []),
+            withTimeout(databaseService.getRecentScans(RECENT_LIMIT, debouncedSearch)).catch(() => []),
           ]);
+          scans = mergeUniqueScans(history, recentScans);
         } else if (SHOW_TABLE_WITHOUT_SIGN_IN) {
-          // Unauthenticated: use /api/recent (global recent scans; searches Postgres via ?search=)
-          // Limit to 10 rows for public view - sign in required to see full history
-          history = await Promise.race([
-            databaseService.getRecentScans(10, debouncedSearch),
-            timeoutPromise
-          ]);
-        } else {
-          history = [];
+          scans = await withTimeout(databaseService.getRecentScans(RECENT_LIMIT, debouncedSearch)).catch(() => []);
         }
-        
-        // Load dashboard stats for charts (best-effort, don't block)
-        if (isMounted) {
-          databaseService.getDashboardMetrics()
-            .then((metrics) => {
-              if (isMounted) {
-                setDashboardStats(metrics);
-              }
-            })
-            .catch((err) => {
-              // console.error("Error loading dashboard stats:", err); // prod: no console
-            });
-        }
-        
-        // Enrich scans using utility function (uses Promise.allSettled internally)
-        const enrichedScans = await enrichScans(history);
-        
+
+        const enrichedFast = await enrichScans(scans, { skipFullFetch: true });
+        const enrichedScans =
+          enrichedFast.length > 0 || scans.length === 0
+            ? enrichedFast
+            : await enrichScans(scans, { skipFullFetch: false });
+
         if (isMounted) {
           setAllScans(enrichedScans);
         }
       } catch (error) {
-        // console.error("Failed to load scan history:", error); // prod: no console
         if (isMounted) {
           setAllScans([]);
         }
       } finally {
-        clearTimeout(safetyTimeout);
         if (isMounted) {
           setLoading(false);
         }
@@ -235,9 +247,8 @@ const ScanHistoryPage = () => {
     return () => {
       isMounted = false;
     };
-  }, [isAuthenticated, accessToken, canLoadHistory, debouncedSearch]);
+  }, [accessToken, canLoadHistory, debouncedSearch, isAuthenticated]);
 
-  // Handle scroll shadows for horizontal scrolling
   useEffect(() => {
     const tableWrapper = tableWrapperRef.current;
     if (!tableWrapper) return;
@@ -248,34 +259,33 @@ const ScanHistoryPage = () => {
       const isScrolledFromRight = scrollLeft < scrollWidth - clientWidth - 1;
 
       if (isScrolledFromLeft) {
-        tableWrapper.classList.add('show-left-shadow');
-        tableWrapper.classList.add('scrolled');
+        tableWrapper.classList.add("show-left-shadow");
+        tableWrapper.classList.add("scrolled");
       } else {
-        tableWrapper.classList.remove('show-left-shadow');
-        tableWrapper.classList.remove('scrolled');
+        tableWrapper.classList.remove("show-left-shadow");
+        tableWrapper.classList.remove("scrolled");
       }
 
       if (isScrolledFromRight) {
-        tableWrapper.classList.add('show-right-shadow');
+        tableWrapper.classList.add("show-right-shadow");
       } else {
-        tableWrapper.classList.remove('show-right-shadow');
+        tableWrapper.classList.remove("show-right-shadow");
       }
     };
 
     handleScroll();
-    tableWrapper.addEventListener('scroll', handleScroll);
-    window.addEventListener('resize', handleScroll);
+    tableWrapper.addEventListener("scroll", handleScroll);
+    window.addEventListener("resize", handleScroll);
 
     return () => {
-      tableWrapper.removeEventListener('scroll', handleScroll);
-      window.removeEventListener('resize', handleScroll);
+      tableWrapper.removeEventListener("scroll", handleScroll);
+      window.removeEventListener("resize", handleScroll);
     };
   }, [allScans]);
 
-  // When using getRecentScans, search is done server-side (Postgres). Otherwise filter client-side.
   const filteredScans = useMemo(() => {
     if (SHOW_TABLE_WITHOUT_SIGN_IN && !isAuthenticated) {
-      return allScans; // Server already filtered by debouncedSearch
+      return allScans;
     }
     if (!searchTerm.trim()) return allScans;
     const term = searchTerm.toLowerCase();
@@ -284,35 +294,8 @@ const ScanHistoryPage = () => {
         scan.extension_name?.toLowerCase().includes(term) ||
         scan.extension_id?.toLowerCase().includes(term)
     );
-  }, [allScans, searchTerm, isAuthenticated]);
+  }, [allScans, isAuthenticated, searchTerm]);
 
-  // Format user count
-  const formatUserCount = (count) => {
-    if (!count) return "—";
-    const num = typeof count === "string" ? parseInt(count.replace(/,/g, ""), 10) : count;
-    if (num >= 1000000) return `${(num / 1000000).toFixed(1)}M`;
-    if (num >= 1000) return `${(num / 1000).toFixed(1)}K`;
-    return num.toString();
-  };
-
-  // Format time ago
-  const formatTimeAgo = (timestamp) => {
-    if (!timestamp) return "—";
-    const now = new Date();
-    const scanTime = new Date(timestamp);
-    const diffMs = now - scanTime;
-    const diffMins = Math.floor(diffMs / 60000);
-    const diffHours = Math.floor(diffMs / 3600000);
-    const diffDays = Math.floor(diffMs / 86400000);
-
-    if (diffMins < 1) return "Just now";
-    if (diffMins < 60) return `${diffMins}m ago`;
-    if (diffHours < 24) return `${diffHours}h ago`;
-    if (diffDays < 7) return `${diffDays}d ago`;
-    return scanTime.toLocaleDateString();
-  };
-
-  // Handle sorting
   const handleSort = (key) => {
     let direction = "asc";
     if (sortConfig.key === key && sortConfig.direction === "asc") {
@@ -321,15 +304,14 @@ const ScanHistoryPage = () => {
     setSortConfig({ key, direction });
   };
 
-  // Sort and paginate data
   const sortedAndPaginatedScans = useMemo(() => {
-    let sorted = [...filteredScans];
+    const sorted = [...filteredScans];
 
     if (sortConfig.key) {
       sorted.sort((a, b) => {
         let aVal = a[sortConfig.key];
         let bVal = b[sortConfig.key];
-        // For timestamp, use fallback chain (API maps scanned_at→timestamp)
+
         if (sortConfig.key === "timestamp" || sortConfig.key === "scanned_at") {
           aVal = a.timestamp ?? a.scanned_at ?? a.created_at ?? a.updated_at;
           bVal = b.timestamp ?? b.scanned_at ?? b.created_at ?? b.updated_at;
@@ -350,7 +332,7 @@ const ScanHistoryPage = () => {
         } else if (typeof aVal === "string") {
           const aNum = parseFloat(aVal);
           const bNum = parseFloat(bVal);
-          if (!isNaN(aNum) && !isNaN(bNum)) {
+          if (!Number.isNaN(aNum) && !Number.isNaN(bNum)) {
             aVal = aNum;
             bVal = bNum;
           }
@@ -364,54 +346,16 @@ const ScanHistoryPage = () => {
 
     const startIndex = (currentPage - 1) * rowsPerPage;
     return sorted.slice(startIndex, startIndex + rowsPerPage);
-  }, [filteredScans, sortConfig, currentPage, rowsPerPage]);
+  }, [currentPage, filteredScans, rowsPerPage, sortConfig]);
 
-  const totalPages = Math.ceil(filteredScans.length / rowsPerPage);
+  const totalPages = Math.max(1, Math.ceil(filteredScans.length / rowsPerPage));
+  const isPublicView = !isAuthenticated;
+  const showLoginRequiredGate = !isAuthenticated && !SHOW_TABLE_WITHOUT_SIGN_IN;
 
-  // View existing scan report - no auth required (only scanning new extensions requires login)
   const handleViewReport = (scan) => {
     const route = getScanResultsRoute(scan.extension_id, scan.extension_name);
     navigate(route);
   };
-
-  const handleCopyLink = async (scan) => {
-    const route = getScanResultsRoute(scan.extension_id, scan.extension_name);
-    const link = `${window.location.origin}${route}`;
-    try {
-      await navigator.clipboard.writeText(link);
-      setCopiedId(scan.extension_id);
-      setTimeout(() => setCopiedId(null), 2000);
-    } catch (err) {
-      // console.error("Failed to copy:", err); // prod: no console
-    }
-  };
-
-  const handleExport = () => {
-    const dataToExport = filteredScans.map((scan) => ({
-      id: scan.extension_id,
-      name: scan.extension_name,
-      timestamp: scan.timestamp,
-      score: scan.score,
-      risk_level: scan.risk_level,
-      findings_count: scan.findings_count,
-    }));
-
-    const blob = new Blob([JSON.stringify(dataToExport, null, 2)], {
-      type: "application/json",
-    });
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement("a");
-    a.href = url;
-    a.download = `extension-shield-history-${new Date().toISOString().split("T")[0]}.json`;
-    document.body.appendChild(a);
-    a.click();
-    document.body.removeChild(a);
-    URL.revokeObjectURL(url);
-  };
-
-  const isPublicView = !isAuthenticated;
-  const showBlur = isPublicView && !SHOW_TABLE_WITHOUT_SIGN_IN; // No blur when testing without sign-in
-  const showLoginRequiredGate = !isAuthenticated && !SHOW_TABLE_WITHOUT_SIGN_IN;
 
   return (
     <>
@@ -423,368 +367,327 @@ const ScanHistoryPage = () => {
       />
       <div className="history-page">
         <div className="history-content">
-        {/* Login required gate */}
-        {showLoginRequiredGate && (
-          <div className="history-login-gate">
-            <p className="history-login-gate__text">Login required to view scan history.</p>
-            <button type="button" className="action-signin" onClick={openSignInModal}>
-              Sign In
-            </button>
-          </div>
-        )}
-
-        {!showLoginRequiredGate && (
-        <>
-        {/* Header */}
-        <div className="history-header">
-          <h1>Scan History</h1>
-          <p>Browse and search all scanned extensions</p>
-        </div>
-
-        {/* Toolbar */}
-        <div className="history-toolbar">
-          <div className="toolbar-left">
-            <div className="scan-count-badge">
-              <span>All Scans</span>
-              <span className="count-number">{filteredScans.length}</span>
+          {showLoginRequiredGate && (
+            <div className="history-login-gate">
+              <p className="history-login-gate__text">Login required to view scan history.</p>
+              <button type="button" className="action-signin" onClick={openSignInModal}>
+                Sign In
+              </button>
             </div>
-          </div>
+          )}
 
-          <div className="toolbar-right">
-            <div className="search-input-wrapper">
-              <svg className="search-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-                <circle cx="11" cy="11" r="8" />
-                <path d="m21 21-4.35-4.35" />
-              </svg>
-              <input
-                type="text"
-                className="search-input"
-                placeholder="Search extensions (searches Postgres)..."
-                value={searchTerm}
-                onChange={(e) => {
-                  setSearchTerm(e.target.value);
-                  setCurrentPage(1);
-                }}
-              />
-            </div>
-            <button className="export-btn" onClick={handleExport}>
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-                <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
-                <polyline points="7,10 12,15 17,10" />
-                <line x1="12" y1="15" x2="12" y2="3" />
-              </svg>
-              Export
-            </button>
-          </div>
-        </div>
+          {!showLoginRequiredGate && (
+            <>
+              <div className="history-header">
+                <p className="history-tagline">Scan History</p>
+                <h1 className="history-headline">Review previously scanned Chrome extensions.</h1>
+                <p className="history-subtitle">
+                  The same scan table used on the main scanner page, with saved history first and recent scans filling the gaps.
+                </p>
+              </div>
 
-        {/* Loading State */}
-        {loading && (
-          <div className="loading-state">
-            <div className="loading-spinner" />
-            <span className="loading-text">Loading scan history...</span>
-          </div>
-        )}
+              <div className="history-toolbar">
+                <div className="toolbar-left">
+                  <div className="scan-count-badge">
+                    <span>Available scans</span>
+                    <span className="count-number">{filteredScans.length}</span>
+                  </div>
+                </div>
 
-        {/* Extensions Table */}
-        {!loading && filteredScans.length > 0 && (
-          <div className={`extensions-table-container ${showBlur ? 'blurred-content' : ''}`}>
-            <div className="table-wrapper surface-panel" ref={tableWrapperRef}>
-              <table className="extensions-table">
-                <thead>
-                  <tr>
-                    <th className="sortable" onClick={() => handleSort("extension_name")}>
-                      <div className="th-content">
-                        <svg className="th-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-                          <rect x="3" y="3" width="18" height="18" rx="2" />
-                          <path d="M12 8v8M8 12h8" />
-                        </svg>
-                        Extension
-                        {sortConfig.key === "extension_name" && (
-                          <span className="sort-arrow">{sortConfig.direction === "asc" ? "↑" : "↓"}</span>
-                        )}
-                      </div>
-                    </th>
-                    <th className="sortable hide-mobile" onClick={() => handleSort("user_count")}>
-                      <div className="th-content">
-                        Users
-                        {sortConfig.key === "user_count" && (
-                          <span className="sort-arrow">{sortConfig.direction === "asc" ? "↑" : "↓"}</span>
-                        )}
-                      </div>
-                    </th>
-                    <th className="sortable hide-mobile" onClick={() => handleSort("rating")}>
-                      <div className="th-content">
-                        Rating
-                        {sortConfig.key === "rating" && (
-                          <span className="sort-arrow">{sortConfig.direction === "asc" ? "↑" : "↓"}</span>
-                        )}
-                      </div>
-                    </th>
-                    <th className="sortable hide-tablet" onClick={() => handleSort("rating_count")}>
-                      <div className="th-content">
-                        Reviews
-                        {sortConfig.key === "rating_count" && (
-                          <span className="sort-arrow">{sortConfig.direction === "asc" ? "↑" : "↓"}</span>
-                        )}
-                      </div>
-                    </th>
-                    <th className="sortable" onClick={() => handleSort("score")}>
-                      <div className="th-content">
-                        <svg className="th-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-                          <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" />
-                        </svg>
-                        Risk
-                        {sortConfig.key === "score" && (
-                          <span className="sort-arrow">{sortConfig.direction === "asc" ? "↑" : "↓"}</span>
-                        )}
-                      </div>
-                    </th>
-                    <th>
-                      <div className="th-content">
-                        <svg className="th-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-                          <path d="M22 12h-4l-3 9L9 3l-3 9H2" />
-                        </svg>
-                        Signals
-                      </div>
-                    </th>
-                    <th className="sortable" onClick={() => handleSort("findings_count")}>
-                      <div className="th-content">
-                        <svg className="th-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-                          <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
-                          <path d="M14 2v6h6" />
-                          <line x1="16" y1="13" x2="8" y2="13" />
-                          <line x1="16" y1="17" x2="8" y2="17" />
-                        </svg>
-                        Evidence
-                        {sortConfig.key === "findings_count" && (
-                          <span className="sort-arrow">{sortConfig.direction === "asc" ? "↑" : "↓"}</span>
-                        )}
-                      </div>
-                    </th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {sortedAndPaginatedScans.map((scan, index) => (
-                    <tr
-                      key={scan.extension_id || index}
-                      className={hoveredRow === scan.extension_id ? "row-hovered" : ""}
-                      onMouseEnter={() => setHoveredRow(scan.extension_id)}
-                      onMouseLeave={() => setHoveredRow(null)}
-                      onClick={() => handleViewReport(scan)}
-                      onKeyDown={(e) => {
-                        if (e.key === "Enter" || e.key === " ") {
-                          e.preventDefault();
-                          handleViewReport(scan);
-                        }
+                <div className="toolbar-right">
+                  <div className="search-input-wrapper">
+                    <svg className="search-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                      <circle cx="11" cy="11" r="8" />
+                      <path d="m21 21-4.35-4.35" />
+                    </svg>
+                    <input
+                      type="text"
+                      className="search-input"
+                      placeholder="Search extensions by name or ID"
+                      value={searchTerm}
+                      onChange={(e) => {
+                        setSearchTerm(e.target.value);
+                        setCurrentPage(1);
                       }}
-                      role="button"
-                      tabIndex={0}
-                    >
-                      <td className="extension-cell">
-                        <div className="extension-info">
-                          <img
-                            src={getExtensionIconUrl(scan.extension_id)}
-                            alt={scan.extension_name}
-                            className="extension-icon"
-                            onError={(e) => {
-                              e.target.onerror = null;
-                              e.target.src = EXTENSION_ICON_PLACEHOLDER;
+                    />
+                  </div>
+                </div>
+              </div>
+
+              <div className="extensions-table-container">
+                <div className="table-header-section">
+                  {loading && <div className="loading-indicator">Loading...</div>}
+                  {!loading && filteredScans.length > 0 && (
+                    <div className="table-section-heading">
+                      <h2 className="table-section-title">Scanned extensions</h2>
+                      <p className="table-section-subtitle">Click View to open the evidence report.</p>
+                    </div>
+                  )}
+                </div>
+
+                {loading && (
+                  <div className="loading-state">
+                    <div className="loading-spinner" />
+                    <span className="loading-text">Loading scan history...</span>
+                  </div>
+                )}
+
+                {!loading && filteredScans.length > 0 && (
+                  <div className="table-wrapper" ref={tableWrapperRef}>
+                    <table className="extensions-table">
+                      <thead>
+                        <tr>
+                          <th className="sortable" onClick={() => handleSort("extension_name")}>
+                            <div className="th-content">
+                              <svg className="th-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                                <rect x="3" y="3" width="18" height="18" rx="2" />
+                                <path d="M12 8v8M8 12h8" />
+                              </svg>
+                              Extension
+                              {sortConfig.key === "extension_name" && (
+                                <span className="sort-arrow">{sortConfig.direction === "asc" ? "↑" : "↓"}</span>
+                              )}
+                            </div>
+                          </th>
+                          <th className="sortable hide-mobile" onClick={() => handleSort("user_count")}>
+                            <div className="th-content">
+                              Users
+                              {sortConfig.key === "user_count" && (
+                                <span className="sort-arrow">{sortConfig.direction === "asc" ? "↑" : "↓"}</span>
+                              )}
+                            </div>
+                          </th>
+                          <th className="sortable hide-mobile" onClick={() => handleSort("rating")}>
+                            <div className="th-content">
+                              Rating
+                              {sortConfig.key === "rating" && (
+                                <span className="sort-arrow">{sortConfig.direction === "asc" ? "↑" : "↓"}</span>
+                              )}
+                            </div>
+                          </th>
+                          <th className="sortable hide-tablet" onClick={() => handleSort("rating_count")}>
+                            <div className="th-content">
+                              Reviews
+                              {sortConfig.key === "rating_count" && (
+                                <span className="sort-arrow">{sortConfig.direction === "asc" ? "↑" : "↓"}</span>
+                              )}
+                            </div>
+                          </th>
+                          <th className="sortable" onClick={() => handleSort("score")}>
+                            <div className="th-content">
+                              <svg className="th-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                                <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" />
+                              </svg>
+                              Risk
+                              {sortConfig.key === "score" && (
+                                <span className="sort-arrow">{sortConfig.direction === "asc" ? "↑" : "↓"}</span>
+                              )}
+                            </div>
+                          </th>
+                          <th>
+                            <div className="th-content">
+                              <svg className="th-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                                <path d="M22 12h-4l-3 9L9 3l-3 9H2" />
+                              </svg>
+                              Signals
+                            </div>
+                          </th>
+                          <th className="sortable" onClick={() => handleSort("findings_count")}>
+                            <div className="th-content">
+                              <svg className="th-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                                <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+                                <path d="M14 2v6h6" />
+                                <line x1="16" y1="13" x2="8" y2="13" />
+                                <line x1="16" y1="17" x2="8" y2="17" />
+                              </svg>
+                              Evidence
+                              {sortConfig.key === "findings_count" && (
+                                <span className="sort-arrow">{sortConfig.direction === "asc" ? "↑" : "↓"}</span>
+                              )}
+                            </div>
+                          </th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {sortedAndPaginatedScans.map((scan, index) => (
+                          <tr
+                            key={scan.extension_id || index}
+                            className={hoveredRow === scan.extension_id ? "row-hovered" : ""}
+                            onMouseEnter={() => setHoveredRow(scan.extension_id)}
+                            onMouseLeave={() => setHoveredRow(null)}
+                            onClick={() => handleViewReport(scan)}
+                            onKeyDown={(e) => {
+                              if (e.key === "Enter" || e.key === " ") {
+                                e.preventDefault();
+                                handleViewReport(scan);
+                              }
                             }}
-                          />
-                          <div className="extension-details">
-                            <span className="extension-name">
-                              {scan.extension_name || scan.metadata?.title || scan.metadata?.name || scan.manifest?.name || scan.extension_id}
-                            </span>
-                            <span className="extension-scanned">
-                              {formatTimeAgo(scan.timestamp ?? scan.scanned_at ?? scan.created_at ?? scan.updated_at)}
-                            </span>
-                          </div>
-                        </div>
-                      </td>
-                      <td className="hide-mobile">{formatUserCount(scan.user_count)}</td>
-                      <td className="hide-mobile">
-                        {scan.rating != null ? (
-                          <span className="rating-value">{parseFloat(scan.rating).toFixed(1)}</span>
-                        ) : (
-                          <span className="no-data">—</span>
-                        )}
-                      </td>
-                      <td className="hide-tablet">
-                        {scan.rating_count != null ? (
-                          <span>{formatUserCount(scan.rating_count)}</span>
-                        ) : (
-                          <span className="no-data">—</span>
-                        )}
-                      </td>
-                      <td>
-                        <RiskBadge level={scan.risk_level} score={scan.score} />
-                      </td>
-                      <td className="signals-cell">
-                        <div className="signals-container">
-                          <SignalChip type="security" signal={scan.signals?.security_signal} />
-                          <SignalChip type="privacy" signal={scan.signals?.privacy_signal} />
-                          <SignalChip type="governance" signal={scan.signals?.governance_signal} />
-                        </div>
-                      </td>
-                      <td className="evidence-cell">
-                        <div className="evidence-container">
-                          <span className="findings-count">
-                            {scan.findings_count || 0} finding{scan.findings_count !== 1 ? "s" : ""}
-                          </span>
-                          <button
-                            className="view-report-btn"
-                            onClick={(e) => {
-                              e.stopPropagation();
-                              handleViewReport(scan);
-                            }}
+                            role="button"
+                            tabIndex={0}
                           >
-                            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-                              <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z" />
-                              <circle cx="12" cy="12" r="3" />
-                            </svg>
-                            View
-                          </button>
-                          <button
-                            className="copy-link-btn"
-                            onClick={(e) => {
-                              e.stopPropagation();
-                              handleCopyLink(scan);
-                            }}
-                            aria-label="Copy share link"
-                          >
-                            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-                              <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
-                              <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
-                            </svg>
-                          </button>
-                        </div>
-                        {copiedId === scan.extension_id && (
-                          <span className="copied-toast">Copied!</span>
-                        )}
-                      </td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-            </div>
+                            <td className="extension-cell">
+                              <div className="extension-info">
+                                <img
+                                  src={getExtensionIconUrl(scan.extension_id)}
+                                  alt={scan.extension_name}
+                                  className="extension-icon"
+                                  onError={(e) => {
+                                    e.target.onerror = null;
+                                    e.target.src = EXTENSION_ICON_PLACEHOLDER;
+                                  }}
+                                />
+                                <div className="extension-details">
+                                  <span className="extension-name">
+                                    {scan.extension_name || scan.metadata?.title || scan.metadata?.name || scan.manifest?.name || scan.extension_id}
+                                  </span>
+                                  <span className="extension-scanned">
+                                    {formatTimeAgo(scan.timestamp ?? scan.scanned_at ?? scan.created_at ?? scan.updated_at)}
+                                  </span>
+                                </div>
+                              </div>
+                            </td>
+                            <td className="hide-mobile">{formatUserCount(scan.user_count)}</td>
+                            <td className="hide-mobile">
+                              {scan.rating != null ? (
+                                <span className="rating-value">{parseFloat(scan.rating).toFixed(1)}</span>
+                              ) : (
+                                <span className="no-data">—</span>
+                              )}
+                            </td>
+                            <td className="hide-tablet">
+                              {scan.rating_count != null ? (
+                                <span>{formatUserCount(scan.rating_count)}</span>
+                              ) : (
+                                <span className="no-data">—</span>
+                              )}
+                            </td>
+                            <td>
+                              <RiskBadge level={scan.risk_level} score={scan.score} />
+                            </td>
+                            <td className="signals-cell">
+                              <div className="signals-container">
+                                <SignalChip type="security" signal={scan.signals?.security_signal} />
+                                <SignalChip type="privacy" signal={scan.signals?.privacy_signal} />
+                                <SignalChip type="governance" signal={scan.signals?.governance_signal} />
+                              </div>
+                            </td>
+                            <td className="evidence-cell">
+                              <div className="evidence-container">
+                                <span className="findings-count">
+                                  {scan.findings_count || 0} finding{scan.findings_count !== 1 ? "s" : ""}
+                                </span>
+                                <button
+                                  className="view-report-btn"
+                                  onClick={(e) => {
+                                    e.stopPropagation();
+                                    handleViewReport(scan);
+                                  }}
+                                >
+                                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                                    <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z" />
+                                    <circle cx="12" cy="12" r="3" />
+                                  </svg>
+                                  View
+                                </button>
+                              </div>
+                            </td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+                )}
 
-            {/* Pagination */}
-            <div className="table-pagination">
-              <div className="pagination-info">
-                Showing {(currentPage - 1) * rowsPerPage + 1} to{" "}
-                {Math.min(currentPage * rowsPerPage, filteredScans.length)} of {filteredScans.length} rows
-              </div>
-              <div className="pagination-controls">
-                <button
-                  className="pagination-btn"
-                  onClick={() => setCurrentPage(1)}
-                  disabled={currentPage === 1}
-                >
-                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-                    <path d="M11 17l-5-5 5-5M18 17l-5-5 5-5" />
-                  </svg>
-                </button>
-                <button
-                  className="pagination-btn"
-                  onClick={() => setCurrentPage((p) => Math.max(1, p - 1))}
-                  disabled={currentPage === 1}
-                >
-                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-                    <path d="M15 18l-6-6 6-6" />
-                  </svg>
-                </button>
-                <button
-                  className="pagination-btn"
-                  onClick={() => setCurrentPage((p) => Math.min(totalPages, p + 1))}
-                  disabled={currentPage === totalPages}
-                >
-                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-                    <path d="M9 18l6-6-6-6" />
-                  </svg>
-                </button>
-                <button
-                  className="pagination-btn"
-                  onClick={() => setCurrentPage(totalPages)}
-                  disabled={currentPage === totalPages}
-                >
-                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-                    <path d="M13 17l5-5-5-5M6 17l5-5-5-5" />
-                  </svg>
-                </button>
-              </div>
-              <div className="pagination-rows">
-                <label>Rows per page:</label>
-                <select
-                  value={rowsPerPage}
-                  onChange={(e) => {
-                    setRowsPerPage(Number(e.target.value));
-                    setCurrentPage(1);
-                  }}
-                >
-                  <option value={10}>10</option>
-                  <option value={25}>25</option>
-                  <option value={50}>50</option>
-                  <option value={100}>100</option>
-                </select>
-              </div>
-            </div>
-          </div>
-        )}
+                {!loading && filteredScans.length > 0 && (
+                  <div className="table-pagination">
+                    <div className="pagination-info">
+                      Showing {(currentPage - 1) * rowsPerPage + 1} to{" "}
+                      {Math.min(currentPage * rowsPerPage, filteredScans.length)} of {filteredScans.length} rows
+                    </div>
+                    <div className="pagination-controls">
+                      <button
+                        className="pagination-btn"
+                        onClick={() => setCurrentPage(1)}
+                        disabled={currentPage === 1}
+                      >
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                          <path d="M11 17l-5-5 5-5M18 17l-5-5 5-5" />
+                        </svg>
+                      </button>
+                      <button
+                        className="pagination-btn"
+                        onClick={() => setCurrentPage((page) => Math.max(1, page - 1))}
+                        disabled={currentPage === 1}
+                      >
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                          <path d="M15 18l-6-6 6-6" />
+                        </svg>
+                      </button>
+                      <button
+                        className="pagination-btn"
+                        onClick={() => setCurrentPage((page) => Math.min(totalPages, page + 1))}
+                        disabled={currentPage === totalPages}
+                      >
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                          <path d="M9 18l6-6-6-6" />
+                        </svg>
+                      </button>
+                      <button
+                        className="pagination-btn"
+                        onClick={() => setCurrentPage(totalPages)}
+                        disabled={currentPage === totalPages}
+                      >
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                          <path d="M13 17l5-5-5-5M6 17l5-5-5-5" />
+                        </svg>
+                      </button>
+                    </div>
+                    <div className="pagination-rows">
+                      <label>Rows per page:</label>
+                      <select
+                        value={rowsPerPage}
+                        onChange={(e) => {
+                          setRowsPerPage(Number(e.target.value));
+                          setCurrentPage(1);
+                        }}
+                      >
+                        <option value={10}>10</option>
+                        <option value={25}>25</option>
+                        <option value={50}>50</option>
+                        <option value={100}>100</option>
+                      </select>
+                    </div>
+                  </div>
+                )}
 
-        {/* Empty State */}
-        {!loading && filteredScans.length === 0 && (
-          <div className="empty-state">
-            <div className="empty-icon">📭</div>
-            <h3>
-              {searchTerm
-                ? "No matching scans found"
-                : isPublicView
-                  ? "Sign in to view your scan history"
-                  : "No scan history yet"}
-            </h3>
-            <p>
-              {searchTerm
-                ? `No scans match "${searchTerm}". Try a different search term.`
-                : isPublicView
-                  ? "Your saved scans are tied to your account."
-                  : "Start by scanning your first Chrome extension."}
-            </p>
-            {!searchTerm && !isPublicView && (
-              <button className="empty-action-btn" onClick={() => navigate("/scan")}>
-                <span>⚡</span>
-                Start Your First Scan
-              </button>
-            )}
-            {!searchTerm && isPublicView && (
-              <button type="button" className="empty-action-btn action-signin" onClick={openSignInModal}>
-                Sign In
-              </button>
-            )}
-          </div>
-        )}
-
-        {/* Login Overlay for Blurred Content */}
-        {isPublicView && !loading && filteredScans.length > 0 && (
-          <>
-            <div className="login-overlay-backdrop" aria-hidden />
-            <div className="login-overlay">
-            <div className="login-overlay-content">
-              <svg className="lock-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-                <rect x="3" y="11" width="18" height="11" rx="2" ry="2" />
-                <path d="M7 11V7a5 5 0 0 1 10 0v4" />
-              </svg>
-              <h3>Sign in to view scanned extensions</h3>
-              <button type="button" className="login-overlay-btn action-signin" onClick={openSignInModal}>
-                Sign In
-              </button>
-            </div>
-            </div>
-          </>
-        )}
-        </>
-        )}
-      </div>
+                {!loading && filteredScans.length === 0 && (
+                  <div className="empty-state">
+                    <div className="empty-icon">🛡️</div>
+                    <h3>{searchTerm ? "No matching scans found" : isPublicView ? "Sign in to view your scan history" : "No scan history yet"}</h3>
+                    <p>
+                      {searchTerm
+                        ? `No scans match "${searchTerm}". Try a different search term.`
+                        : isPublicView
+                          ? "Your saved scans are tied to your account."
+                          : "Start by scanning a Chrome Web Store extension from the main scan page."}
+                    </p>
+                    {!searchTerm && !isPublicView && (
+                      <button className="empty-action-btn" onClick={() => navigate("/scan")}>
+                        <span>⚡</span>
+                        Go To Scan Page
+                      </button>
+                    )}
+                    {!searchTerm && isPublicView && (
+                      <button type="button" className="empty-action-btn action-signin" onClick={openSignInModal}>
+                        Sign In
+                      </button>
+                    )}
+                  </div>
+                )}
+              </div>
+            </>
+          )}
+        </div>
       </div>
     </>
   );

--- a/frontend/src/pages/ScanHistoryPage.scss
+++ b/frontend/src/pages/ScanHistoryPage.scss
@@ -6,8 +6,9 @@
   min-height: 100vh;
   min-width: 100%;
   width: 100%;
-  background: var(--extensionshield-bg-primary);
-  color: var(--extensionshield-text-primary, #f8fafc);
+  background: transparent;
+  color: var(--theme-text-primary, #f8fafc);
+  font-family: var(--font-sans);
   display: flex;
   flex-direction: column;
   position: relative;
@@ -46,7 +47,7 @@
   width: 100%;
   max-width: 1600px;
   margin: 0 auto;
-  padding: 64px 64px 48px;
+  padding: 96px 64px 48px;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -120,29 +121,37 @@
   flex-direction: column;
   align-items: center;
   text-align: center;
-  margin-bottom: 3rem;
   gap: 0.75rem;
+  margin-bottom: 2.25rem;
+  max-width: 760px;
+}
 
-  h1 {
-    font-size: clamp(2rem, 5vw, 2.5rem);
-    font-weight: 700;
-    letter-spacing: -0.03em;
-    line-height: 1.1;
-    background: linear-gradient(135deg, #f8fafc 0%, #94a3b8 100%);
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
-    background-clip: text;
-    margin: 0;
-  }
+.history-tagline {
+  font-size: clamp(0.6875rem, 1.5vw, 0.75rem);
+  font-weight: 600;
+  color: var(--extensionshield-text-muted, #64748b);
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  margin: 0;
+  line-height: 1.4;
+}
 
-  p {
-    font-size: 0.9375rem;
-    color: var(--theme-text-muted);
-    max-width: 500px;
-    line-height: 1.5;
-    font-weight: 400;
-    margin: 0;
-  }
+.history-headline {
+  font-size: clamp(1.75rem, 4vw, 3rem);
+  font-weight: 600;
+  line-height: 1.15;
+  margin: 0;
+  letter-spacing: -0.025em;
+  color: var(--extensionshield-text-primary, #f8fafc);
+}
+
+.history-subtitle {
+  font-size: 0.9375rem;
+  color: var(--theme-text-muted, #94a3b8);
+  max-width: 640px;
+  line-height: 1.5;
+  font-weight: 400;
+  margin: 0;
 }
 
 /* ============================================================================
@@ -153,13 +162,12 @@
   align-items: center;
   justify-content: space-between;
   gap: 1.5rem;
-  margin-bottom: 2rem;
+  margin-bottom: 1rem;
   flex-wrap: wrap;
   position: relative;
   width: 100%;
   max-width: 1400px;
-  margin-top: 30px;
-  padding: 0 2rem; // Match extensions-table-container padding
+  padding: 0 2rem;
 }
 
 .toolbar-left {
@@ -425,6 +433,36 @@
   color: var(--extensionshield-text-secondary, #94a3b8);
 }
 
+.table-header-section {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 1rem;
+  min-height: 2.5rem;
+}
+
+.loading-indicator {
+  font-size: 0.875rem;
+  color: var(--extensionshield-text-muted, #64748b);
+}
+
+.table-section-heading {
+  .table-section-title {
+    font-size: 1.125rem;
+    font-weight: 600;
+    color: var(--extensionshield-text-secondary, #94a3b8);
+    letter-spacing: -0.02em;
+    margin: 0 0 0.125rem;
+  }
+
+  .table-section-subtitle {
+    font-size: 0.75rem;
+    color: var(--extensionshield-text-muted, #64748b);
+    margin: 0;
+    line-height: 1.4;
+  }
+}
+
 /* ============================================================================
    EXTENSIONS TABLE - Same as Scanner Page
    ============================================================================ */
@@ -609,8 +647,9 @@
   border-radius: 8px;
   font-size: 0.75rem;
   font-weight: 600;
-  border: 1px solid;
+  border: 2px solid;
   transition: all 0.2s ease;
+  background: rgba(255, 255, 255, 0.03);
 
   .risk-level {
     text-transform: uppercase;
@@ -1016,14 +1055,12 @@
 
 /* History page – search input same as homepage/scanner, table same as /scan */
 .light .history-page {
-  .history-header h1 {
-    background: linear-gradient(135deg, var(--extensionshield-text-primary) 0%, var(--extensionshield-text-secondary) 100%);
-    -webkit-background-clip: text;
-    background-clip: text;
-    -webkit-text-fill-color: transparent;
+  .history-headline {
+    color: var(--extensionshield-text-primary);
   }
 
-  .history-header p {
+  .history-tagline,
+  .history-subtitle {
     color: var(--extensionshield-text-secondary);
   }
 


### PR DESCRIPTION
## Summary
- make `/scan/history` show scanned extensions for signed-in users even when `user_scan_history` is sparse
- merge authenticated history results with the same `/api/recent` feed used by `/scan`
- align the history page table/header styling with the main scan page

## Testing
- git status
- manual code review