### PR TITLE
Fix/enforcing ownership checks

### DIFF
--- a/src/extension_shield/api/main.py
+++ b/src/extension_shield/api/main.py
@@ -502,6 +502,27 @@ def _require_admin_or_telemetry_key(request: Request) -> None:
         )
 
 
+def _require_private_scan_artifact_access(
+    request: Request,
+    extension_id: str,
+    payload: Optional[Dict[str, Any]] = None,
+) -> None:
+    """Block access to private scan artifacts unless the requester owns the scan."""
+    requester_id = getattr(getattr(request, "state", None), "user_id", None)
+    if isinstance(payload, dict):
+        is_private = payload.get("visibility") == "private" or payload.get("source") == "upload"
+        owner_id = payload.get("user_id") or scan_user_ids.get(extension_id)
+    else:
+        is_private = scan_source.get(extension_id) == "upload"
+        owner_id = scan_user_ids.get(extension_id)
+
+    if not is_private:
+        return
+
+    if not requester_id or not owner_id or requester_id != owner_id:
+        raise HTTPException(status_code=404, detail="Scan results not found")
+
+
 def _deep_scan_limit_status(rate_limit_key: str) -> Dict[str, Any]:
     """Get deep scan limit status. Returns unlimited in local/dev environments.
     Anonymous (IP-based) users get 1 scan per day; authenticated users get 3.
@@ -2886,7 +2907,7 @@ async def batch_scan_status(req: BatchStatusRequest, request: Request):
 
 
 @app.get("/api/scan/enforcement_bundle/{extension_id}")
-async def get_enforcement_bundle(extension_id: str):
+async def get_enforcement_bundle(extension_id: str, http_request: Request):
     """
     Get the governance enforcement bundle for an analyzed extension.
     
@@ -2924,6 +2945,8 @@ async def get_enforcement_bundle(extension_id: str):
     
     if not results:
         raise HTTPException(status_code=404, detail="Scan results not found")
+
+    _require_private_scan_artifact_access(http_request, extension_id, results)
     
     # Check if governance analysis was run
     governance_bundle = results.get("governance_bundle")
@@ -2957,7 +2980,7 @@ async def get_enforcement_bundle(extension_id: str):
 
 
 @app.get("/api/scan/report/{extension_id}")
-async def generate_pdf_report(extension_id: str) -> Response:
+async def generate_pdf_report(extension_id: str, http_request: Request) -> Response:
     """
     Generate a PDF security report for an analyzed extension.
 
@@ -2986,6 +3009,8 @@ async def generate_pdf_report(extension_id: str) -> Response:
 
     if not results:
         raise HTTPException(status_code=404, detail="Scan results not found")
+
+    _require_private_scan_artifact_access(http_request, extension_id, results)
 
     # Generate PDF report
     try:
@@ -3036,6 +3061,8 @@ async def get_file_list(extension_id: str, http_request: Request) -> FileListRes
     if not results:
         raise HTTPException(status_code=404, detail="Extension not found")
 
+    _require_private_scan_artifact_access(http_request, extension_id, results)
+
     extracted_path = results.get("extracted_path")
     if not extracted_path or not os.path.exists(extracted_path):
         raise HTTPException(status_code=404, detail="Extracted files not found")
@@ -3066,6 +3093,8 @@ async def get_file_content(extension_id: str, file_path: str, http_request: Requ
     results = scan_results.get(extension_id)
     if not results:
         raise HTTPException(status_code=404, detail="Extension not found")
+
+    _require_private_scan_artifact_access(http_request, extension_id, results)
 
     extracted_path = results.get("extracted_path")
     if not extracted_path:
@@ -3822,7 +3851,7 @@ async def database_health_check(request: Request):
 
 
 @app.get("/api/scan/icon/{extension_id}")
-async def get_extension_icon(extension_id: str):
+async def get_extension_icon(extension_id: str, http_request: Request):
     """
     Get extension icon from the extracted extension folder.
     Uses icon_path from storage when available, and falls back to persisted icon bytes.
@@ -3848,6 +3877,9 @@ async def get_extension_icon(extension_id: str):
         icon_media_type = results.get("icon_media_type")
     else:
         db_icon_record = _load_icon_record_from_db(extension_id)
+        results = db.get_scan_result(extension_id)
+        if results:
+            scan_results[extension_id] = results
         extracted_path = db_icon_record.get("extracted_path")
         icon_path = db_icon_record.get("icon_path")
         icon_base64 = db_icon_record.get("icon_base64")
@@ -3891,6 +3923,7 @@ async def get_extension_icon(extension_id: str):
 
     # Best practice: if we have a persisted icon blob, serve it immediately.
     # This avoids relying on filesystem state (ephemeral/persistent) and prevents slow fallbacks.
+    _require_private_scan_artifact_access(http_request, extension_id, results)
     persisted = _extension_icon_response_from_base64(icon_base64, icon_media_type)
     if persisted:
         return persisted

--- a/tests/api/test_enforcement_bundle.py
+++ b/tests/api/test_enforcement_bundle.py
@@ -118,6 +118,38 @@ class TestEnforcementBundleEndpoint:
         
         assert response.status_code == 404
         assert "not found" in response.json()["detail"].lower()
+
+    def test_private_scan_artifact_requires_owner(self, client, tmp_path):
+        """Private scan artifacts should not be readable without the owning user."""
+        ext_id = "privateartifact1234567890123456"
+        extracted = tmp_path / ext_id
+        extracted.mkdir()
+
+        scan_results[ext_id] = {
+            "extension_id": ext_id,
+            "extension_name": "Private Extension",
+            "status": "completed",
+            "visibility": "private",
+            "user_id": "owner-user-1",
+            "governance_bundle": {"decision": {"verdict": "ALLOW"}},
+            "extracted_path": str(extracted),
+        }
+
+        try:
+            endpoints = [
+                f"/api/scan/enforcement_bundle/{ext_id}",
+                f"/api/scan/report/{ext_id}",
+                f"/api/scan/files/{ext_id}",
+                f"/api/scan/file/{ext_id}/manifest.json",
+                f"/api/scan/icon/{ext_id}",
+            ]
+
+            for endpoint in endpoints:
+                response = client.get(endpoint)
+                assert response.status_code == 404
+                assert "not found" in response.json()["detail"].lower()
+        finally:
+            scan_results.pop(ext_id, None)
     
     def test_get_enforcement_bundle_no_governance_data(self, client):
         """Test 404 when governance bundle not available."""


### PR DESCRIPTION
Private scan artifacts are not consistently protected across the API.

Affected endpoints:
- main.py:1571
- main.py:2890
- main.py:2961
- main.py:3019
- main.py:3049
- main.py:3826

The results route correctly enforces:
- visibility == "private"
- ownership checks (main.py:2624, main.py:2648)

However, report, enforcement bundle, file list, file content, and icon endpoints do not.

Impact:
If a private upload UUID leaks, attackers can access full reports and extracted files.

Fix:
- Centralize ownership validation
- Apply authorization checks to all artifact-returning endpoints

here is what i did,

Added a shared ownership guard for private scans in main.py:502 and applied it
across all scan artifact endpoints.

Updated endpoints:
- enforcement bundle
- PDF report
- file list
- file content
- icon access

Behavior:
- Blocks access to any private upload or scan artifact unless requester.user_id
  matches the scan owner
- Icon endpoint now validates ownership before serving cached blobs or filesystem fallbacks

Impact:
Prevents unauthorized access to private scan data if a scan UUID is exposed.

This ensures consistent access control across all artifact-returning routes.