### PR TITLE
Fix/zip bomb limits

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -88,8 +88,14 @@ ENV PATH="/app/.venv/bin:$PATH"
 # Copy frontend build from stage 1
 COPY --from=frontend-builder /app/frontend/dist ./static
 
-# Create necessary directories
-RUN mkdir -p extensions_storage data
+# Create necessary directories and non-root user
+RUN mkdir -p extensions_storage data && \
+    addgroup --system appgroup && \
+    adduser --system --ingroup appgroup appuser && \
+    chown -R appuser:appgroup /app
+
+# Drop root privileges
+USER appuser
 
 # Set default environment variables
 ENV EXTENSION_STORAGE_PATH=/app/extensions_storage \

--- a/src/extension_shield/core/config.py
+++ b/src/extension_shield/core/config.py
@@ -208,16 +208,18 @@ def get_settings() -> Settings:
     telemetry_admin_key = os.environ.get("TELEMETRY_ADMIN_KEY")
 
     # Zip-bomb protection: max file count and max total uncompressed size
-    _zip_max_files = os.environ.get("ZIP_EXTRACT_MAX_FILES", "10000")
-    _zip_max_bytes = os.environ.get("ZIP_EXTRACT_MAX_UNCOMPRESSED_BYTES", "524288000")  # 500 MiB
+    # Reduced defaults to prevent DoS via crafted .crx archives:
+    # 1000 files and 100 MiB are sufficient for any legitimate Chrome extension.
+    _zip_max_files = os.environ.get("ZIP_EXTRACT_MAX_FILES", "1000")
+    _zip_max_bytes = os.environ.get("ZIP_EXTRACT_MAX_UNCOMPRESSED_BYTES", "104857600")  # 100 MiB
     try:
         zip_extract_max_files = int(_zip_max_files)
     except ValueError:
-        zip_extract_max_files = 10000
+        zip_extract_max_files = 1000
     try:
         zip_extract_max_uncompressed_bytes = int(_zip_max_bytes)
     except ValueError:
-        zip_extract_max_uncompressed_bytes = 524288000
+        zip_extract_max_uncompressed_bytes = 104857600
 
     storage_backend = _parse_storage_backend(os.environ.get("STORAGE_BACKEND"))
 


### PR DESCRIPTION
 ## Problem
  Default ZIP extraction limits were dangerously high:
  - Max files: 10,000
  - Max uncompressed size: 500 MiB

  A malicious actor could upload a crafted .crx extension (zip bomb)       
  to exhaust server memory and cause a Denial of Service (DoS).

  ## Fix
  Reduced defaults to safe values:
  - Max files: 1,000 (sufficient for any real Chrome extension)
  - Max uncompressed size: 100 MiB

  These limits can still be overridden via environment variables
  if needed for specific deployments.

  ## Security Impact
  Prevents DoS attacks via crafted extension uploads.