### PR TITLE
fix(api): plug memory leak by replacing global dictionary caches with TTLCache

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
     "psycopg[binary]>=3.2.2",
     # Optional: send enterprise pilot confirmation emails (when RESEND_API_KEY is set)
     "resend>=2.0.0",
+    "cachetools>=6.2.6",
 ]
 
 [dependency-groups]

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ langchain
 openai
 python-dateutil
 python-multipart
+cachetools

--- a/src/extension_shield/api/main.py
+++ b/src/extension_shield/api/main.py
@@ -454,7 +454,7 @@ def _require_admin_key(request: Request) -> None:
             status_code=403,
             detail="Admin API key is not configured"
         )
- provided_key = request.headers.get("X-Admin-Key") or request.headers.get("x-admin-key")
+    provided_key = request.headers.get("X-Admin-Key") or request.headers.get("x-admin-key")
     if not provided_key:
         raise HTTPException(
             status_code=403,

--- a/src/extension_shield/api/shared.py
+++ b/src/extension_shield/api/shared.py
@@ -8,20 +8,21 @@ imports between ``main.py`` and route routers.
 
 from typing import Any, Dict, Optional
 from pydantic import BaseModel
+import cachetools
 
 
 # ── In-memory state (process-local, not persisted) ──────────────────────
 
-scan_results: Dict[str, Dict[str, Any]] = {}
+scan_results: cachetools.TTLCache = cachetools.TTLCache(maxsize=10000, ttl=3600)
 """extension_id → full scan payload (in-flight + recently completed)."""
 
-scan_status: Dict[str, str] = {}
+scan_status: cachetools.TTLCache = cachetools.TTLCache(maxsize=10000, ttl=3600)
 """extension_id → scan lifecycle status string."""
 
-scan_user_ids: Dict[str, Optional[str]] = {}
+scan_user_ids: cachetools.TTLCache = cachetools.TTLCache(maxsize=10000, ttl=3600)
 """extension_id → authenticated user_id (Supabase ``sub``) at trigger time."""
 
-scan_source: Dict[str, Optional[str]] = {}
+scan_source: cachetools.TTLCache = cachetools.TTLCache(maxsize=10000, ttl=3600)
 """extension_id → 'upload' for private builds; None/webstore for public."""
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -776,6 +776,7 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },
+    { name = "cachetools" },
     { name = "click" },
     { name = "fastapi" },
     { name = "fastmcp" },
@@ -815,6 +816,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "beautifulsoup4", specifier = ">=4.14.2" },
+    { name = "cachetools", specifier = ">=6.2.6" },
     { name = "click", specifier = ">=8.1.0" },
     { name = "fastapi", specifier = ">=0.115.0" },
     { name = "fastmcp", specifier = ">=1.0" },


### PR DESCRIPTION
## Description

This PR fixes a memory leak caused by unbounded growth of in-memory scan state dictionaries (`scan_results`, `scan_status`, `scan_user_ids`, `scan_source`).

## Problem

Scan data was stored in process-local dictionaries without a unified cleanup mechanism. In edge cases (e.g., interrupted or failed scans), entries were never removed, leading to steadily increasing memory usage in production.

## Solution

Replaced in-memory dictionaries with `cachetools.TTLCache` to enforce bounded storage and automatic expiration of stale entries.

## Changes Made

- Replaced `Dict`-based scan state storage with `TTLCache`
- Configured limits:
  - `maxsize=10000`
  - `ttl=3600` (1 hour)
- Added `cachetools` to dependency management (`requirements.txt`, `pyproject.toml`)
- Fixed a minor indentation issue in `_require_admin_key()` to restore test execution

## Impact

- Prevents memory growth from stale scan data  
- Ensures automatic cleanup of abandoned or incomplete scans  
- Stabilizes memory usage in long-running production instances  

## Checklist:
- [x] Memory limit caps defined
- [x] Time-based evictions verified
- [x] Dependencies synced locally via `uv add cachetools`
- [x] `make test` correctly initiates without syntax failure

closes #160 