### PR TITLE
Fix Supabase search filter escaping

### DIFF
--- a/src/extension_shield/api/database.py
+++ b/src/extension_shield/api/database.py
@@ -59,6 +59,11 @@ def _relevance_rank(extension_name: str, extension_id: str, search_term: str) ->
     return 4
 
 
+def _escape_postgrest_like_term(term: str) -> str:
+    """Escape wildcard characters before interpolating into a PostgREST ilike filter."""
+    return re.sub(r"([%_\\])", r"\\\1", term)
+
+
 class Database:
     """SQLite database manager (dev fallback when Postgres/Supabase is not used)."""
 
@@ -1506,7 +1511,7 @@ class SupabaseDatabase:
                 q = q.or_("visibility.is.null,visibility.eq.public").or_("source.is.null,source.eq.webstore")
             q = q.order("updated_at", desc=True)
             if search and search.strip():
-                term = search.strip()
+                term = _escape_postgrest_like_term(search.strip())
                 q = q.or_(f"extension_name.ilike.%{term}%,extension_id.ilike.%{term}%")
             resp = q.limit(limit_fetch).execute()
             rows = getattr(resp, "data", None) or []
@@ -1559,7 +1564,7 @@ class SupabaseDatabase:
                         .order("updated_at", desc=True)
                     )
                     if search and search.strip():
-                        term = search.strip()
+                        term = _escape_postgrest_like_term(search.strip())
                         q = q.or_(f"extension_name.ilike.%{term}%,extension_id.ilike.%{term}%")
                     resp = q.limit(limit_fetch).execute()
                     rows = getattr(resp, "data", None) or []


### PR DESCRIPTION
Summary
This change fixes a filter-injection issue in the Supabase implementation of get_recent_scans().

The search parameter was previously interpolated directly into a PostgREST ilike filter string. This update escapes special wildcard characters before building the Supabase filter, bringing the behavior in line with the safer SQLite path.

Changes
Added escaping for %, _, and \ before using the search term in Supabase ilike filters
Applied the fix in both Supabase get_recent_scans() query paths, including the fallback branch

Additional
Should i add a a focused regression test for this??

fixes # 52