### PR TITLE
Fix user-only scan history

### DIFF
--- a/frontend/src/pages/ScanHistoryPage.jsx
+++ b/frontend/src/pages/ScanHistoryPage.jsx
@@ -16,7 +16,6 @@ import "./ScanHistoryPage.scss";
 
 const SHOW_TABLE_WITHOUT_SIGN_IN = false;
 const HISTORY_LIMIT = 100;
-const RECENT_LIMIT = 100;
 const REQUEST_TIMEOUT_MS = 5000;
 
 const SignalTooltip = ({ type, children }) => {
@@ -136,20 +135,6 @@ const withTimeout = (promise, timeoutMs = REQUEST_TIMEOUT_MS) =>
     }),
   ]);
 
-const mergeUniqueScans = (...scanSets) => {
-  const merged = [];
-  const seen = new Set();
-
-  scanSets.flat().forEach((scan) => {
-    const extensionId = scan?.extension_id || scan?.extensionId;
-    if (!extensionId || seen.has(extensionId)) return;
-    seen.add(extensionId);
-    merged.push(scan);
-  });
-
-  return merged;
-};
-
 const formatUserCount = (count) => {
   if (!count) return "—";
   const num = typeof count === "string" ? parseInt(count.replace(/,/g, ""), 10) : count;
@@ -213,13 +198,11 @@ const ScanHistoryPage = () => {
         let scans = [];
 
         if (isAuthenticated) {
-          const [history, recentScans] = await Promise.all([
-            withTimeout(databaseService.getScanHistory(HISTORY_LIMIT, accessToken)).catch(() => []),
-            withTimeout(databaseService.getRecentScans(RECENT_LIMIT, debouncedSearch)).catch(() => []),
-          ]);
-          scans = mergeUniqueScans(history, recentScans);
+          scans = await withTimeout(
+            databaseService.getScanHistory(HISTORY_LIMIT, accessToken)
+          ).catch(() => []);
         } else if (SHOW_TABLE_WITHOUT_SIGN_IN) {
-          scans = await withTimeout(databaseService.getRecentScans(RECENT_LIMIT, debouncedSearch)).catch(() => []);
+          scans = await withTimeout(databaseService.getRecentScans(HISTORY_LIMIT, debouncedSearch)).catch(() => []);
         }
 
         const enrichedFast = await enrichScans(scans, { skipFullFetch: true });
@@ -380,9 +363,9 @@ const ScanHistoryPage = () => {
             <>
               <div className="history-header">
                 <p className="history-tagline">Scan History</p>
-                <h1 className="history-headline">Review previously scanned Chrome extensions.</h1>
+                <h1 className="history-headline">Review your scanned Chrome extensions.</h1>
                 <p className="history-subtitle">
-                  The same scan table used on the main scanner page, with saved history first and recent scans filling the gaps.
+                  Every extension you scan while signed in appears here in your personal history.
                 </p>
               </div>
 

--- a/src/extension_shield/api/database.py
+++ b/src/extension_shield/api/database.py
@@ -1242,9 +1242,10 @@ class SupabaseDatabase:
                 ).eq("user_id", user_id).eq("extension_id", extension_id).execute()
                 return True
             
-            # Insert new scan history (trigger will handle karma increment)
+            # Insert new scan history with last_viewed_at set immediately so new scans
+            # sort correctly even if the column default was missing in an older deployment.
             self.client.table("user_scan_history").insert(
-                {"user_id": user_id, "extension_id": extension_id}
+                {"user_id": user_id, "extension_id": extension_id, "last_viewed_at": now_iso}
             ).execute()
             return True
         except Exception as e:
@@ -1337,6 +1338,7 @@ class SupabaseDatabase:
                 .select("extension_id, created_at, last_viewed_at")
                 .eq("user_id", user_id)
                 .order("last_viewed_at", desc=True)
+                .order("created_at", desc=True)
                 .limit(limit)
                 .execute()
             )
@@ -2082,4 +2084,3 @@ def _create_db():
 
 # Global database instance
 db = _create_db()
-

--- a/supabase/migrations/20260401160000_user_scan_history_last_viewed_not_null.sql
+++ b/supabase/migrations/20260401160000_user_scan_history_last_viewed_not_null.sql
@@ -1,0 +1,18 @@
+-- Ensure user scan history rows always have last_viewed_at populated so
+-- authenticated /api/history ordering is stable for both new and existing scans.
+
+ALTER TABLE public.user_scan_history
+  ADD COLUMN IF NOT EXISTS last_viewed_at timestamptz;
+
+UPDATE public.user_scan_history
+SET last_viewed_at = COALESCE(last_viewed_at, created_at, now())
+WHERE last_viewed_at IS NULL;
+
+ALTER TABLE public.user_scan_history
+  ALTER COLUMN last_viewed_at SET DEFAULT now();
+
+ALTER TABLE public.user_scan_history
+  ALTER COLUMN last_viewed_at SET NOT NULL;
+
+CREATE INDEX IF NOT EXISTS user_scan_history_user_last_viewed_idx
+  ON public.user_scan_history (user_id, last_viewed_at DESC);

--- a/supabase/schemas/user_scan_history.sql
+++ b/supabase/schemas/user_scan_history.sql
@@ -4,11 +4,15 @@ create table "public"."user_scan_history" (
   "id" uuid primary key default gen_random_uuid(),
   "user_id" uuid not null references auth.users(id) on delete cascade,
   "extension_id" text not null,
-  "created_at" timestamptz not null default now()
+  "created_at" timestamptz not null default now(),
+  "last_viewed_at" timestamptz not null default now()
 );
 
 create index "user_scan_history_user_created_at_idx"
   on "public"."user_scan_history" ("user_id", "created_at" desc);
+
+create index "user_scan_history_user_last_viewed_idx"
+  on "public"."user_scan_history" ("user_id", "last_viewed_at" desc);
 
 alter table "public"."user_scan_history" enable row level security;
 
@@ -29,4 +33,3 @@ create policy "user_scan_history_delete_own"
   on "public"."user_scan_history"
   for delete
   using (auth.uid() = user_id);
-


### PR DESCRIPTION
## Summary
- stop /scan/history from merging user history with global recent scans for signed-in users
- write and order user_scan_history rows by last_viewed_at so fresh scans appear immediately
- add a Supabase migration/schema update to backfill and enforce last_viewed_at

## Verification
- git diff --check master...HEAD
- manually reviewed diff against master

## Notes
- previous PR #57 was already merged, so this is a clean follow-up branch rebased on the latest master