### PR TITLE
Sanitize governance enforcement bundle errors

### DIFF
--- a/src/extension_shield/api/main.py
+++ b/src/extension_shield/api/main.py
@@ -2934,9 +2934,14 @@ async def get_enforcement_bundle(extension_id: str):
         # Governance analysis was not run or failed
         governance_error = results.get("governance_error")
         if governance_error:
+            logger.error(
+                "Governance failed for %s: %s",
+                extension_id,
+                governance_error,
+            )
             raise HTTPException(
                 status_code=500,
-                detail=f"Governance analysis failed: {governance_error}"
+                detail="Governance analysis failed. Please try again."
             )
         raise HTTPException(
             status_code=404,

--- a/tests/api/test_enforcement_bundle.py
+++ b/tests/api/test_enforcement_bundle.py
@@ -140,7 +140,7 @@ class TestEnforcementBundleEndpoint:
             scan_results.pop(ext_id, None)
     
     def test_get_enforcement_bundle_governance_error(self, client):
-        """Test 500 when governance analysis failed."""
+        """Test 500 when governance analysis failed without leaking internal details."""
         ext_id = "goverror12345678901234567890123456"
         
         # Scan result with governance error
@@ -155,8 +155,8 @@ class TestEnforcementBundleEndpoint:
             response = client.get(f"/api/scan/enforcement_bundle/{ext_id}")
             
             assert response.status_code == 500
-            assert "failed" in response.json()["detail"].lower()
-            assert "invalid rulepack" in response.json()["detail"]
+            assert response.json()["detail"] == "Governance analysis failed. Please try again."
+            assert "invalid rulepack" not in response.json()["detail"]
         finally:
             scan_results.pop(ext_id, None)
     
@@ -319,4 +319,3 @@ class TestEnforcementBundleFromDatabase:
             
             assert response.status_code == 200
             assert response.json()["verdict"] == "ALLOW"
-


### PR DESCRIPTION
## Summary
This PR fixes a problem in GET /api/scan/enforcement_bundle/{extension_id} where HTTP 500 responses sent back raw Python exception text from governance_error.

The endpoint now logs the raw governance failure on the server and sends back a generic error message that is safe for clients.

## Changes
The enforcement bundle endpoint has been updated so that it no longer shows raw governance_error values in the response.
Added logging on the server side for the governance failure that caused the problem
Updated the existing API test to assert that internal exception details are not leaked

fixes: #53 