### PR TITLE
[BUG FIX] Changed background of Data Sources section to match the rest of the page.

### DIFF
--- a/frontend/src/pages/research/BenchmarksPage.scss
+++ b/frontend/src/pages/research/BenchmarksPage.scss
@@ -209,7 +209,7 @@
 
 /* SourcesBox (used in sources-section) */
 .sources-box {
-  background: rgba(13, 20, 36, 0.6);
+  background: rgba(148, 163, 184, 0.05);
   border: 1px solid rgba(148, 163, 184, 0.1);
   border-radius: 12px;
   padding: 1.5rem;


### PR DESCRIPTION
**Before**
<img width="1718" height="993" alt="Screenshot 2026-04-04 204956" src="https://github.com/user-attachments/assets/6cb5b961-bf23-427d-9c60-fb6b28f163ca" />

**After**
<img width="1682" height="1035" alt="Screenshot 2026-04-04 205003" src="https://github.com/user-attachments/assets/b88b9877-6cef-40f8-863e-1997785a26b9" />

Fixes Issue #23 