### PR TITLE
[BUG FIX] The scanning progress overlay is fixed to be static

### DIFF
--- a/frontend/src/pages/research/BenchmarksPage.scss
+++ b/frontend/src/pages/research/BenchmarksPage.scss
@@ -209,7 +209,7 @@
 
 /* SourcesBox (used in sources-section) */
 .sources-box {
-  background: rgba(13, 20, 36, 0.6);
+  background: rgba(148, 163, 184, 0.05);
   border: 1px solid rgba(148, 163, 184, 0.1);
   border-radius: 12px;
   padding: 1.5rem;

--- a/frontend/src/pages/scanner/ScanProgressPage.scss
+++ b/frontend/src/pages/scanner/ScanProgressPage.scss
@@ -12,7 +12,7 @@
 }
 
 .scan-progress-center {
-  position: fixed;
+  position: relative;
   inset: 0;
   z-index: 1;
   display: flex;
@@ -41,7 +41,7 @@
 /* Retro Style Header Overlay */
 .retro-header-overlay {
   padding-top: 100px;
-  position: absolute;
+  position: relative;
   top: 0;
   left: 0;
   right: 0;
@@ -104,7 +104,7 @@
   /* Retro scanline effect */
   &::before {
     content: '';
-    position: absolute;
+    position: relative;
     top: 0;
     left: 0;
     right: 0;
@@ -123,7 +123,7 @@
   /* Retro pixelated effect - enhanced */
   &::after {
     content: 'Scan in progress — game mode.';
-    position: absolute;
+    position: relative;
     top: 0;
     left: 0;
     color: rgba(34, 197, 94, 0.15);
@@ -205,7 +205,7 @@
   /* Retro scanline effect on button */
   &::before {
     content: '';
-    position: absolute;
+    position: relative;
     top: 0;
     left: -100%;
     width: 100%;
@@ -670,7 +670,7 @@
 }
 
 .scanner-ring {
-  position: absolute;
+  position: relative;
   border-radius: 50%;
   border: 2px solid rgba(59, 130, 246, 0.3);
 }
@@ -702,7 +702,7 @@
 }
 
 .scanner-core {
-  position: absolute;
+  position: relative;
   width: 80px;
   height: 80px;
   top: 50%;
@@ -717,7 +717,7 @@
 }
 
 .core-pulse {
-  position: absolute;
+  position: relative;
   width: 100%;
   height: 100%;
   border-radius: 50%;
@@ -897,7 +897,7 @@
 
 /* Inline error on scan progress (no dialog overlay) */
 .scan-progress-inline-error {
-  position: absolute;
+  position: relative;
   left: 50%;
   top: calc(50% + 10.5rem);
   transform: translate(-50%, 0);


### PR DESCRIPTION
**Before**
<img width="1916" height="1022" alt="Screenshot 2026-04-04 100935" src="https://github.com/user-attachments/assets/09bc6dc9-8c24-40e6-92ef-a222ffb1aa4e" />

As seen above, the progress overlay lays on top of the page footer when the user scrolls down. 

**After**
<img width="1919" height="1198" alt="Screenshot 2026-04-04 221049" src="https://github.com/user-attachments/assets/644c62b6-fd59-4d82-a49c-5e7e992c9060" />

The bug has been fixed to make sure the div stays static and does not move with scrolling.

File changed: ScanProgressPage.scss

Fixes issue: #168 