### PR TITLE
fix: update benchmarks data sources background

### DIFF
--- a/frontend/src/pages/research/BenchmarksPage.scss
+++ b/frontend/src/pages/research/BenchmarksPage.scss
@@ -904,9 +904,9 @@
 }
 
 .light .sources-box {
-  background: var(--extensionshield-surface-card);
+  background: var(--extensionshield-bg-primary);
   border: 1px solid var(--extensionshield-border);
-  box-shadow: 0 4px 20px rgba(38, 35, 31, 0.06);
+  box-shadow: none;
 }
 
 .light .sources-box__title {


### PR DESCRIPTION
## Summary
- make the Data Sources box match the surrounding benchmarks page background in light mode
- remove the extra card-style shadow so the section blends with the page as described in the issue

Closes #23
