### PR TITLE
fix: run container as non-root user to reduce attack surface

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -88,8 +88,14 @@ ENV PATH="/app/.venv/bin:$PATH"
 # Copy frontend build from stage 1
 COPY --from=frontend-builder /app/frontend/dist ./static
 
-# Create necessary directories
-RUN mkdir -p extensions_storage data
+# Create necessary directories and non-root user
+RUN mkdir -p extensions_storage data && \
+    addgroup --system appgroup && \
+    adduser --system --ingroup appgroup appuser && \
+    chown -R appuser:appgroup /app
+
+# Drop root privileges
+USER appuser
 
 # Set default environment variables
 ENV EXTENSION_STORAGE_PATH=/app/extensions_storage \


### PR DESCRIPTION
## Problem                                                               
  The final Docker image runs the application as root. If the app is
  compromised, an attacker gains full system-level access inside the       
  container.

  ## Fix
  - Created a non-root system user `appuser` and group `appgroup`
  - Transferred ownership of /app directory to this user
  - Added `USER appuser` directive before CMD so the app runs with minimal 
  privileges

  ## Security Impact
  Limits blast radius of any container escape or RCE vulnerability. 