### PR TITLE
fix: increase Manifest V2 risk penalty to reflect Chrome deprecation

### DIFF
--- a/src/extension_shield/core/security_scorer.py
+++ b/src/extension_shield/core/security_scorer.py
@@ -363,9 +363,9 @@ class SecurityScorer:
         mv_risk = 0
         manifest_version = manifest.get('manifest_version')
         if manifest_version == 2:
-            mv_risk = 2  # MV2 is deprecated
-            risk += 2
-            issues.append('Using deprecated Manifest V2')
+            mv_risk = 5  # MV2 is deprecated and actively being removed by Chrome
+            risk += 5
+            issues.append('Using deprecated Manifest V2 (Chrome is removing MV2 support; extension should migrate to MV3)')
 
         details = {
             'manifest_version': manifest_version,


### PR DESCRIPTION
 ## Problem
  Manifest V2 extensions were only penalized 2 risk points despite Chrome  
  actively removing MV2 support. This underweights a significant security  
  signal — MV2 extensions will soon stop working entirely.

  ## Fix
  - Increased MV2 risk score from 2 → 5
  - Updated issue message to explain why MV2 is risky (Chrome removal)     

  ## Reference
  Chrome is deprecating MV2: https://developer.chrome.com/docs/extensions/d
  evelop/migrate/mv2-deprecation-timeline