### PR TITLE
fix: wrap int() conversions in try/except to prevent crashes on bad D…

### DIFF
--- a/src/extension_shield/api/database.py
+++ b/src/extension_shield/api/database.py
@@ -420,7 +420,10 @@ class Database:
                 (day, path),
             )
             row = cursor.fetchone()
-            return int(row["count"]) if row else 0
+            try:
+                return int(row["count"]) if row else 0
+            except (TypeError, ValueError):
+                return 0
 
     def get_page_view_summary(self, days: int = 14) -> Dict[str, Any]:
         """
@@ -708,7 +711,7 @@ class Database:
                             "high_risk_extensions": row["high_risk"] or 0,
                             "total_files_analyzed": row["total_files"] or 0,
                             "total_vulnerabilities": row["total_findings"] or 0,
-                            "avg_security_score": int(row["avg_security_score"] or 0),
+                            "avg_security_score": int(row["avg_security_score"] or 0) if row["avg_security_score"] is None or isinstance(row["avg_security_score"], (int, float)) else 0,
                         }
                     )
 


### PR DESCRIPTION
 ## Problem
  Two `int()` conversions in `database.py` had no error handling:
  - `int(row["count"])` at page view query
  - `int(row["avg_security_score"] or 0)` in stats aggregation

  If the database contains a corrupt/non-numeric value, these raise        
  `ValueError`/`TypeError` and crash the API endpoint.

  ## Fix
  - Wrapped `int(row["count"])` in try/except returning 0 on failure       
  - Added type guard for avg_security_score before conversion

  ## Impact
  Prevents unhandled exceptions that could expose internal stack traces    
  or cause API downtime.