### PR TITLE
Solved sign-in button issue

### DIFF
--- a/frontend/src/App.scss
+++ b/frontend/src/App.scss
@@ -779,14 +779,21 @@ body {
 /* Theme toggle styles live in components/ThemeToggle.scss */
 
 .action-signin {
-  padding: 0.5rem 1.25rem;
+  padding: 0.4rem 1rem;
   font-size: 0.9375rem;
   font-weight: 500;
   color: #fff;
   text-decoration: none;
   background: var(--extensionshield-accent-cta, var(--extensionshield-accent));
   border: 1px solid var(--extensionshield-accent-cta, var(--extensionshield-accent));
-  border-radius: 8px;
+  
+  border-radius: 9999px;
+  white-space: nowrap;
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+
   cursor: pointer;
   transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease;
   font-family: inherit;


### PR DESCRIPTION
Fixex #184
At around 920px viewport width, the Sign In button expands to full height inside the navbar, causing the header to become taller and visually misaligned.


https://github.com/user-attachments/assets/5170c006-afcc-43a5-8e9c-f33fcf5379ff



I am posting the drive link in which I had added the screen recording of the corrected version of this issue.
Kindly review the changes and let me know if any adjustments are needed.