### PR TITLE
This PR fixes responsive layout issues with benchmark charts on narrow mobile screens. #221

### DIFF
--- a/frontend/src/components/benchmarks/TrendChart.jsx
+++ b/frontend/src/components/benchmarks/TrendChart.jsx
@@ -36,21 +36,30 @@ const TrendChart = ({ data, dataKey, title, color = "#22c55e", height = 350, the
   };
 
   return (
-    <div className="trend-chart" style={{ width: '100%', height }}>
+    <div className="trend-chart" style={{ width: '100%', height, display: 'flex', flexDirection: 'column', minWidth: 0 }}>
       <h4 className="trend-chart__title" style={{ 
         fontSize: '0.9375rem', 
         fontWeight: 600, 
-        marginBottom: '1rem'
+        marginBottom: '1rem',
+        flexShrink: 0
       }}>
         {title}
       </h4>
-      <ResponsiveContainer width="100%" height="100%">
+      <ResponsiveContainer width="100%" height="100%" minWidth={0}>
         <LineChart data={formattedData} margin={{ top: 5, right: 30, left: 20, bottom: 5 }}>
           <CartesianGrid strokeDasharray="3 3" stroke="var(--theme-border-subtle)" />
           <XAxis 
             dataKey="date" 
             stroke="var(--theme-text-subtle)"
             style={{ fontSize: '0.75rem' }}
+            interval="preserveEnd"
+            minTickGap={20}
+            angle={-35}
+            textAnchor="end"
+            dx={-5}
+            dy={10}
+            height={60}
+            tickLine={false}
           />
           <YAxis 
             stroke="var(--theme-text-subtle)"

--- a/frontend/src/pages/research/BenchmarksPage.scss
+++ b/frontend/src/pages/research/BenchmarksPage.scss
@@ -261,15 +261,14 @@
   line-height: 1.5;
 }
 
-/* Charts */
 .charts-grid {
   display: grid;
-  grid-template-columns: repeat(2, 1fr);
+  grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 1.5rem;
   margin-bottom: 1.5rem;
 
   @media (max-width: 968px) {
-    grid-template-columns: 1fr;
+    grid-template-columns: minmax(0, 1fr);
   }
 }
 
@@ -296,6 +295,7 @@
   border-radius: 16px;
   padding: 1.5rem;
   transition: all 0.3s ease;
+  min-width: 0;
 
   .trend-chart__title {
     color: var(--extensionshield-text-primary, #f8fafc);

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,7 +4,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "ExtensionShield",
       "devDependencies": {
         "dotenv": "^16.4.5",
         "resend": "^4.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "ExtensionShield",
       "devDependencies": {
         "dotenv": "^16.4.5",
         "resend": "^4.0.0",


### PR DESCRIPTION


Changes Made
- Reduced default chart height in ->TrendChart.jsx
- Rotated X-axis labels for better readability on small screens
- Added extra bottom spacing for axis labels
- Preserved chart responsiveness within card boundaries

Issue Fixed
On very narrow viewports (~300px width), benchmark charts were overflowing their cards and overlapping adjacent content, making the layout cluttered and hard to read.

Testing
Tested on:
- Viewport: `300px × 611px`

Verified that:
- Charts stay within their containers
- X-axis labels no longer overlap other elements and it should not overlap on the graph x axis
- Layout remains clean and readable on mobile devices

Demo

I am attaching video reference 

https://github.com/user-attachments/assets/0cc5a89e-a4e2-45cf-a004-16cd5f640ff2

Closes #221

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chart display with better label positioning and visibility on the Benchmarks page
  * Fixed grid layout constraints to prevent content overflow and improve responsiveness across different screen sizes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->