### PR TITLE
Fix: Improve scan function reliability by removing runtime messaging dependency

### DIFF
--- a/packages/extension/src/popup.js
+++ b/packages/extension/src/popup.js
@@ -619,34 +619,37 @@
     }
   }
 
-  function scan(force) {
-    showStatus('Getting extensions…');
+ function scan(force) {
+  showStatus('Getting extensions…');
 
-    chrome.runtime.sendMessage({ action: 'getAllExtensions' }, function (all) {
+  try {
+    chrome.management.getAll(function (all) {
       if (chrome.runtime.lastError || !all) {
-        chrome.management.getAll(function (fallbackAll) {
-          if (chrome.runtime.lastError) {
-            hideStatus();
-            showError('Cannot access extensions: ' + (chrome.runtime.lastError.message || 'unknown'));
-            return;
-          }
-          var selfId = chrome.runtime.id;
-          var filtered = [];
-          for (var j = 0; j < fallbackAll.length; j++) {
-            if (fallbackAll[j].type === 'extension' && fallbackAll[j].id !== selfId && fallbackAll[j].enabled) filtered.push(fallbackAll[j]);
-          }
-          runScanWithExtensions(filtered, force);
-        });
+        hideStatus();
+        showError('Cannot access extensions');
         return;
       }
 
+      var selfId = chrome.runtime.id;
       var exts = [];
+
       for (var i = 0; i < all.length; i++) {
-        if (all[i].enabled) exts.push(all[i]);
+        if (
+          all[i].type === 'extension' &&
+          all[i].id !== selfId &&
+          all[i].enabled
+        ) {
+          exts.push(all[i]);
+        }
       }
+
       runScanWithExtensions(exts, force);
     });
+  } catch (e) {
+    hideStatus();
+    showError('Unexpected error while scanning');
   }
+}
 
   function runScanWithExtensions(exts, force) {
     if (!exts || exts.length === 0) {


### PR DESCRIPTION
 Changes Made

- Removed dependency on chrome.runtime.sendMessage
- Directly used chrome.management.getAll for fetching extensions
- Added error handling using try-catch
- Improved reliability and reduced failure cases

 Why this fix?

The previous implementation relied on runtime messaging which could fail if the background script was not properly configured. This update simplifies the logic and ensures consistent behavior.

 Result

- More stable extension scanning
- Cleaner and maintainable code
- Better user experience
