### PR TITLE
test: fix layer details governance fixture

### DIFF
--- a/tests/test_layer_details_generator.py
+++ b/tests/test_layer_details_generator.py
@@ -188,7 +188,7 @@ class TestLayerDetailsGenerator:
                 "one_liner": "Low governance risk with good policy compliance.",
                 "key_points": [
                     "WebStoreTrust: 50,000 users indicates established extension",
-                    "WebStoreTrust and store metadata show no policy violations detected."
+                    "WebStoreTrust reports no Chrome Web Store policy violations for this listing."
                 ],
                 "what_to_watch": [
                     "Monitor WebStoreTrust changes and store policy updates."


### PR DESCRIPTION
## Summary
- remove the banned generic phrase from the mocked governance bullet in layer details tests
- keep the concrete WebStoreTrust reference required by the validator
- leave the separate Railway deploy secret issue unchanged because it is not fixable in repo code

## Verification
- PYTHONPATH=src EXTSHIELD_MODE=oss OPENAI_API_KEY=sk-test-placeholder ./.venv/bin/python -m pytest tests/test_layer_details_generator.py -q
- git diff --check