### PR TITLE
restricting trusted proxy headers to prevent IP spoofing & HTTPS bypass

### DIFF
--- a/src/extension_shield/api/main.py
+++ b/src/extension_shield/api/main.py
@@ -62,6 +62,14 @@ from extension_shield.scoring.engine import ScoringEngine
 # Initialize logger
 logger = logging.getLogger(__name__)
 
+
+def _parse_trusted_proxy_hosts() -> list[str]:
+    """Return the explicit proxy hosts allowed to send forwarded headers."""
+    raw_hosts = os.getenv("TRUSTED_PROXY_HOSTS", "").strip()
+    if raw_hosts:
+        return [host.strip() for host in raw_hosts.split(",") if host.strip()]
+    return ["127.0.0.1", "localhost", "::1"]
+
 # Import safe JSON utilities from shared module
 from extension_shield.utils.json_encoder import (
     safe_json_dumps,
@@ -361,8 +369,9 @@ else:
     print(f"✅ CSP: Production mode detected (STATIC_DIR={STATIC_DIR}, index.html exists)")
 app.add_middleware(CSPMiddleware, is_dev=_is_dev)
 
-# Trust X-Forwarded-Proto / X-Forwarded-For from Railway/Cloudflare so request.url.scheme is correct
-app.add_middleware(ProxyHeadersMiddleware, trusted_hosts="*")
+# Trust forwarded headers only from explicitly allowed proxy hosts.
+# Set TRUSTED_PROXY_HOSTS to your actual reverse proxy / CDN hop(s).
+app.add_middleware(ProxyHeadersMiddleware, trusted_hosts=_parse_trusted_proxy_hosts())
 
 # In-memory state lives in shared.py; import references here so existing
 # code in this file (and tests) can continue using module-level names.
@@ -408,20 +417,9 @@ def _get_client_ip(request: Request) -> str:
     """
     Get the client's IP address for rate limiting anonymous users.
     
-    Handles proxied requests via X-Forwarded-For and X-Real-IP headers.
-    Falls back to client host if no headers present.
+    Relies on ProxyHeadersMiddleware to rewrite request.client only when the
+    request came from a trusted proxy host.
     """
-    # Check X-Forwarded-For header (from reverse proxy/load balancer)
-    x_forwarded_for = request.headers.get("x-forwarded-for")
-    if x_forwarded_for:
-        # Take the first IP (original client)
-        return x_forwarded_for.split(",")[0].strip()
-    
-    # Check X-Real-IP header (from nginx)
-    x_real_ip = request.headers.get("x-real-ip")
-    if x_real_ip:
-        return x_real_ip.strip()
-    
     # Fall back to direct client IP
     if request.client:
         return request.client.host


### PR DESCRIPTION
Proxy trust is too broad in main.py:365. The application trusts forwarded headers
again for HSTS and client IP logic at main.py:310 and main.py:415.

Because trusted_hosts="*" accepts forwarded headers from any source, an attacker can:
- Spoof X-Forwarded-For to bypass scan quotas
- Spoof X-Forwarded-Proto to fake HTTPS status

Fix:
- Restrict trusted proxies to known reverse-proxy/CDN CIDRs
- Derive client IP and scheme only from trusted hops

here is what i did,

Updated main.py to stop trusting forwarded headers from arbitrary sources.

Changes:
- Configure ProxyHeadersMiddleware to accept headers only from TRUSTED_PROXY_HOSTS
- Default to loopback hosts when no explicit allowlist is provided
- Remove manual X-Forwarded-For / X-Real-IP fallback in client IP detection

Impact:
Previously, trusted_hosts="*" allowed attackers to spoof client IP and protocol via
forwarded headers, enabling:
- Bypass of anonymous scan limits
- Incorrect HTTPS detection affecting security logic

Now, client IP and scheme are derived only from trusted proxy hops,
eliminating header spoofing as an attack vector.