### PR TITLE
Fix scoring decision authority and governance rulepacks

### DIFF
--- a/docs/adr/0001-scoring-governance-decision-authority.md
+++ b/docs/adr/0001-scoring-governance-decision-authority.md
@@ -1,0 +1,148 @@
+# ADR 0001: Single Decision Authority, Confidence, and Protected-Service Governance
+
+- **Status:** Accepted
+- **Date:** 2026-06-12
+- **Area:** Scoring engine (`scoring/`) and governance pipeline (`governance/`, `workflow/`)
+
+## Context
+
+A review of the scoring/governance stack found several correctness and
+maintainability problems:
+
+1. **Multiple competing verdict paths.** The V2 scoring engine, the legacy
+   scorecards, and the DSL rules engine each produced a verdict, and the
+   governance node surfaced more than one of them. There was no single,
+   well-defined precedence for the final ALLOW / BLOCK / NEEDS_REVIEW.
+2. **`overall_confidence` was effectively hardcoded to `1.0`.** The engine built
+   `ScoringResult` directly and never populated confidence, so every scan
+   reported 100% confidence regardless of how little data was available.
+3. **Zero-data extensions looked safe.** With no SAST, VirusTotal, or network
+   coverage an extension could surface as ~80/100 at 100% confidence.
+4. **Two different threshold systems.** `engine.py` used `<30 / <75`; the gate
+   helper used `<30 / <50`.
+5. **Layer weights disagreed with their own docs** (`0.5/0.3/0.2` in docstrings
+   vs `0.34/0.33/0.33` in code).
+6. **The rules engine failed open.** A malformed condition or rulepack was
+   silently dropped, which for a BLOCK rule means a silent ALLOW.
+7. **Visa / travel-document detection was hardcoded** in `scoring/gates.py` and
+   `scoring/engine.py` (domain lists, regexes), making it brittle and
+   non-auditable.
+
+## Decision
+
+### 1. One final decision authority
+`scoring/decision.py` defines a single `resolve()` function — the only place a
+final verdict is computed — with one precedence chain:
+
+```
+org_block            (explicit org blocklist)            -> BLOCK
+org_allow_exception  (explicit org allow exception)      -> ALLOW   (wins over automated rungs)
+baseline_governance  (governance rulepack BLOCK)         -> BLOCK
+hard_gate            (hard security/privacy gate BLOCK)  -> BLOCK
+score_threshold      (DecisionPolicy thresholds, warns)  -> BLOCK / NEEDS_REVIEW
+low_confidence       (insufficient data / low conf.)     -> NEEDS_REVIEW (downgrades ALLOW only)
+score_pass                                               -> ALLOW
+```
+
+- `ScoringEngine` uses `resolve()` for its decision (scoring rungs only).
+- `governance_node` calls the **same** `resolve()` with the full input set
+  (rulepack baseline verdicts + optional `OrgPolicy`) and surfaces that as the
+  single authoritative `governance_verdict`. The rules-engine report and the
+  per-layer scores remain as detail/audit, not as competing verdicts.
+- The old `ScoringEngine._determine_decision` was removed.
+
+### 2. Confidence fix
+`overall_confidence` is computed in the engine as the layer-weighted average of
+the three layer confidences and passed into `ScoringResult`. It is never the
+`1.0` default. Low coverage now visibly produces low confidence.
+
+### 3. Insufficient-data behavior
+When **none** of SAST, VirusTotal, or network analysis produced coverage, the
+result is marked `insufficient_data`, the overall score is capped into the
+review band (`INSUFFICIENT_DATA_SCORE_CAP = 65`), and the decision authority
+forces `NEEDS_REVIEW`. This is intentionally distinct from the pre-existing
+"SAST-only missing → cap at 80" behavior, which is preserved.
+
+### 4. Single threshold policy
+`DecisionPolicy` (`BLOCK_SCORE=30`, `REVIEW_SCORE=75`, `LOW_CONFIDENCE=0.5`) is
+the only source of thresholds. `gates.get_final_decision` delegates to
+`resolve()`; the divergent `<50` path is gone.
+
+### 5. Layer weights
+Standardized on the in-code behavior **`0.34 / 0.33 / 0.33`** (security /
+privacy / governance) and corrected the docstrings and the dead-code
+`assemble()` defaults that claimed `0.5/0.3/0.2`. No score behavior changed.
+(Hard gates already enforce hard BLOCKs for severe findings independent of layer
+weights, so equal-ish weighting of the smooth score is acceptable. Re-weighting
+toward security can be revisited separately with a calibration set.)
+
+### 6. Rules-engine fails closed
+- A condition that cannot be parsed raises `RuleConditionError`; the rule
+  becomes `NEEDS_REVIEW`, never a silent ALLOW.
+- `validate_rulepack()` checks structure (ids, conditions, verdict enum,
+  confidence range). `load_rulepacks_with_report()` returns
+  `(valid_rulepacks, errors)`; parse/schema errors and missing requested
+  rulepacks produce synthetic `NEEDS_REVIEW` results.
+
+### 7. Protected-service automation rulepack (visa / travel-doc)
+Detection was migrated out of hardcoded Python into declarative, versioned data
+and rules:
+
+- `config/protected_services.yaml` — single source of truth for protected-service
+  domains, ecosystem domains, code patterns, identity keywords, and sabotage
+  indicators.
+- `governance/protected_services.py` — loads the YAML and centralizes detection.
+- `governance/signal_extractor.py` — emits `PROTECTED_SERVICE_AUTOMATION`,
+  `CREDENTIAL_CAPTURE`, `IDENTITY_DATA_EXFIL`, `SCREENSHOT_CAPTURE`,
+  `XHR_INTERCEPTION`, etc.
+- `governance/rulepacks/PROTECTED_SERVICE_AUTOMATION.yaml` — declarative,
+  cited rules that turn those signals into BLOCK / NEEDS_REVIEW.
+- `scoring/gates.py` now imports its domain lists from the single declarative
+  source (re-exported under the legacy names).
+
+## Why the hardcoded TOS gate remains (temporarily)
+
+The hardcoded `TOS_VIOLATION` gate in `scoring/gates.py` is **deliberately kept
+as a defensive backstop**, not removed, even though `PROTECTED_SERVICE_AUTOMATION`
+now covers the same case. Rationale:
+
+- **Do not weaken detection during a refactor.** The gate is a proven path that
+  produces a hard BLOCK; the rulepack path is new and depends on signal
+  extraction wiring.
+- **Defense in depth.** Two independent paths (gate + rulepack) both BLOCK the
+  CheckVisaSlots fixture, so a regression in one does not silently drop the BLOCK.
+- **Retirement criterion.** Retire the gate's travel-docs branch only after the
+  rulepack has proven itself across more fixtures (more real protected-service
+  extensions, plus benign visa-adjacent extensions to bound false positives).
+  Until then the gate stays. The branch carries a deprecation note pointing here.
+
+## Consequences
+
+- There is exactly one precedence chain; consumers must not re-derive verdicts.
+- Confidence and insufficient-data are now meaningful and surfaced.
+- Malformed governance policy fails closed (safe for a tool whose job is to BLOCK).
+- Protected-service detection is auditable and versioned via YAML; tuning no
+  longer requires a Python release.
+- Two detection paths exist for protected-service automation until the gate is
+  retired — intentional redundancy, tracked here.
+
+## Verification
+
+- New tests: `tests/scoring/test_decision_authority.py`,
+  `tests/governance/test_rules_engine_failclosed.py`,
+  `tests/scoring/test_checkvisaslots_block.py`,
+  `tests/governance/test_protected_service_rulepack.py`.
+- Targeted suite (`tests/scoring`, `tests/governance`, `tests/workflow`,
+  `tests/test_scoring_gates.py`, `tests/test_golden_snapshots.py`): **235 passed**.
+- The CheckVisaSlots fixture asserts BLOCK via both the gate and the rulepack;
+  detection is not weakened.
+
+## Note on unrelated failures
+
+In a full-repo `pytest tests/` run, a small number of API / Supabase /
+open-core tests (`tests/api/test_telemetry_atomic.py`,
+`tests/api/test_supabase_auth.py`,
+`tests/test_open_core_enforceability.py::...returns_sqlite...`) fail or error.
+These are **pre-existing infrastructure / test-isolation issues**: they import
+the DB/Supabase layer (not any module changed here) and pass in isolation. They
+are out of scope for this audit and must not be folded into this commit.

--- a/frontend/src/components/home/SecurityPipeline.jsx
+++ b/frontend/src/components/home/SecurityPipeline.jsx
@@ -8,9 +8,9 @@ import { Shield, Eye, Scale, CheckCircle2, Loader2, Package } from "lucide-react
 import "./SecurityPipeline.scss";
 
 const PIPELINE_STAGES = [
-  { id: "security", label: "Security", Icon: Shield, weight: "40%", color: "#3b82f6", description: "Malware & threat detection" },
-  { id: "privacy", label: "Privacy", Icon: Eye, weight: "35%", color: "#8b5cf6", description: "Data collection analysis" },
-  { id: "governance", label: "Governance", Icon: Scale, weight: "25%", color: "#f59e0b", description: "Compliance verification" },
+  { id: "security", label: "Security", Icon: Shield, weight: "34%", color: "#3b82f6", description: "Malware & threat detection" },
+  { id: "privacy", label: "Privacy", Icon: Eye, weight: "33%", color: "#8b5cf6", description: "Data collection analysis" },
+  { id: "governance", label: "Governance", Icon: Scale, weight: "33%", color: "#f59e0b", description: "Compliance verification" },
 ];
 
 export default function SecurityPipeline({ reducedMotion = false }) {

--- a/frontend/src/data/blogPosts.js
+++ b/frontend/src/data/blogPosts.js
@@ -436,7 +436,7 @@ export const blogPosts = [
       },
       {
         heading: "ExtensionShield's model",
-        body: "ExtensionShield scores Security at 40%, Privacy at 35%, and Governance at 25%. The report keeps each layer visible so the final number can be explained."
+        body: "ExtensionShield's smooth score weights Security, Privacy, and Governance near-equally (about 34% / 33% / 33%), while hard gates override the score to BLOCK severe findings such as malware or credential capture. The report keeps each layer visible so the final number can be explained."
       },
       {
         heading: "Use the score as a decision aid",

--- a/frontend/src/pages/compare/CompareCrxcavatorPage.jsx
+++ b/frontend/src/pages/compare/CompareCrxcavatorPage.jsx
@@ -34,7 +34,7 @@ const CompareCrxcavatorPage = () => {
               <strong>CRXcavator</strong> offers permission-based scoring, RetireJS for vulnerable libraries, CSP checks, and enterprise allowlisting. It scans Chrome, Firefox, and Edge extensions on a schedule. Many teams look for <strong>CRXcavator alternatives</strong> because of intermittent availability, limited transparency in scoring, and no dedicated governance/compliance layer.
             </p>
             <p>
-              <strong>ExtensionShield</strong> gives you a single <strong>chrome extension risk score</strong> (0–100) with three layers: Security (40%), Privacy (35%), and Governance (25%). We add SAST (Semgrep), VirusTotal integration, obfuscation detection, and explicit governance (ToS alignment, disclosure, consistency) so you can <strong>audit chrome extension security</strong> and support <strong>extension governance and compliance</strong>. Our methodology is fully documented; you get evidence-based reports suitable for audits.
+              <strong>ExtensionShield</strong> gives you a single <strong>chrome extension risk score</strong> (0–100) with three near-equally weighted layers: Security (34%), Privacy (33%), and Governance (33%), plus hard gates that override the score to BLOCK severe findings. We add SAST (Semgrep), VirusTotal integration, obfuscation detection, and explicit governance (ToS alignment, disclosure, consistency) so you can <strong>audit chrome extension security</strong> and support <strong>extension governance and compliance</strong>. Our methodology is fully documented; you get evidence-based reports suitable for audits.
             </p>
             <ul>
               <li>Transparent weights and methodology (Security / Privacy / Governance)</li>

--- a/frontend/src/pages/compare/CompareCrxplorerPage.jsx
+++ b/frontend/src/pages/compare/CompareCrxplorerPage.jsx
@@ -34,7 +34,7 @@ const CompareCrxplorerPage = () => {
               <strong>CRXplorer</strong> offers a single risk score, full source code viewer, and fast results. Its AI reads the code to produce a score, but the methodology and weights are not fully transparent. It does not document SAST, VirusTotal, or a dedicated governance/compliance layer.
             </p>
             <p>
-              <strong>ExtensionShield</strong> provides a <strong>chrome extension risk score</strong> (0–100) with three documented layers: Security (40%), Privacy (35%), and Governance (25%). We use Semgrep SAST, VirusTotal, obfuscation detection, and ChromeStats — plus a dedicated governance layer for ToS alignment and disclosure — so you can <strong>check if a chrome extension is safe</strong> with evidence you can cite. Ideal for <strong>browser extension security audit</strong> and <strong>extension risk assessment</strong>.
+              <strong>ExtensionShield</strong> provides a <strong>chrome extension risk score</strong> (0–100) with three documented, near-equally weighted layers: Security (34%), Privacy (33%), and Governance (33%), plus hard gates that override the score to BLOCK severe findings. We use Semgrep SAST, VirusTotal, obfuscation detection, and ChromeStats — plus a dedicated governance layer for ToS alignment and disclosure — so you can <strong>check if a chrome extension is safe</strong> with evidence you can cite. Ideal for <strong>browser extension security audit</strong> and <strong>extension risk assessment</strong>.
             </p>
             <ul>
               <li>Transparent three-layer scoring (Security / Privacy / Governance)</li>

--- a/frontend/src/pages/compare/CompareExtensionAuditorPage.jsx
+++ b/frontend/src/pages/compare/CompareExtensionAuditorPage.jsx
@@ -34,7 +34,7 @@ const CompareExtensionAuditorPage = () => {
               <strong>ExtensionAuditor</strong> offers real-time permission analysis, color-coded risk, review sentiment, and CSV export. It runs as a browser extension (Chrome, Edge, Opera, Brave) and processes data on-device. Scoring methodology is not fully transparent, and it does not document SAST or VirusTotal integration.
             </p>
             <p>
-              <strong>ExtensionShield</strong> delivers a <strong>chrome extension risk score</strong> (0–100) with three documented layers: Security (40%), Privacy (35%), and Governance (25%). We combine a <strong>chrome extension permissions checker</strong> with SAST (Semgrep), VirusTotal, obfuscation detection, and a dedicated governance layer — so you can <strong>audit chrome extension security</strong> and support <strong>extension governance and compliance</strong>. Reports are evidence-based and audit-ready.
+              <strong>ExtensionShield</strong> delivers a <strong>chrome extension risk score</strong> (0–100) with three documented, near-equally weighted layers: Security (34%), Privacy (33%), and Governance (33%) — plus hard gates that override the score to BLOCK severe findings. We combine a <strong>chrome extension permissions checker</strong> with SAST (Semgrep), VirusTotal, obfuscation detection, and a dedicated governance layer — so you can <strong>audit chrome extension security</strong> and support <strong>extension governance and compliance</strong>. Reports are evidence-based and audit-ready.
             </p>
             <ul>
               <li>Transparent three-layer scoring and methodology</li>

--- a/frontend/src/pages/landing/CrxcavatorAlternativePage.jsx
+++ b/frontend/src/pages/landing/CrxcavatorAlternativePage.jsx
@@ -37,7 +37,7 @@ const CrxcavatorAlternativePage = () => {
               CRXcavator provides permission-based scoring, RetireJS, and CSP checks for Chrome, Firefox, and Edge extensions. Teams often look for alternatives due to availability, limited transparency in how scores are calculated, or the need for a dedicated <strong>governance and compliance</strong> layer.
             </p>
             <p>
-              <strong>ExtensionShield</strong> gives you a single <strong>chrome extension risk score</strong> (0–100) with three dimensions: Security (40%), Privacy (35%), and Governance (25%). We add SAST (Semgrep), VirusTotal integration, obfuscation detection, and explicit governance signals so you can audit extensions and support compliance. Our methodology is documented; reports are evidence-based and suitable for audits.
+              <strong>ExtensionShield</strong> gives you a single <strong>chrome extension risk score</strong> (0–100) with three near-equally weighted dimensions: Security (34%), Privacy (33%), and Governance (33%), with hard gates that override the score to BLOCK severe findings. We add SAST (Semgrep), VirusTotal integration, obfuscation detection, and explicit governance signals so you can audit extensions and support compliance. Our methodology is documented; reports are evidence-based and suitable for audits.
             </p>
             <ul>
               <li>Transparent weights and methodology (Security / Privacy / Governance)</li>

--- a/frontend/src/pages/landing/ExtensionRiskScorePage.jsx
+++ b/frontend/src/pages/landing/ExtensionRiskScorePage.jsx
@@ -47,9 +47,10 @@ const ExtensionRiskScorePage = () => {
 
             <h2>The three scoring layers</h2>
             <ul>
-              <li><strong>Security - 40%:</strong> suspicious code patterns, SAST rules, vulnerable libraries, obfuscation, threat-intel findings, and exploit-relevant APIs.</li>
-              <li><strong>Privacy - 35%:</strong> sensitive permissions, all-site access, cookies, history, clipboard, storage, network destinations, and data exfiltration paths.</li>
-              <li><strong>Governance - 25%:</strong> policy alignment, permission justification, disclosure accuracy, developer reputation, update risk, and audit readiness.</li>
+              <li><strong>Security - 34%:</strong> suspicious code patterns, SAST rules, vulnerable libraries, obfuscation, threat-intel findings, and exploit-relevant APIs.</li>
+              <li><strong>Privacy - 33%:</strong> sensitive permissions, all-site access, cookies, history, clipboard, storage, network destinations, and data exfiltration paths.</li>
+              <li><strong>Governance - 33%:</strong> policy alignment, permission justification, disclosure accuracy, developer reputation, update risk, and audit readiness.</li>
+              <li><em>Hard gates override the weighted score to BLOCK severe findings (e.g. malware or credential capture).</em></li>
             </ul>
 
             <h2>Why this is different from a scanner score</h2>

--- a/frontend/src/pages/research/MethodologyPage.jsx
+++ b/frontend/src/pages/research/MethodologyPage.jsx
@@ -16,7 +16,7 @@ const methodologyFaqSchema = {
       "name": "How is the extension risk score calculated?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "ExtensionShield combines three pipelines: Security (40%), Privacy (35%), and Governance (25%). Security uses open-source SAST (Semgrep-based rules), Privacy analyzes data collection and tracking, and Governance covers policy alignment and developer reputation."
+        "text": "ExtensionShield combines three pipelines weighted near-equally in the smooth score: Security (34%), Privacy (33%), and Governance (33%). Security uses open-source SAST (Semgrep-based rules), Privacy analyzes data collection and tracking, and Governance covers policy alignment and developer reputation. Hard gates override the smooth score to BLOCK severe findings such as malware or credential capture."
       }
     },
     {
@@ -83,17 +83,17 @@ const MethodologyPage = () => {
             <div className="aggregate-formula">
               <div className="formula-item">
                 <span className="formula-label">Security</span>
-                <span className="formula-weight">× 40%</span>
+                <span className="formula-weight">× 34%</span>
               </div>
               <span className="formula-plus">+</span>
               <div className="formula-item">
                 <span className="formula-label">Privacy</span>
-                <span className="formula-weight">× 35%</span>
+                <span className="formula-weight">× 33%</span>
               </div>
               <span className="formula-plus">+</span>
               <div className="formula-item">
                 <span className="formula-label">Governance</span>
-                <span className="formula-weight">× 25%</span>
+                <span className="formula-weight">× 33%</span>
               </div>
             </div>
           </div>

--- a/frontend/src/services/realScanService.js
+++ b/frontend/src/services/realScanService.js
@@ -350,10 +350,13 @@ class RealScanService {
         overall_confidence: cliResults.overall_confidence,
         decision_v2: cliResults.decision_v2,
         decision_reasons_v2: cliResults.decision_reasons_v2,
+        insufficient_data: cliResults.insufficient_data,
+        decision_authority: cliResults.decision_authority,
         scoring_v2: cliResults.scoring_v2,
-        
+
         // Governance bundle - needed for factors and evidence
         governance_bundle: cliResults.governance_bundle,
+        // Authoritative final verdict (single Decision Authority)
         governance_verdict: cliResults.governance_verdict,
         
         // Preserve raw manifest and metadata for permissions
@@ -620,7 +623,13 @@ class RealScanService {
           summary: bundle.report?.decision || {},
           facts: bundle.facts || null,
           // New governance-specific fields (mapped verdict)
-          verdict: this.mapVerdict(bundle.decision?.verdict || reportData.governance_verdict),
+          // Prefer the single Decision Authority; the legacy rules-engine
+          // bundle.decision.verdict is a fallback only (must not override it).
+          verdict: this.mapVerdict(
+            bundle.decision?.final_verdict ||
+            reportData.governance_verdict ||
+            bundle.decision?.verdict
+          ),
           rationale: bundle.decision?.rationale,
           action_required: bundle.decision?.action_required,
           store_listing: bundle.store_listing,

--- a/frontend/src/utils/normalizeScanResult.test.ts
+++ b/frontend/src/utils/normalizeScanResult.test.ts
@@ -596,6 +596,72 @@ describe('normalizeScanResult', () => {
 });
 
 // =============================================================================
+// DECISION AUTHORITY CONSUMER CONSISTENCY (ADR 0001)
+// =============================================================================
+
+describe('normalizeScanResult - decision authority consistency', () => {
+  it('prefers governance_verdict over scoring_v2.decision', () => {
+    // Scoring layer says ALLOW, but the governance authority says BLOCK.
+    const raw: RawScanResult = {
+      extension_id: 'authority1',
+      governance_verdict: 'BLOCK',
+      scoring_v2: {
+        security_score: 80,
+        privacy_score: 80,
+        governance_score: 80,
+        overall_score: 80,
+        overall_confidence: 0.9,
+        decision: 'ALLOW', // scoring-layer detail only
+      },
+    };
+    const result = normalizeScanResult(raw);
+    expect(result.scores.decision).toBe('BLOCK');
+  });
+
+  it('prefers governance_bundle.decision.final_verdict over legacy bundle verdict', () => {
+    const raw: RawScanResult = {
+      extension_id: 'authority2',
+      governance_bundle: {
+        decision: { final_verdict: 'NEEDS_REVIEW', verdict: 'ALLOW' },
+      } as unknown as RawScanResult['governance_bundle'],
+      scoring_v2: { overall_score: 90, decision: 'ALLOW' },
+    };
+    const result = normalizeScanResult(raw);
+    // NEEDS_REVIEW normalizes to the 'WARN' band in the VM.
+    expect(result.scores.decision).toBe('WARN');
+  });
+
+  it('falls back to scoring_v2.decision when no governance verdict exists', () => {
+    const raw: RawScanResult = {
+      extension_id: 'authority3',
+      scoring_v2: { overall_score: 21, decision: 'BLOCK' },
+    };
+    const result = normalizeScanResult(raw);
+    expect(result.scores.decision).toBe('BLOCK');
+  });
+
+  it('surfaces insufficient_data so a low-coverage scan is not shown as confidently safe', () => {
+    const raw: RawScanResult = {
+      extension_id: 'lowcov',
+      insufficient_data: true,
+      governance_verdict: 'NEEDS_REVIEW',
+      scoring_v2: {
+        overall_score: 65,
+        overall_confidence: 0.46,
+        decision: 'NEEDS_REVIEW',
+        insufficient_data: true,
+        decision_authority: 'insufficient_data',
+      },
+    };
+    const result = normalizeScanResult(raw);
+    expect(result.scores.insufficientData).toBe(true);
+    // NEEDS_REVIEW normalizes to the 'WARN' band in the VM.
+    expect(result.scores.decision).toBe('WARN');
+    expect(result.scores.decisionAuthority).toBe('insufficient_data');
+  });
+});
+
+// =============================================================================
 // RUNTIME ASSERTIONS (can be run independently)
 // =============================================================================
 

--- a/frontend/src/utils/normalizeScanResult.ts
+++ b/frontend/src/utils/normalizeScanResult.ts
@@ -99,7 +99,7 @@ export function normalizeHighlights(raw: RawScanResult | null | undefined): Norm
 
   // If oneLiner is empty, use a placeholder based on decision
   if (!result.oneLiner) {
-    const decision = raw.scoring_v2?.decision || raw.decision_v2 || raw.governance_verdict;
+    const decision = resolveFinalVerdict(raw);
     if (decision === 'BLOCK') result.oneLiner = 'This extension was blocked by automated security checks.';
     else if (decision === 'WARN' || decision === 'NEEDS_REVIEW') result.oneLiner = 'This extension requires manual review before use.';
     else result.oneLiner = 'This extension has been analyzed for security, privacy, and compliance risks.';
@@ -117,6 +117,45 @@ export function normalizeHighlights(raw: RawScanResult | null | undefined): Norm
  */
 function safeGet<T>(value: T | undefined | null, defaultValue: T): T {
   return value !== undefined && value !== null ? value : defaultValue;
+}
+
+/**
+ * Resolve the final cross-system verdict.
+ *
+ * Precedence follows the single Decision Authority (ADR 0001): prefer
+ * governance_verdict / final_verdict, and treat scoring_v2.decision /
+ * decision_v2 as scoring-layer detail only. Never let the scoring-layer
+ * decision override the governance authority.
+ */
+function resolveFinalVerdict(
+  raw: RawScanResult,
+  scoringV2?: RawScoringV2 | null
+): string | undefined {
+  const sv2 = scoringV2 ?? raw.scoring_v2;
+  return (
+    raw.final_verdict ||
+    raw.governance_verdict ||
+    raw.governance_bundle?.decision?.final_verdict ||
+    sv2?.decision ||
+    raw.decision_v2 ||
+    undefined
+  );
+}
+
+/**
+ * Resolve whether this scan had insufficient analysis coverage. A low-coverage
+ * scan must not be shown as confidently safe.
+ */
+function resolveInsufficientData(
+  raw: RawScanResult,
+  scoringV2?: RawScoringV2 | null
+): boolean {
+  const sv2 = scoringV2 ?? raw.scoring_v2;
+  return Boolean(
+    raw.insufficient_data ||
+    sv2?.insufficient_data ||
+    raw.governance_bundle?.decision?.insufficient_data
+  );
 }
 
 /**
@@ -903,9 +942,14 @@ export function normalizeScanResult(raw: RawScanResult): ReportViewModel {
   };
   
   // Build scores
-  const decision = normalizeDecision(
-    scoringV2?.decision || raw.decision_v2 || raw.governance_verdict
-  );
+  // Final verdict prefers the governance Decision Authority over scoring-layer detail.
+  const decision = normalizeDecision(resolveFinalVerdict(raw, scoringV2));
+  const insufficientData = resolveInsufficientData(raw, scoringV2);
+  const decisionAuthority =
+    raw.decision_authority ||
+    scoringV2?.decision_authority ||
+    raw.governance_bundle?.decision?.final_authority ||
+    null;
   
   // Get scores from scoring_v2 or fallback to legacy (also support formatted camelCase)
   const securityScore = scoringV2?.security_score ?? raw.security_score ?? raw.overall_security_score ?? formatted.securityScore ?? null;
@@ -998,6 +1042,8 @@ export function normalizeScanResult(raw: RawScanResult): ReportViewModel {
     },
     decision,
     reasons: scoringV2?.decision_reasons || scoringV2?.reasons || raw.decision_reasons_v2 || [],
+    insufficientData,
+    decisionAuthority,
   };
   
   // Build factors by layer

--- a/frontend/src/utils/reportTypes.ts
+++ b/frontend/src/utils/reportTypes.ts
@@ -244,9 +244,13 @@ export interface RawScoringV2 {
   governance_score?: number;
   overall_score?: number;
   overall_confidence?: number;
+  /** Scoring-layer decision (engine scoring rungs only) — secondary/detail.
+   *  The authoritative cross-system verdict is raw.governance_verdict. */
   decision?: string; // "ALLOW" | "BLOCK" | "NEEDS_REVIEW"
   decision_reasons?: string[];
   reasons?: string[];
+  insufficient_data?: boolean;
+  decision_authority?: string;
   hard_gates_triggered?: string[];
   risk_level?: string;
   explanation?: string | {
@@ -269,6 +273,12 @@ export interface RawScoringV2 {
 
 /** Raw governance bundle decision */
 export interface RawGovernanceDecision {
+  /** Authoritative final verdict from the single Decision Authority (preferred). */
+  final_verdict?: string;
+  final_authority?: string;
+  final_reasons?: string[];
+  insufficient_data?: boolean;
+  /** Legacy rules-engine verdict — secondary/detail only; must NOT override final_verdict. */
   verdict?: string;
   rationale?: string;
   action_required?: string;
@@ -440,12 +450,17 @@ export interface RawScanResult {
   privacy_score?: number;
   governance_score?: number;
   overall_confidence?: number;
+  /** Scoring-layer decision — secondary/detail. Authoritative verdict is governance_verdict. */
   decision_v2?: string;
   decision_reasons_v2?: string[];
+  insufficient_data?: boolean;
+  decision_authority?: string;
   scoring_v2?: RawScoringV2;
 
   // Governance (Pipeline B)
+  /** Authoritative final verdict (single Decision Authority). Prefer this. */
   governance_verdict?: string;
+  final_verdict?: string;
   governance_bundle?: RawGovernanceBundle;
   governance_report?: {
     scan_id?: string;
@@ -489,8 +504,13 @@ export interface ScoresVM {
   privacy: ScoreVM;
   governance: ScoreVM;
   overall: ScoreVM;
+  /** Final cross-system verdict (prefers governance_verdict/final_verdict). */
   decision: Decision;
   reasons: string[];
+  /** True when analysis coverage was too low to clear the extension as safe. */
+  insufficientData?: boolean;
+  /** Which rung of the Decision Authority produced the verdict (detail). */
+  decisionAuthority?: string | null;
 }
 
 /** Factor view model */

--- a/src/extension_shield/api/main.py
+++ b/src/extension_shield/api/main.py
@@ -837,6 +837,8 @@ def _refresh_scan_payload_with_store_metadata(
         updated_payload["overall_confidence"] = scoring_v2.get("overall_confidence")
         updated_payload["decision_v2"] = scoring_v2.get("decision")
         updated_payload["decision_reasons_v2"] = scoring_v2.get("decision_reasons")
+        updated_payload["insufficient_data"] = scoring_v2.get("insufficient_data")
+        updated_payload["decision_authority"] = scoring_v2.get("decision_authority")
         updated_payload["overall_risk"] = scoring_v2.get(
             "risk_level",
             updated_payload.get("overall_risk", "unknown"),
@@ -1493,10 +1495,14 @@ async def run_analysis_workflow(url: str, extension_id: str):
                 "overall_confidence": scoring_result.overall_confidence,
                 "decision": scoring_result.decision.value,
                 "decision_reasons": scoring_result.reasons,
+                "insufficient_data": scoring_result.insufficient_data,
+                "decision_authority": scoring_result.decision_authority,
                 "hard_gates_triggered": scoring_result.hard_gates_triggered,
                 "risk_level": scoring_result.risk_level.value,
                 "explanation": scoring_result.explanation,
             }
+            if scoring_result.insufficient_data_reason is not None:
+                scoring_v2_payload["insufficient_data_reason"] = scoring_result.insufficient_data_reason
             if scoring_result.base_overall is not None:
                 scoring_v2_payload["base_overall"] = scoring_result.base_overall
             if scoring_result.gate_penalty is not None:
@@ -1547,6 +1553,8 @@ async def run_analysis_workflow(url: str, extension_id: str):
                 "overall_confidence": scoring_result.overall_confidence,
                 "decision_v2": scoring_result.decision.value,
                 "decision_reasons_v2": scoring_result.reasons,
+                "insufficient_data": scoring_result.insufficient_data,
+                "decision_authority": scoring_result.decision_authority,
                 # Full v2 scoring payload
                 "scoring_v2": scoring_v2_payload,
                 # Legacy helper outputs (kept for backward compatibility)

--- a/src/extension_shield/config/protected_services.yaml
+++ b/src/extension_shield/config/protected_services.yaml
@@ -1,0 +1,83 @@
+# Declarative data for protected-service (visa / travel-document) automation
+# detection. This is the SINGLE SOURCE OF TRUTH for the domain/pattern/keyword
+# lists that were previously hardcoded in scoring/gates.py and scoring/engine.py.
+#
+# Edit this file (not Python) to tune detection. It is versioned and consumed by:
+#   - governance/protected_services.py (detector + signal extraction)
+#   - scoring/gates.py                 (legacy TOS gate, re-exported for compat)
+#   - governance/rulepacks/PROTECTED_SERVICE_AUTOMATION.yaml (declarative rules)
+version: "1.0.0"
+
+# Services whose Terms of Use prohibit automated/bot access and scraping.
+# Automating a user's session on these is a compliance/ToS violation.
+protected_service_domains:
+  - usvisascheduling.com
+  - ustraveldocs.com
+  - cgi-federal.com
+  - b2clogin.com            # Azure B2C auth used by the visa portals
+
+# Known third-party visa-slot / automation ecosystem endpoints. When an
+# extension that touches a protected service also talks to one of these, it is a
+# strong signal of unauthorized third-party processing / data exfiltration.
+ecosystem_domains:
+  - checkvisaslots.com
+  - visaslots.ca
+  - easyslotbooking.com
+  - usavisaslot.com
+  - earlyvisa.co
+  - firstslotsalert.com
+  - fastervisa.co
+  - luckybee.app
+  - visaslotwatch.com
+  - slotbot.in
+  - vecnaselfie.com
+  - visaslots.info
+  - visaslots.us
+  - visajar.com
+
+# Regex patterns (case-insensitive) grouped by behavior category.
+screenshot_capture_patterns:
+  - 'html2canvas'
+  - 'toDataURL\(\s*["'']image/(png|jpeg)["'']\s*\)'
+  - 'captureVisibleTab'
+  - 'desktopCapture'
+
+xhr_interception_patterns:
+  - 'xmlhttprequest\.prototype\.(open|send)\s*='
+  - '\.open\s*=\s*function'
+  - '\.send\s*=\s*function'
+  - 'intercept.*xmlhttprequest'
+
+credential_capture_patterns:
+  - 'logindetails'
+  - 'securityquestions'
+  - 'security\s*question'
+  - '#?password'
+  - '#?signinname'
+  - 'credential'
+  - '\blogin\b'
+
+# External-exfiltration intent in code (paired with an ecosystem/external host).
+exfil_patterns:
+  - 'fetch\s*\('
+  - 'sendbeacon'
+  - 'xmlhttprequest'
+  - 'new\s+formdata'
+  - '/push/'
+
+# Sensitive identity keywords whose presence near a protected service indicates
+# collection of high-sensitivity identity data.
+identity_keywords:
+  - passport
+  - visa
+  - appointment
+  - applicant
+  - consular
+  - travel document
+
+# Indicators of anti-competitive sabotage of other extensions (deceptive behavior).
+sabotage_indicators:
+  - visajar.com
+  - visaslots.info
+  - 'remove.*extension'
+  - 'crappyextensions'

--- a/src/extension_shield/governance/context_builder.py
+++ b/src/extension_shield/governance/context_builder.py
@@ -32,6 +32,7 @@ logger = logging.getLogger(__name__)
 DEFAULT_RULEPACKS = [
     "ENTERPRISE_GOV_BASELINE",
     "CWS_LIMITED_USE",
+    "PROTECTED_SERVICE_AUTOMATION",
 ]
 
 # Supported regions

--- a/src/extension_shield/governance/protected_services.py
+++ b/src/extension_shield/governance/protected_services.py
@@ -1,0 +1,206 @@
+"""
+Protected-Service (visa / travel-document) automation detection.
+
+This module is the declarative replacement for the visa/travel-doc detection
+that was hardcoded in ``scoring/gates.py`` and ``scoring/engine.py``. The domain,
+pattern, and keyword lists live in ``config/protected_services.yaml`` (versioned,
+auditable) and are loaded here once.
+
+It exposes:
+- The raw lists (``PROTECTED_SERVICE_DOMAINS`` etc.) for the legacy gate to import,
+  so there is a single source of truth.
+- ``detect()`` which turns a SignalPack + manifest into structured, evidence-bearing
+  detections. The governance ``SignalExtractor`` uses this to emit signals that the
+  ``PROTECTED_SERVICE_AUTOMATION`` rulepack evaluates.
+
+Detection here is deterministic and side-effect free (no network, no source copy).
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from functools import lru_cache
+from pathlib import Path
+from typing import Any, Dict, List, Tuple
+
+import yaml
+
+_CONFIG_PATH = Path(__file__).parent.parent / "config" / "protected_services.yaml"
+
+
+@lru_cache(maxsize=1)
+def _load_config() -> Dict[str, Any]:
+    try:
+        with open(_CONFIG_PATH, "r", encoding="utf-8") as f:
+            data = yaml.safe_load(f) or {}
+    except FileNotFoundError:
+        data = {}
+    return data
+
+
+def _list(key: str) -> List[str]:
+    return [str(x) for x in (_load_config().get(key) or [])]
+
+
+# Public, declarative lists (single source of truth).
+DATA_VERSION: str = str(_load_config().get("version", "0"))
+PROTECTED_SERVICE_DOMAINS: Tuple[str, ...] = tuple(_list("protected_service_domains"))
+ECOSYSTEM_DOMAINS: Tuple[str, ...] = tuple(_list("ecosystem_domains"))
+IDENTITY_KEYWORDS: Tuple[str, ...] = tuple(_list("identity_keywords"))
+SABOTAGE_INDICATORS: Tuple[str, ...] = tuple(_list("sabotage_indicators"))
+
+
+def _compile(key: str) -> List[re.Pattern[str]]:
+    return [re.compile(p, re.IGNORECASE) for p in _list(key)]
+
+
+_SCREENSHOT_RX = _compile("screenshot_capture_patterns")
+_XHR_RX = _compile("xhr_interception_patterns")
+_CREDENTIAL_RX = _compile("credential_capture_patterns")
+_EXFIL_RX = _compile("exfil_patterns")
+_SABOTAGE_RX = [
+    re.compile(p, re.IGNORECASE) for p in SABOTAGE_INDICATORS if any(c in p for c in ".*\\[")
+]
+
+
+@dataclass
+class ProtectedServiceDetection:
+    """Structured result of protected-service analysis."""
+
+    protected_domain: bool = False
+    automation_capability: bool = False
+    screenshot_capture: bool = False
+    xhr_interception: bool = False
+    credential_capture: bool = False
+    external_exfil: bool = False
+    identity_keywords: bool = False
+    competitor_sabotage: bool = False
+    protected_domain_hits: List[str] = field(default_factory=list)
+    ecosystem_hits: List[str] = field(default_factory=list)
+    evidence: List[str] = field(default_factory=list)
+
+    @property
+    def is_protected_service_automation(self) -> bool:
+        """Protected service + a capability to act on / capture from it."""
+        return self.protected_domain and (
+            self.automation_capability or self.xhr_interception or self.screenshot_capture
+        )
+
+    @property
+    def any_signal(self) -> bool:
+        return any(
+            [
+                self.protected_domain,
+                self.screenshot_capture,
+                self.xhr_interception,
+                self.credential_capture,
+                self.external_exfil,
+                self.identity_keywords,
+                self.competitor_sabotage,
+            ]
+        )
+
+
+def _domains_in(text: str, domains: Tuple[str, ...]) -> List[str]:
+    low = text.lower()
+    return [d for d in domains if d in low]
+
+
+def detect(signal_pack: Any, manifest: Dict[str, Any] | None = None) -> ProtectedServiceDetection:
+    """Analyze a SignalPack (+ optional manifest) for protected-service automation.
+
+    Uses only data already on the SignalPack (permissions, SAST findings, network
+    domains) plus the manifest. No network access, no source copy.
+    """
+    manifest = manifest or {}
+    det = ProtectedServiceDetection()
+
+    perms = getattr(signal_pack, "permissions", None)
+    api_perms = list(getattr(perms, "api_permissions", []) or [])
+    host_perms = list(getattr(perms, "host_permissions", []) or [])
+    network = getattr(signal_pack, "network", None)
+    net_domains = list(getattr(network, "domains", []) or [])
+
+    # Manifest text (content_scripts matches, externally_connectable, etc.)
+    manifest_text = " ".join(
+        str(v) for v in [
+            manifest.get("host_permissions"),
+            manifest.get("content_scripts"),
+            manifest.get("externally_connectable"),
+        ] if v
+    ).lower()
+
+    # SAST findings text (descriptive; check_id + message + snippet).
+    sast = getattr(signal_pack, "sast", None)
+    findings_text_parts: List[str] = []
+    for f in getattr(sast, "deduped_findings", []) or []:
+        findings_text_parts.append(
+            f"{getattr(f, 'check_id', '')} {getattr(f, 'message', '')} "
+            f"{getattr(f, 'code_snippet', '') or ''}"
+        )
+    sast_text = "\n".join(findings_text_parts)
+
+    host_blob = " ".join(host_perms + api_perms).lower() + " " + manifest_text
+
+    # --- Protected service domains ---
+    domain_hits = list(dict.fromkeys(
+        _domains_in(host_blob, PROTECTED_SERVICE_DOMAINS)
+        + _domains_in(sast_text, PROTECTED_SERVICE_DOMAINS)
+    ))
+    if domain_hits:
+        det.protected_domain = True
+        det.protected_domain_hits = domain_hits
+        det.evidence.append(f"protected_service_domains:{','.join(domain_hits)}")
+
+    # --- Ecosystem (third-party processor) domains ---
+    eco_hits = list(dict.fromkeys(
+        _domains_in(" ".join(net_domains).lower(), ECOSYSTEM_DOMAINS)
+        + _domains_in(sast_text, ECOSYSTEM_DOMAINS)
+        + _domains_in(manifest_text, ECOSYSTEM_DOMAINS)
+    ))
+    det.ecosystem_hits = eco_hits
+
+    # --- Automation capability (inject scripts / intercept) ---
+    has_injection = (
+        any(p in api_perms for p in ("scripting", "webRequest", "webRequestBlocking", "declarativeNetRequest"))
+        or bool(manifest.get("content_scripts"))
+    )
+    if has_injection:
+        det.automation_capability = True
+        det.evidence.append("automation_capability:scripting_or_content_scripts")
+
+    # --- Pattern-based behaviors in code ---
+    if any(rx.search(sast_text) for rx in _SCREENSHOT_RX):
+        det.screenshot_capture = True
+        det.evidence.append("screenshot_capture")
+    if any(rx.search(sast_text) for rx in _XHR_RX):
+        det.xhr_interception = True
+        det.automation_capability = True
+        det.evidence.append("xhr_interception")
+    if any(rx.search(sast_text) for rx in _CREDENTIAL_RX):
+        det.credential_capture = True
+        det.evidence.append("credential_capture")
+
+    # --- External exfiltration: ecosystem endpoint OR exfil pattern + external host ---
+    has_exfil_pattern = any(rx.search(sast_text) for rx in _EXFIL_RX)
+    if eco_hits or (has_exfil_pattern and (eco_hits or net_domains)):
+        det.external_exfil = True
+        det.evidence.append("external_exfil:" + (",".join(eco_hits) if eco_hits else "exfil_pattern"))
+
+    # --- Sensitive identity keywords ---
+    if any(kw in sast_text.lower() for kw in IDENTITY_KEYWORDS) or any(
+        kw in manifest_text for kw in IDENTITY_KEYWORDS
+    ):
+        det.identity_keywords = True
+        det.evidence.append("identity_keywords")
+
+    # --- Competitor sabotage indicators ---
+    plain_indicators = [s for s in SABOTAGE_INDICATORS if not any(c in s for c in ".*\\[")]
+    if any(ind in sast_text.lower() for ind in plain_indicators) or any(
+        rx.search(sast_text) for rx in _SABOTAGE_RX
+    ):
+        det.competitor_sabotage = True
+        det.evidence.append("competitor_sabotage")
+
+    return det

--- a/src/extension_shield/governance/rulepacks/PROTECTED_SERVICE_AUTOMATION.yaml
+++ b/src/extension_shield/governance/rulepacks/PROTECTED_SERVICE_AUTOMATION.yaml
@@ -1,0 +1,99 @@
+rulepack_id: "PROTECTED_SERVICE_AUTOMATION"
+version: "1.0.0"
+name: "Protected Service Automation & Identity Exfiltration"
+description: >
+  Declarative rules detecting browser extensions that automate protected services
+  whose Terms of Use prohibit automated access (e.g. U.S. visa / travel-document
+  scheduling portals) and/or exfiltrate sensitive identity data. This rulepack
+  replaces the previously hardcoded visa/travel-doc heuristics in scoring/gates.py
+  and scoring/engine.py. Domain/pattern/keyword lists are defined declaratively in
+  config/protected_services.yaml and surfaced as signals by the SignalExtractor.
+
+rules:
+  # ==========================================================================
+  # BLOCK: automation of a protected service combined with capture/exfil
+  # ==========================================================================
+  - rule_id: "PROTECTED_SERVICE_AUTOMATION::R1"
+    name: "Protected Service Automation with Capture or Exfiltration"
+    description: >
+      Extension automates a protected service (ToS prohibits automation) AND
+      captures credentials, exfiltrates identity data, or screenshots the page.
+    condition: |
+      signals contains type="PROTECTED_SERVICE_AUTOMATION" AND
+      (signals contains type="CREDENTIAL_CAPTURE" OR
+       signals contains type="IDENTITY_DATA_EXFIL" OR
+       signals contains type="SCREENSHOT_CAPTURE")
+    verdict: "BLOCK"
+    confidence: 0.95
+    recommended_action: "Block — automates a protected portal and captures/exfiltrates sensitive data (ToS + privacy violation)"
+    citations: ["PROTECTED_SERVICE_AUTOMATION::TOS", "CWS_LIMITED_USE::SECTION_2"]
+    evidence_refs: []
+
+  # ==========================================================================
+  # BLOCK: credential / security-question capture on a protected service
+  # ==========================================================================
+  - rule_id: "PROTECTED_SERVICE_AUTOMATION::R2"
+    name: "Credential Capture on Protected Service"
+    description: >
+      Extension targets a protected service and captures or auto-fills login
+      credentials or security-question answers. Never acceptable for these portals.
+    condition: |
+      signals contains type="PROTECTED_SERVICE_DOMAIN" AND
+      signals contains type="CREDENTIAL_CAPTURE"
+    verdict: "BLOCK"
+    confidence: 0.9
+    recommended_action: "Block — captures government-portal credentials/security answers"
+    citations: ["PROTECTED_SERVICE_AUTOMATION::CREDENTIALS"]
+    evidence_refs: []
+
+  # ==========================================================================
+  # NEEDS_REVIEW: interception / capture on a protected service
+  # ==========================================================================
+  - rule_id: "PROTECTED_SERVICE_AUTOMATION::R3"
+    name: "API Interception on Protected Service"
+    description: "Extension intercepts the protected portal's own XHR/fetch API traffic."
+    condition: |
+      signals contains type="PROTECTED_SERVICE_DOMAIN" AND
+      signals contains type="XHR_INTERCEPTION"
+    verdict: "NEEDS_REVIEW"
+    confidence: 0.8
+    recommended_action: "Review — intercepts a protected portal's API responses"
+    citations: ["PROTECTED_SERVICE_AUTOMATION::INTERCEPTION"]
+    evidence_refs: []
+
+  - rule_id: "PROTECTED_SERVICE_AUTOMATION::R4"
+    name: "Screenshot Capture on Protected Service"
+    description: "Extension screenshots/rasterizes pages of a protected portal (may include identity documents)."
+    condition: |
+      signals contains type="PROTECTED_SERVICE_DOMAIN" AND
+      signals contains type="SCREENSHOT_CAPTURE"
+    verdict: "NEEDS_REVIEW"
+    confidence: 0.8
+    recommended_action: "Review — captures screenshots of a protected portal (possible passport/identity exposure)"
+    citations: ["PROTECTED_SERVICE_AUTOMATION::CAPTURE"]
+    evidence_refs: []
+
+  # ==========================================================================
+  # NEEDS_REVIEW: identity exfiltration and competitor sabotage
+  # ==========================================================================
+  - rule_id: "PROTECTED_SERVICE_AUTOMATION::R5"
+    name: "Identity Data Exfiltration to Third Party"
+    description: "Extension sends data to a known visa-slot ecosystem / external third-party endpoint."
+    condition: |
+      signals contains type="IDENTITY_DATA_EXFIL"
+    verdict: "NEEDS_REVIEW"
+    confidence: 0.75
+    recommended_action: "Review — sends data to an external third-party processor"
+    citations: ["PROTECTED_SERVICE_AUTOMATION::EXFIL", "CWS_LIMITED_USE::SECTION_4"]
+    evidence_refs: []
+
+  - rule_id: "PROTECTED_SERVICE_AUTOMATION::R6"
+    name: "Competitor Extension Sabotage"
+    description: "Extension shows indicators of deceptively sabotaging competitor extensions."
+    condition: |
+      signals contains type="COMPETITOR_SABOTAGE"
+    verdict: "NEEDS_REVIEW"
+    confidence: 0.7
+    recommended_action: "Review — deceptive manipulation of other extensions (CWS deceptive behavior policy)"
+    citations: ["PROTECTED_SERVICE_AUTOMATION::SABOTAGE"]
+    evidence_refs: []

--- a/src/extension_shield/governance/rules_engine.py
+++ b/src/extension_shield/governance/rules_engine.py
@@ -13,12 +13,69 @@ The Rules Engine is:
 import logging
 import re
 from datetime import datetime, timezone
-from typing import Dict, Any, List, Optional, Literal
+from typing import Dict, Any, List, Optional, Literal, Tuple
 from pathlib import Path
 
 from .schemas import RuleResult, RuleResults
 
 logger = logging.getLogger(__name__)
+
+VALID_VERDICTS = {"ALLOW", "BLOCK", "NEEDS_REVIEW"}
+
+
+class RuleConditionError(Exception):
+    """Raised when a rule condition cannot be parsed/evaluated.
+
+    This is distinct from a condition that legitimately evaluates to False. A
+    parse/evaluation error must fail CLOSED (NEEDS_REVIEW), never silently ALLOW.
+    """
+
+
+def validate_rulepack(rulepack: Any) -> List[str]:
+    """Validate a rulepack's structure. Returns a list of human-readable errors.
+
+    An empty list means the rulepack is structurally valid. Used to fail closed:
+    a rulepack with errors must not be silently dropped into an ALLOW.
+    """
+    errors: List[str] = []
+    if not isinstance(rulepack, dict):
+        return [f"rulepack is not a mapping (got {type(rulepack).__name__})"]
+
+    rp_id = rulepack.get("rulepack_id")
+    if not rp_id or not isinstance(rp_id, str):
+        errors.append("missing or non-string 'rulepack_id'")
+
+    rules = rulepack.get("rules")
+    if not isinstance(rules, list) or not rules:
+        errors.append(f"rulepack '{rp_id}' has no 'rules' list")
+        return errors
+
+    seen_ids = set()
+    for idx, rule in enumerate(rules):
+        where = f"rulepack '{rp_id}' rule #{idx}"
+        if not isinstance(rule, dict):
+            errors.append(f"{where}: rule is not a mapping")
+            continue
+        rid = rule.get("rule_id")
+        if not rid or not isinstance(rid, str):
+            errors.append(f"{where}: missing or non-string 'rule_id'")
+        elif rid in seen_ids:
+            errors.append(f"{where}: duplicate rule_id '{rid}'")
+        else:
+            seen_ids.add(rid)
+        cond = rule.get("condition")
+        if not cond or not isinstance(cond, str) or not cond.strip():
+            errors.append(f"{where} ('{rid}'): missing or empty 'condition'")
+        verdict = rule.get("verdict")
+        if verdict not in VALID_VERDICTS:
+            errors.append(
+                f"{where} ('{rid}'): invalid verdict {verdict!r} "
+                f"(must be one of {sorted(VALID_VERDICTS)})"
+            )
+        conf = rule.get("confidence", 0.8)
+        if not isinstance(conf, (int, float)) or not (0.0 <= float(conf) <= 1.0):
+            errors.append(f"{where} ('{rid}'): confidence {conf!r} not in [0,1]")
+    return errors
 
 
 class ConditionEvaluator:
@@ -50,11 +107,14 @@ class ConditionEvaluator:
         """
         self.context = context
         try:
-            result = self._parse_or(condition.strip())
-            return result
+            return self._parse_or(condition.strip())
+        except RuleConditionError:
+            # Propagate parse errors so the rule fails CLOSED (NEEDS_REVIEW),
+            # rather than being swallowed into a silent ALLOW.
+            raise
         except Exception as e:
             logger.error(f"Error evaluating condition '{condition}': {e}")
-            return False
+            raise RuleConditionError(str(e)) from e
     
     def _parse_or(self, expr: str) -> bool:
         """Parse OR expressions (lowest precedence)."""
@@ -111,8 +171,8 @@ class ConditionEvaluator:
         if " < " in expr:
             return self._eval_numeric_comparison(expr, "<")
         
-        logger.warning(f"Unknown comparison operator in: {expr}")
-        return False
+        # Unknown / unparseable expression: fail closed (do not silently ALLOW).
+        raise RuleConditionError(f"Unknown comparison operator in: {expr}")
     
     def _split_on_operator(self, expr: str, operator: str) -> List[str]:
         """Split expression on operator, respecting parentheses."""
@@ -339,47 +399,88 @@ class RulesEngine:
     and produces rule_results.json with ALLOW/BLOCK/NEEDS_REVIEW verdicts.
     """
     
-    def __init__(self, rulepacks: List[Dict[str, Any]]):
+    def __init__(
+        self,
+        rulepacks: List[Dict[str, Any]],
+        load_errors: Optional[List[str]] = None,
+    ):
         """
         Initialize the Rules Engine.
-        
+
         Args:
-            rulepacks: List of rulepack dictionaries loaded from YAML
+            rulepacks: List of *validated* rulepack dictionaries loaded from YAML
+            load_errors: Errors encountered while loading/validating rulepacks.
+                When non-empty the engine fails CLOSED (emits a NEEDS_REVIEW
+                synthetic result) so malformed rulepacks never silently ALLOW.
         """
         self.rulepacks = rulepacks
+        self.load_errors = list(load_errors or [])
         self.evaluator = ConditionEvaluator()
-        logger.info(f"Initialized Rules Engine with {len(rulepacks)} rulepacks")
-    
+        logger.info(
+            "Initialized Rules Engine with %d rulepacks (%d load errors)",
+            len(rulepacks),
+            len(self.load_errors),
+        )
+
     @staticmethod
-    def load_rulepacks(rulepacks_dir: str) -> List[Dict[str, Any]]:
+    def load_rulepacks_with_report(
+        rulepacks_dir: str,
+    ) -> Tuple[List[Dict[str, Any]], List[str]]:
         """
-        Load all rulepacks from a directory.
-        
-        Args:
-            rulepacks_dir: Path to directory containing rulepack YAML files
-            
+        Load and validate all rulepacks from a directory.
+
         Returns:
-            List of rulepack dictionaries
+            (valid_rulepacks, errors). A YAML parse error or a schema-validation
+            error excludes that rulepack from ``valid_rulepacks`` and records a
+            message in ``errors`` so the caller can fail closed.
         """
         import yaml
-        
-        rulepacks = []
+
+        rulepacks: List[Dict[str, Any]] = []
+        errors: List[str] = []
         dir_path = Path(rulepacks_dir)
-        
+
         if not dir_path.exists():
-            logger.warning(f"Rulepacks directory not found: {rulepacks_dir}")
-            return []
-        
-        for yaml_file in dir_path.glob("*.yaml"):
+            msg = f"Rulepacks directory not found: {rulepacks_dir}"
+            logger.warning(msg)
+            return [], [msg]
+
+        for yaml_file in sorted(dir_path.glob("*.yaml")):
             try:
                 with open(yaml_file, "r") as f:
                     rulepack = yaml.safe_load(f)
-                    if rulepack:
-                        rulepacks.append(rulepack)
-                        logger.info(f"Loaded rulepack: {rulepack.get('rulepack_id')}")
             except Exception as e:
-                logger.error(f"Error loading rulepack {yaml_file}: {e}")
-        
+                msg = f"Failed to parse rulepack {yaml_file.name}: {e}"
+                logger.error(msg)
+                errors.append(msg)
+                continue
+
+            if not rulepack:
+                msg = f"Rulepack {yaml_file.name} is empty"
+                logger.error(msg)
+                errors.append(msg)
+                continue
+
+            rp_errors = validate_rulepack(rulepack)
+            if rp_errors:
+                for err in rp_errors:
+                    msg = f"Invalid rulepack {yaml_file.name}: {err}"
+                    logger.error(msg)
+                    errors.append(msg)
+                continue
+
+            rulepacks.append(rulepack)
+            logger.info(f"Loaded rulepack: {rulepack.get('rulepack_id')}")
+
+        return rulepacks, errors
+
+    @staticmethod
+    def load_rulepacks(rulepacks_dir: str) -> List[Dict[str, Any]]:
+        """Backwards-compatible loader returning only the valid rulepacks.
+
+        Prefer :meth:`load_rulepacks_with_report` so load errors can fail closed.
+        """
+        rulepacks, _errors = RulesEngine.load_rulepacks_with_report(rulepacks_dir)
         return rulepacks
     
     def evaluate(
@@ -408,26 +509,58 @@ class RulesEngine:
         # Build evaluation context
         eval_context = self._build_eval_context(facts, signals, store_listing)
         
+        rule_results: List[RuleResult] = []
+
+        # Fail CLOSED on rulepack load/validation errors: a malformed rulepack
+        # must surface as NEEDS_REVIEW, never be silently dropped into an ALLOW.
+        for load_err in self.load_errors:
+            rule_results.append(self._fail_closed_result("__rulepack_load_error__", load_err))
+
         # Get rulepacks from context
         rulepack_ids = context.get("rulepacks", [])
         active_rulepacks = [
-            rp for rp in self.rulepacks 
+            rp for rp in self.rulepacks
             if rp.get("rulepack_id") in rulepack_ids
         ]
-        
-        if not active_rulepacks:
-            logger.warning(f"No active rulepacks found for context: {rulepack_ids}")
-        
+
+        # Requested rulepacks that could not be found also fail closed.
+        missing = [rid for rid in rulepack_ids if rid not in {rp.get("rulepack_id") for rp in self.rulepacks}]
+        for rid in missing:
+            logger.warning("Requested rulepack not available: %s", rid)
+            rule_results.append(
+                self._fail_closed_result(
+                    "__rulepack_missing__",
+                    f"Requested rulepack '{rid}' is not available; cannot evaluate its policy",
+                )
+            )
+
+        if not active_rulepacks and not missing and not self.load_errors:
+            logger.warning(f"No active rulepacks selected for context: {rulepack_ids}")
+
         # Evaluate rules
-        rule_results = []
         for rulepack in active_rulepacks:
             for rule in rulepack.get("rules", []):
                 result = self._evaluate_rule(rule, eval_context, rulepack.get("rulepack_id"))
                 rule_results.append(result)
-        
-        logger.info(f"Evaluated {len(rule_results)} rules")
-        
+
+        logger.info(f"Evaluated {len(rule_results)} rule results")
+
         return RuleResults(scan_id=scan_id, rule_results=rule_results)
+
+    @staticmethod
+    def _fail_closed_result(rule_id: str, message: str) -> RuleResult:
+        """Build a synthetic NEEDS_REVIEW result used when the engine fails closed."""
+        return RuleResult(
+            rule_id=rule_id,
+            rulepack="__engine__",
+            verdict="NEEDS_REVIEW",
+            confidence=1.0,
+            evidence_refs=[],
+            citations=[],
+            explanation=f"Fail-closed: {message}",
+            recommended_action="Manual review required (rulepack could not be evaluated)",
+            triggered_at=datetime.now(timezone.utc),
+        )
     
     def _build_eval_context(
         self,

--- a/src/extension_shield/governance/signal_extractor.py
+++ b/src/extension_shield/governance/signal_extractor.py
@@ -57,6 +57,17 @@ class SignalType:
     HIGH_ENTROPY = "HIGH_ENTROPY"
     UNREASONABLE_PERMISSIONS = "UNREASONABLE_PERMISSIONS"
 
+    # Protected-service (visa / travel-document) automation signal types.
+    # Consumed by the PROTECTED_SERVICE_AUTOMATION rulepack.
+    PROTECTED_SERVICE_DOMAIN = "PROTECTED_SERVICE_DOMAIN"
+    PROTECTED_SERVICE_AUTOMATION = "PROTECTED_SERVICE_AUTOMATION"
+    SCREENSHOT_CAPTURE = "SCREENSHOT_CAPTURE"
+    XHR_INTERCEPTION = "XHR_INTERCEPTION"
+    CREDENTIAL_CAPTURE = "CREDENTIAL_CAPTURE"
+    IDENTITY_DATA_EXFIL = "IDENTITY_DATA_EXFIL"
+    SENSITIVE_IDENTITY_KEYWORDS = "SENSITIVE_IDENTITY_KEYWORDS"
+    COMPETITOR_SABOTAGE = "COMPETITOR_SABOTAGE"
+
 
 # Sensitive Chrome APIs that warrant review
 SENSITIVE_APIS = [
@@ -405,6 +416,7 @@ class SignalExtractor:
         signals_list.extend(self._extract_permissions_signals(signal_pack))
         signals_list.extend(self._extract_webstore_signals(signal_pack))
         signals_list.extend(self._extract_chromestats_signals(signal_pack))
+        signals_list.extend(self._extract_protected_service_signals(signal_pack))
         
         # Link evidence to signals
         signals_list = self._link_evidence_to_signals(signal_pack, signals_list)
@@ -417,6 +429,64 @@ class SignalExtractor:
         
         return Signals(scan_id=signal_pack.scan_id, signals=signals_list)
     
+    def _extract_protected_service_signals(self, signal_pack: "SignalPack") -> List[Signal]:
+        """Emit protected-service (visa/travel-doc) automation signals.
+
+        Detection is delegated to ``governance.protected_services.detect`` which
+        reads the declarative config/protected_services.yaml. These signals are
+        consumed by the PROTECTED_SERVICE_AUTOMATION rulepack.
+        """
+        from extension_shield.governance.protected_services import detect
+
+        manifest = getattr(signal_pack, "manifest", None) or {}
+        det = detect(signal_pack, manifest)
+        signals: List[Signal] = []
+
+        def _add(stype: str, desc: str, severity: str, confidence: float = 0.85):
+            signals.append(Signal(
+                signal_id=self._next_signal_id(),
+                type=stype,
+                confidence=confidence,
+                evidence_refs=[],
+                description=desc,
+                severity=severity,
+            ))
+
+        if det.protected_domain:
+            _add(
+                SignalType.PROTECTED_SERVICE_DOMAIN,
+                f"Targets protected service domain(s): {', '.join(det.protected_domain_hits)}",
+                "high",
+                0.95,
+            )
+        if det.is_protected_service_automation:
+            _add(
+                SignalType.PROTECTED_SERVICE_AUTOMATION,
+                "Automates a protected service whose terms prohibit automated access",
+                "critical",
+                0.9,
+            )
+        if det.screenshot_capture:
+            _add(SignalType.SCREENSHOT_CAPTURE, "Screenshot/page capture of rendered content", "high")
+        if det.xhr_interception:
+            _add(SignalType.XHR_INTERCEPTION, "Intercepts the page's XHR/fetch API traffic", "high")
+        if det.credential_capture:
+            _add(SignalType.CREDENTIAL_CAPTURE, "Captures or auto-fills credentials/security answers", "critical", 0.9)
+        if det.external_exfil:
+            _add(
+                SignalType.IDENTITY_DATA_EXFIL,
+                "Sends data to an external/third-party endpoint: "
+                + (", ".join(det.ecosystem_hits) or "external host"),
+                "critical",
+                0.9,
+            )
+        if det.identity_keywords:
+            _add(SignalType.SENSITIVE_IDENTITY_KEYWORDS, "Handles sensitive identity data (passport/visa/appointment)", "high")
+        if det.competitor_sabotage:
+            _add(SignalType.COMPETITOR_SABOTAGE, "Indicators of sabotaging competitor extensions", "medium", 0.7)
+
+        return signals
+
     def _extract_sast_signals(self, signal_pack: "SignalPack") -> List[Signal]:
         """Extract signals from SAST findings in SignalPack."""
         signals = []

--- a/src/extension_shield/scoring/decision.py
+++ b/src/extension_shield/scoring/decision.py
@@ -1,0 +1,222 @@
+"""
+Decision Authority - THE single source of truth for the final verdict.
+
+Every consumer (scoring engine, governance node, hard-gate convenience helpers)
+must derive its verdict from :func:`resolve` so there is exactly one precedence
+chain in the system.
+
+Precedence chain (highest authority first):
+
+    1. org_block            - explicit organization blocklist            -> BLOCK
+    2. org_allow_exception  - explicit organization allow exception      -> ALLOW
+    3. baseline_governance  - baseline governance rulepack BLOCK         -> BLOCK
+    4. hard_gate            - hard security/privacy gate BLOCK           -> BLOCK
+    5. score_threshold      - score below BLOCK / REVIEW thresholds,
+                              warning gates, or baseline review rules    -> BLOCK / NEEDS_REVIEW
+    6. low_confidence       - insufficient coverage / low confidence
+                              downgrades an otherwise-ALLOW to review    -> NEEDS_REVIEW
+    7. score_pass           - everything cleared                         -> ALLOW
+
+Notes:
+- Rungs 1-2 are organization overrides. An explicit org ALLOW exception wins over
+  every automated signal below it (that is the point of an exception); an explicit
+  org BLOCK wins over everything.
+- The low-confidence / insufficient-data rung can only *downgrade* a tentative
+  ALLOW to NEEDS_REVIEW. It never upgrades a BLOCK back to ALLOW.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Iterable, List, Optional, Sequence, Set
+
+from extension_shield.scoring.models import Decision
+
+
+# =============================================================================
+# SHARED THRESHOLD POLICY  (single source of truth - P1.4)
+# =============================================================================
+
+class DecisionPolicy:
+    """Canonical decision thresholds shared by engine.py and gates.py.
+
+    There must be exactly one of these. Do not redefine thresholds elsewhere.
+    """
+
+    # Score at/below which a layer or overall score forces BLOCK.
+    BLOCK_SCORE: int = 30
+    # Score below which a layer or overall score forces NEEDS_REVIEW.
+    REVIEW_SCORE: int = 75
+    # Overall confidence below which an otherwise-ALLOW is downgraded to review.
+    LOW_CONFIDENCE: float = 0.5
+
+
+# =============================================================================
+# ORG POLICY (optional override inputs)
+# =============================================================================
+
+@dataclass(frozen=True)
+class OrgPolicy:
+    """Optional organization-level overrides.
+
+    Defaults are empty, so when no org policy is supplied the chain reduces to
+    the automated rungs (baseline governance -> hard gate -> score -> confidence).
+    """
+
+    block_ids: Set[str] = field(default_factory=set)
+    allow_ids: Set[str] = field(default_factory=set)
+
+    def is_blocked(self, extension_id: str) -> bool:
+        return bool(extension_id) and extension_id in self.block_ids
+
+    def is_allowed(self, extension_id: str) -> bool:
+        return bool(extension_id) and extension_id in self.allow_ids
+
+
+# =============================================================================
+# RESULT
+# =============================================================================
+
+@dataclass
+class FinalDecision:
+    """The single authoritative verdict plus which rung produced it."""
+
+    verdict: Decision
+    authority: str
+    reasons: List[str] = field(default_factory=list)
+    insufficient_data: bool = False
+
+
+def _gate_reasons(gates: Iterable[Any], limit: int = 2) -> List[str]:
+    """Collect human-readable reasons from gate-like objects (duck-typed)."""
+    out: List[str] = []
+    for g in gates or []:
+        reasons = getattr(g, "reasons", None) or []
+        out.extend(list(reasons)[:limit])
+    return out
+
+
+# =============================================================================
+# THE ONE PRECEDENCE CHAIN
+# =============================================================================
+
+def resolve(
+    *,
+    extension_id: str = "",
+    overall_score: int,
+    security_score: int,
+    privacy_score: int = 100,
+    governance_score: int = 100,
+    blocking_gates: Sequence[Any] = (),
+    warning_gates: Sequence[Any] = (),
+    overall_confidence: float = 1.0,
+    insufficient_data: bool = False,
+    extra_review_reasons: Optional[Sequence[str]] = None,
+    baseline_block_reasons: Optional[Sequence[str]] = None,
+    baseline_review_reasons: Optional[Sequence[str]] = None,
+    org_policy: Optional[OrgPolicy] = None,
+    policy: type[DecisionPolicy] = DecisionPolicy,
+) -> FinalDecision:
+    """Resolve the final verdict from all signals using one precedence chain.
+
+    Args:
+        extension_id: Extension ID (for org policy lookups).
+        overall_score / security_score / privacy_score / governance_score: [0-100].
+        blocking_gates / warning_gates: hard-gate results (objects with ``.reasons``).
+        overall_confidence: layer-weighted confidence [0,1].
+        insufficient_data: True when analysis coverage is too low to clear as safe.
+        extra_review_reasons: coverage-driven review reasons (e.g. SAST cap).
+        baseline_block_reasons / baseline_review_reasons: governance rulepack verdicts.
+        org_policy: optional organization overrides.
+
+    Returns:
+        FinalDecision with verdict, deciding authority, and reasons.
+    """
+    # Rung 1: explicit org BLOCK
+    if org_policy is not None and org_policy.is_blocked(extension_id):
+        return FinalDecision(
+            verdict=Decision.BLOCK,
+            authority="org_block",
+            reasons=["Organization policy blocks this extension"],
+        )
+
+    # Rung 2: explicit org ALLOW exception (overrides every automated rung below)
+    if org_policy is not None and org_policy.is_allowed(extension_id):
+        return FinalDecision(
+            verdict=Decision.ALLOW,
+            authority="org_allow_exception",
+            reasons=["Organization policy explicitly allows this extension (exception)"],
+        )
+
+    # Rung 3: baseline governance BLOCK (rulepacks)
+    if baseline_block_reasons:
+        return FinalDecision(
+            verdict=Decision.BLOCK,
+            authority="baseline_governance",
+            reasons=list(baseline_block_reasons)[:4],
+        )
+
+    # Rung 4: hard security/privacy gate BLOCK
+    if blocking_gates:
+        return FinalDecision(
+            verdict=Decision.BLOCK,
+            authority="hard_gate",
+            reasons=_gate_reasons(blocking_gates) or ["Hard security/privacy gate triggered"],
+        )
+
+    # Rung 5: scoring thresholds (BLOCK first, then accumulate review reasons)
+    if security_score < policy.BLOCK_SCORE:
+        return FinalDecision(
+            verdict=Decision.BLOCK,
+            authority="score_threshold",
+            reasons=[f"Security score {security_score}/100 critically low"],
+        )
+    if overall_score < policy.BLOCK_SCORE:
+        return FinalDecision(
+            verdict=Decision.BLOCK,
+            authority="score_threshold",
+            reasons=[f"Overall score {overall_score}/100 critically low"],
+        )
+
+    review_reasons: List[str] = []
+    review_reasons.extend(_gate_reasons(warning_gates))
+    if baseline_review_reasons:
+        review_reasons.extend(list(baseline_review_reasons))
+    if extra_review_reasons:
+        review_reasons.extend(list(extra_review_reasons))
+    if security_score < policy.REVIEW_SCORE:
+        review_reasons.append(f"Security score {security_score}/100 below threshold")
+    if overall_score < policy.REVIEW_SCORE:
+        review_reasons.append(f"Overall score {overall_score}/100 below threshold")
+
+    if review_reasons:
+        return FinalDecision(
+            verdict=Decision.NEEDS_REVIEW,
+            authority="score_threshold",
+            reasons=review_reasons,
+        )
+
+    # Rung 6: low-confidence / insufficient-data override (only downgrades ALLOW)
+    if insufficient_data:
+        return FinalDecision(
+            verdict=Decision.NEEDS_REVIEW,
+            authority="insufficient_data",
+            reasons=["Insufficient analysis coverage to clear this extension as safe"],
+            insufficient_data=True,
+        )
+    if overall_confidence < policy.LOW_CONFIDENCE:
+        return FinalDecision(
+            verdict=Decision.NEEDS_REVIEW,
+            authority="low_confidence",
+            reasons=[
+                f"Low scoring confidence ({overall_confidence:.0%}); manual review recommended"
+            ],
+            insufficient_data=True,
+        )
+
+    # Rung 7: all clear
+    return FinalDecision(
+        verdict=Decision.ALLOW,
+        authority="score_pass",
+        reasons=[f"All checks passed. Overall score: {overall_score}/100"],
+    )

--- a/src/extension_shield/scoring/engine.py
+++ b/src/extension_shield/scoring/engine.py
@@ -55,9 +55,19 @@ from extension_shield.scoring.explain import (
     FactorExplanation,
     LayerExplanation,
 )
+from extension_shield.scoring.decision import (
+    DecisionPolicy,
+    OrgPolicy,
+    resolve as resolve_decision,
+)
 
 
 logger = logging.getLogger(__name__)
+
+
+# Overall score is capped into the review band when analysis coverage is too low
+# to clear an extension as safe (no SAST / VirusTotal / network signals).
+INSUFFICIENT_DATA_SCORE_CAP = 65
 
 
 # =============================================================================
@@ -294,67 +304,103 @@ class ScoringEngine:
         # =====================================================================
         
         overall_score = overall_after_gates
-        
-        # Coverage sanity: cap overall_score when critical analyzers are missing.
-        # Missing SAST coverage must not look like a perfectly safe 100/100.
-        coverage_reasons: List[str] = []
+
+        # ---------------------------------------------------------------------
+        # Overall confidence (P1.2): layer-weighted average of layer confidences.
+        # NEVER defaults to 1.0 - empty/low-coverage scans must show low confidence.
+        # ---------------------------------------------------------------------
+        overall_confidence = round(
+            security_layer.confidence * layer_weights.get("security", 0.34)
+            + privacy_layer.confidence * layer_weights.get("privacy", 0.33)
+            + governance_layer.confidence * layer_weights.get("governance", 0.33),
+            3,
+        )
+
+        # ---------------------------------------------------------------------
+        # Coverage sanity caps
+        # ---------------------------------------------------------------------
+        extra_review_reasons: List[str] = []
         coverage_cap_applied = False
         coverage_cap_reason: Optional[str] = None
-        if sast_missing_coverage and overall_score > 80:
+
+        # Broad insufficient-data detection (P1.3): when NONE of the substantive
+        # code/threat analyzers produced coverage, manifest/permission metadata
+        # alone cannot clear an extension as safe. A zero-data extension must not
+        # look like a confident 80/100. Cap into the review band and force review.
+        sast_ran = (
+            signal_pack.sast.files_scanned > 0 or bool(signal_pack.sast.deduped_findings)
+        )
+        vt_available = (
+            signal_pack.virustotal.enabled and signal_pack.virustotal.total_engines > 0
+        )
+        network_ran = bool(getattr(signal_pack.network, "enabled", False))
+        insufficient_data = (not sast_ran) and (not vt_available) and (not network_ran)
+        insufficient_data_reason: Optional[str] = None
+
+        if insufficient_data:
+            insufficient_data_reason = (
+                "Insufficient analysis coverage (no SAST, VirusTotal, or network signals)"
+            )
+            if overall_score > INSUFFICIENT_DATA_SCORE_CAP:
+                overall_score = INSUFFICIENT_DATA_SCORE_CAP
+            extra_review_reasons.append(insufficient_data_reason)
+        elif sast_missing_coverage and overall_score > 80:
+            # SAST-only coverage gap (other analyzers present): cap at 80 + review.
             overall_score = 80
             coverage_cap_applied = True
             coverage_cap_reason = "SAST coverage missing; score capped at 80"
-            coverage_reasons.append(coverage_cap_reason)
-        
+            extra_review_reasons.append(coverage_cap_reason)
+
         logger.debug(
-            "Layer scores (after gate penalties): security=%d, privacy=%d, governance=%d, overall=%d",
+            "Layer scores (after gate penalties): security=%d, privacy=%d, "
+            "governance=%d, overall=%d, confidence=%.2f",
             security_score,
             privacy_score,
             governance_score,
             overall_score,
+            overall_confidence,
         )
-        
+
         # =====================================================================
         # STEP 5: Get gate results for decision making
         # =====================================================================
-        
+
         blocking_gates = self.gates.get_blocking_gates(gate_results)
         warning_gates = self.gates.get_warning_gates(gate_results)
-        
+
         triggered_gate_ids = [g.gate_id for g in blocking_gates + warning_gates]
-        
+
         if blocking_gates:
             logger.info(
                 "Hard gates triggered BLOCK: %s",
                 [g.gate_id for g in blocking_gates],
             )
-        
+
         # =====================================================================
-        # STEP 6: Determine final decision
+        # STEP 6: Final verdict via the single Decision Authority
+        # (scoring rungs only here; org/baseline-governance rungs are applied by
+        #  the governance node, which has rulepack results. Same precedence fn.)
         # =====================================================================
-        
-        decision, reasons = self._determine_decision(
+
+        final = resolve_decision(
+            extension_id=extension_id,
             overall_score=overall_score,
             security_score=security_score,
             privacy_score=privacy_score,
             governance_score=governance_score,
             blocking_gates=blocking_gates,
             warning_gates=warning_gates,
+            overall_confidence=overall_confidence,
+            insufficient_data=insufficient_data,
+            extra_review_reasons=extra_review_reasons,
         )
-        
-        # Apply coverage sanity: if coverage is limited and we didn't already
-        # BLOCK, ensure at least NEEDS_REVIEW and surface a clear reason.
-        if coverage_reasons:
-            for cr in coverage_reasons:
-                if cr not in reasons:
-                    reasons.append(cr)
-            if decision != Decision.BLOCK:
-                decision = Decision.NEEDS_REVIEW
-        
+        decision = final.verdict
+        reasons = list(final.reasons)
+
         # =====================================================================
         # STEP 7: Build final result
         # =====================================================================
-        
+
         result = ScoringResult(
             scan_id=scan_id,
             extension_id=extension_id,
@@ -382,6 +428,10 @@ class ScoringEngine:
             gate_reasons=gate_reasons_list or None,
             coverage_cap_applied=coverage_cap_applied,
             coverage_cap_reason=coverage_cap_reason,
+            overall_confidence=overall_confidence,
+            insufficient_data=insufficient_data,
+            insufficient_data_reason=insufficient_data_reason,
+            decision_authority=final.authority,
         )
         
         # Cache for explanation generation
@@ -703,80 +753,6 @@ class ScoringEngine:
             )
         
         return adjusted_security, adjusted_privacy, adjusted_governance
-    
-    def _determine_decision(
-        self,
-        overall_score: int,
-        security_score: int,
-        privacy_score: int,
-        governance_score: int,
-        blocking_gates: List[GateResult],
-        warning_gates: List[GateResult],
-    ) -> Tuple[Decision, List[str]]:
-        """
-        Determine final governance decision.
-        
-        Decision priority:
-        1. Any blocking gate → BLOCK
-        2. Security score < 30 → BLOCK
-        3. Overall score < 30 → BLOCK
-        4. Any warning gate → NEEDS_REVIEW
-        5. Security score < 75 → NEEDS_REVIEW
-        6. Overall score < 75 → NEEDS_REVIEW
-        7. All pass → ALLOW
-        
-        Args:
-            overall_score: Weighted overall score
-            security_score: Security layer score
-            privacy_score: Privacy layer score
-            governance_score: Governance layer score
-            blocking_gates: Gates that triggered BLOCK
-            warning_gates: Gates that triggered WARN
-            
-        Returns:
-            Tuple of (Decision, list of reasons)
-        """
-        reasons: List[str] = []
-        
-        # Priority 1: Blocking gates
-        if blocking_gates:
-            for gate in blocking_gates:
-                reasons.extend(gate.reasons[:2])
-            return Decision.BLOCK, reasons
-        
-        # Priority 2: Critical security score
-        if security_score < 30:
-            reasons.append(f"Security score {security_score}/100 critically low")
-            return Decision.BLOCK, reasons
-        
-        # Priority 3: Critical overall score
-        if overall_score < 30:
-            reasons.append(f"Overall score {overall_score}/100 critically low")
-            return Decision.BLOCK, reasons
-        
-        # Priority 4: Warning gates
-        if warning_gates:
-            for gate in warning_gates:
-                reasons.extend(gate.reasons[:2])
-            return Decision.NEEDS_REVIEW, reasons
-        
-        # Priority 5: Low security score
-        if security_score < 75:
-            reasons.append(f"Security score {security_score}/100 below threshold")
-            return Decision.NEEDS_REVIEW, reasons
-
-        # Priority 6: Low overall score
-        if overall_score < 75:
-            reasons.append(f"Overall score {overall_score}/100 below threshold")
-            if privacy_score < 75:
-                reasons.append(f"Privacy score {privacy_score}/100 contributing to low overall")
-            if governance_score < 75:
-                reasons.append(f"Governance score {governance_score}/100 contributing to low overall")
-            return Decision.NEEDS_REVIEW, reasons
-        
-        # Priority 7: All pass
-        reasons.append(f"All checks passed. Overall score: {overall_score}/100")
-        return Decision.ALLOW, reasons
     
     def _build_summary(
         self,

--- a/src/extension_shield/scoring/gates.py
+++ b/src/extension_shield/scoring/gates.py
@@ -43,33 +43,14 @@ from extension_shield.scoring.models import Decision, LayerScore
 # DOMAIN LISTS (COMPLIANCE / SITE TERMS)
 # =============================================================================
 
-# US visa scheduling ecosystem domains referenced in compliance findings.
-# These sites are known to prohibit automated access/scraping and/or
-# unauthorized third-party processing in their Terms of Use.
-TRAVEL_DOCS_PROTECTED_DOMAINS: Tuple[str, ...] = (
-    "usvisascheduling.com",
-    "ustraveldocs.com",
-    "cgi-federal.com",
-    "b2clogin.com",  # Azure B2C auth used by visa portals
-)
-
-# Known third-party visa-slot / automation ecosystem domains (non-exhaustive).
-# Used to flag potential unauthorized processors when paired with protected portals.
-VISA_SLOT_ECOSYSTEM_DOMAINS: Tuple[str, ...] = (
-    "checkvisaslots.com",
-    "visaslots.ca",
-    "easyslotbooking.com",
-    "usavisaslot.com",
-    "earlyvisa.co",
-    "firstslotsalert.com",
-    "fastervisa.co",
-    "luckybee.app",
-    "visaslotwatch.com",
-    "slotbot.in",
-    "vecnaselfie.com",
-    "visaslots.info",
-    "visaslots.us",
-    "visajar.com",
+# Protected visa/travel-doc domains now live in the declarative single source of
+# truth: config/protected_services.yaml (loaded by governance/protected_services.py).
+# They are re-exported here under the legacy names for backward compatibility so the
+# existing TOS gate keeps working unchanged while detection logic migrates to the
+# PROTECTED_SERVICE_AUTOMATION rulepack. Edit the YAML, not this file, to tune lists.
+from extension_shield.governance.protected_services import (  # noqa: E402
+    PROTECTED_SERVICE_DOMAINS as TRAVEL_DOCS_PROTECTED_DOMAINS,
+    ECOSYSTEM_DOMAINS as VISA_SLOT_ECOSYSTEM_DOMAINS,
 )
 
 
@@ -533,6 +514,12 @@ class HardGates:
 
         # ---------------------------------------------------------------------
         # Travel-docs / visa portal ToS risk (deterministic, evidence-based)
+        #
+        # DEPRECATION (backstop): this branch is superseded by the declarative
+        # PROTECTED_SERVICE_AUTOMATION rulepack. It is intentionally KEPT as a
+        # defensive backstop and will be retired only after that rulepack has
+        # proven itself across more fixtures. See docs/adr/0001-scoring-governance-
+        # decision-authority.md ("Why the hardcoded TOS gate remains").
         # ---------------------------------------------------------------------
 
         def _matches_any_domain(patterns: List[str], domains: Tuple[str, ...]) -> List[str]:
@@ -991,59 +978,38 @@ class HardGates:
     ) -> Tuple[Decision, List[str], List[str]]:
         """
         Compute final governance decision from gates and layer scores.
-        
-        Decision priority:
-        1. Any BLOCK gate → BLOCK
-        2. Layer scores below threshold → BLOCK or NEEDS_REVIEW
-        3. Any WARN gate → NEEDS_REVIEW
-        4. All pass → ALLOW
-        
+
+        This delegates to the single Decision Authority (``scoring.decision.resolve``)
+        so gate-only decisions use the exact same precedence chain and thresholds
+        (``DecisionPolicy``) as the scoring engine. Do not reintroduce separate
+        thresholds here.
+
         Args:
             gate_results: Results from evaluate_all()
             layer_scores: Optional dict of layer scores (security, privacy, governance)
-            
+
         Returns:
             Tuple of (Decision, reasons list, triggered gate IDs)
         """
+        from extension_shield.scoring.decision import resolve as resolve_decision
+
         blocking_gates = self.get_blocking_gates(gate_results)
         warning_gates = self.get_warning_gates(gate_results)
-        
-        reasons: List[str] = []
-        triggered_ids: List[str] = []
-        
-        # Priority 1: BLOCK gates
-        if blocking_gates:
-            for gate in blocking_gates:
-                triggered_ids.append(gate.gate_id)
-                reasons.extend(gate.reasons)
-            return Decision.BLOCK, reasons, triggered_ids
-        
-        # Priority 2: Check layer scores if provided
-        if layer_scores:
-            security_score = layer_scores.get("security")
-            if security_score and security_score.score < 30:
-                reasons.append(f"Security score {security_score.score}/100 below threshold")
-                return Decision.BLOCK, reasons, triggered_ids
-            
-            overall_low = False
-            for layer_name, layer in layer_scores.items():
-                if layer.score < 50:
-                    overall_low = True
-                    reasons.append(f"{layer_name.title()} score {layer.score}/100 below threshold")
-            
-            if overall_low:
-                return Decision.NEEDS_REVIEW, reasons, triggered_ids
-        
-        # Priority 3: WARN gates
-        if warning_gates:
-            for gate in warning_gates:
-                triggered_ids.append(gate.gate_id)
-                reasons.extend(gate.reasons)
-            return Decision.NEEDS_REVIEW, reasons, triggered_ids
-        
-        # Priority 4: All pass
-        reasons.append("All gates passed, no significant issues detected")
-        return Decision.ALLOW, reasons, triggered_ids
+        triggered_ids = [g.gate_id for g in blocking_gates + warning_gates]
+
+        def _score(name: str, default: int) -> int:
+            layer = (layer_scores or {}).get(name)
+            return layer.score if layer is not None else default
+
+        final = resolve_decision(
+            overall_score=_score("overall", _score("security", 100)),
+            security_score=_score("security", 100),
+            privacy_score=_score("privacy", 100),
+            governance_score=_score("governance", 100),
+            blocking_gates=blocking_gates,
+            warning_gates=warning_gates,
+        )
+        return final.verdict, final.reasons, triggered_ids
 
 
 # =============================================================================

--- a/src/extension_shield/scoring/models.py
+++ b/src/extension_shield/scoring/models.py
@@ -520,6 +520,12 @@ class ScoringResult(BaseModel):
             "is_blocked": self.is_blocked,
             "needs_review": self.needs_review,
             "reasons": self.reasons,
+            # Audit fields preserved so rebuild/upgrade paths stay consistent
+            # with freshly-scanned payloads (see ADR 0001).
+            "decision_reasons": self.reasons,
+            "overall_confidence": self.overall_confidence,
+            "insufficient_data": self.insufficient_data,
+            "decision_authority": self.decision_authority,
             "explanation": self.explanation,
             "hard_gates_triggered": self.hard_gates_triggered,
             "security_layer": self.security_layer.model_dump_for_api() if self.security_layer else None,
@@ -538,5 +544,7 @@ class ScoringResult(BaseModel):
             out["coverage_cap_applied"] = self.coverage_cap_applied
         if self.coverage_cap_reason is not None:
             out["coverage_cap_reason"] = self.coverage_cap_reason
+        if self.insufficient_data_reason is not None:
+            out["insufficient_data_reason"] = self.insufficient_data_reason
         return out
 

--- a/src/extension_shield/scoring/models.py
+++ b/src/extension_shield/scoring/models.py
@@ -333,7 +333,8 @@ class ScoringResult(BaseModel):
         default=None,
         ge=0,
         le=100,
-        description="Weighted layer sum before gate penalties (sec*0.5 + priv*0.3 + gov*0.2)"
+        description="Weighted layer sum before gate penalties using LAYER_WEIGHTS "
+                    "(sec*0.34 + priv*0.33 + gov*0.33)"
     )
     gate_penalty: Optional[int] = Field(
         default=None,
@@ -351,6 +352,18 @@ class ScoringResult(BaseModel):
     coverage_cap_reason: Optional[str] = Field(
         default=None,
         description="Reason for coverage cap when coverage_cap_applied is True"
+    )
+    insufficient_data: bool = Field(
+        default=False,
+        description="True when analysis coverage is too low to clear the extension as safe"
+    )
+    insufficient_data_reason: Optional[str] = Field(
+        default=None,
+        description="Reason coverage was deemed insufficient (e.g. no SAST/VT/network signals)"
+    )
+    decision_authority: Optional[str] = Field(
+        default=None,
+        description="Which rung of the decision authority produced the verdict (see scoring.decision)"
     )
 
     @computed_field
@@ -387,9 +400,9 @@ class ScoringResult(BaseModel):
         """
         Assemble a ScoringResult from pre-computed layers and a decision.
 
-        Decision logic is centralized in ``ScoringEngine._determine_decision``;
-        this method only aggregates layer scores and attaches the decision that
-        was already computed by the engine.
+        Decision logic is centralized in ``scoring.decision.resolve`` (the single
+        Decision Authority); this method only aggregates layer scores and attaches
+        the decision that was already computed by the engine.
 
         Args:
             scan_id: Unique scan identifier
@@ -407,9 +420,10 @@ class ScoringResult(BaseModel):
         """
         hard_gates = hard_gates_triggered or []
 
-        sec_weight = layer_weights.get("security", 0.5)
-        priv_weight = layer_weights.get("privacy", 0.3)
-        gov_weight = layer_weights.get("governance", 0.2)
+        # Defaults must match weights.LAYER_WEIGHTS (single source of truth).
+        sec_weight = layer_weights.get("security", 0.34)
+        priv_weight = layer_weights.get("privacy", 0.33)
+        gov_weight = layer_weights.get("governance", 0.33)
 
         overall_score = int(
             security_layer.score * sec_weight +

--- a/src/extension_shield/workflow/governance_nodes.py
+++ b/src/extension_shield/workflow/governance_nodes.py
@@ -38,6 +38,7 @@ from extension_shield.governance import (
     GovernanceScorecard,
 )
 from extension_shield.scoring.engine import ScoringEngine
+from extension_shield.scoring.decision import OrgPolicy, resolve as resolve_decision
 from extension_shield.workflow.node_types import CLEANUP_NODE
 
 
@@ -288,8 +289,10 @@ def governance_node(state: dict) -> Command:
         # Stage 7: Run Rules Engine
         logger.info("Stage 7: Evaluating rules...")
         rulepacks_dir = Path(__file__).parent.parent / "governance" / "rulepacks"
-        rulepacks = RulesEngine.load_rulepacks(str(rulepacks_dir))
-        rules_engine = RulesEngine(rulepacks)
+        rulepacks, rulepack_load_errors = RulesEngine.load_rulepacks_with_report(str(rulepacks_dir))
+        if rulepack_load_errors:
+            logger.warning("Rulepack load errors (failing closed): %s", rulepack_load_errors)
+        rules_engine = RulesEngine(rulepacks, load_errors=rulepack_load_errors)
         
         rule_results = rules_engine.evaluate(
             scan_id=scan_id,
@@ -320,7 +323,59 @@ def governance_node(state: dict) -> Command:
             report.rules_triggered,
             report.total_rules_evaluated,
         )
-        
+
+        # =====================================================================
+        # SINGLE DECISION AUTHORITY (final verdict)
+        # =====================================================================
+        # One precedence chain reconciles org policy + baseline governance rules
+        # + hard gates + scores + confidence. This is THE final verdict; the
+        # rules-engine report and scoring decision are retained as detail/audit.
+        gate_results = scoring_v2_gate_results or []
+        blocking_gates = [g for g in gate_results if g.triggered and g.decision == "BLOCK"]
+        warning_gates = [g for g in gate_results if g.triggered and g.decision == "WARN"]
+
+        baseline_block_reasons = [
+            (r.recommended_action or r.explanation)
+            for r in rule_results.rule_results
+            if r.verdict == "BLOCK"
+        ]
+        baseline_review_reasons = [
+            (r.recommended_action or r.explanation)
+            for r in rule_results.rule_results
+            if r.verdict == "NEEDS_REVIEW"
+        ]
+
+        org_cfg = state.get("org_policy") or {}
+        org_policy = (
+            OrgPolicy(
+                block_ids=set(org_cfg.get("block_ids", []) or []),
+                allow_ids=set(org_cfg.get("allow_ids", []) or []),
+            )
+            if org_cfg
+            else None
+        )
+
+        final_decision = resolve_decision(
+            extension_id=scoring_result.extension_id or "",
+            overall_score=scoring_result.overall_score,
+            security_score=scoring_result.security_score,
+            privacy_score=scoring_result.privacy_score,
+            governance_score=scoring_result.governance_score,
+            blocking_gates=blocking_gates,
+            warning_gates=warning_gates,
+            overall_confidence=scoring_result.overall_confidence,
+            insufficient_data=bool(getattr(scoring_result, "insufficient_data", False)),
+            baseline_block_reasons=baseline_block_reasons,
+            baseline_review_reasons=baseline_review_reasons,
+            org_policy=org_policy,
+        )
+        final_verdict = final_decision.verdict.value
+        logger.info(
+            "Final verdict (authority=%s): %s",
+            final_decision.authority,
+            final_verdict,
+        )
+
         # Compile governance bundle (includes Layer 0 SignalPack + Layer 1 Scorecards)
         governance_bundle = {
             # Layer 0: Signal Pack (new 3-layer architecture)
@@ -374,7 +429,12 @@ def governance_node(state: dict) -> Command:
             "report": report_dict,
             # Decision (combines rules engine + governance scorecard)
             "decision": {
-                # From rules engine
+                # FINAL verdict from the single Decision Authority (authoritative)
+                "final_verdict": final_verdict,
+                "final_authority": final_decision.authority,
+                "final_reasons": final_decision.reasons,
+                "insufficient_data": final_decision.insufficient_data,
+                # From rules engine (detail/audit)
                 "verdict": report.decision.verdict,
                 "rationale": report.decision.rationale,
                 "action_required": report.decision.action_required,
@@ -400,7 +460,7 @@ def governance_node(state: dict) -> Command:
             goto=CLEANUP_NODE,
             update={
                 "governance_bundle": governance_bundle,
-                "governance_verdict": report.decision.verdict,
+                "governance_verdict": final_verdict,
                 "governance_report": report_dict,
             },
         )

--- a/tests/governance/test_protected_service_rulepack.py
+++ b/tests/governance/test_protected_service_rulepack.py
@@ -1,0 +1,134 @@
+"""
+Tests for the declarative PROTECTED_SERVICE_AUTOMATION rulepack (P3).
+
+Verifies that the visa/travel-doc detection migrated from hardcoded
+gates.py/engine.py logic into config/protected_services.yaml +
+governance/protected_services.py + the rulepack still BLOCKs CheckVisaSlots,
+end to end through the SignalExtractor and RulesEngine.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from extension_shield.governance.protected_services import (
+    ECOSYSTEM_DOMAINS,
+    PROTECTED_SERVICE_DOMAINS,
+    detect,
+)
+from extension_shield.governance.rules_engine import RulesEngine
+from extension_shield.governance.signal_extractor import SignalExtractor, SignalType
+from extension_shield.governance.signal_pack import (
+    NetworkSignalPack,
+    PermissionsSignalPack,
+    SastFindingNormalized,
+    SastSignalPack,
+    SignalPack,
+    WebstoreStatsSignalPack,
+)
+
+RULEPACKS_DIR = (
+    Path(__file__).parent.parent.parent
+    / "src" / "extension_shield" / "governance" / "rulepacks"
+)
+
+
+def _checkvisaslots_pack() -> SignalPack:
+    """Synthetic CheckVisaSlots pack (no real data) - mirrors P2 fixture."""
+    findings = [
+        SastFindingNormalized(
+            check_id="credential-autofill", file_path="js/content.js", severity="HIGH",
+            message="Writes username/password into #signInName and #password (loginDetails)",
+            code_snippet="document.querySelector('#password').value = loginDetails.password",
+        ),
+        SastFindingNormalized(
+            check_id="security-question-autofill", file_path="js/content.js", severity="HIGH",
+            message="auto-fills security questions during login",
+        ),
+        SastFindingNormalized(
+            check_id="screenshot-capture", file_path="js/content.js", severity="HIGH",
+            message="html2canvas appointment page export",
+            code_snippet="html2canvas(el).then(c => c.toDataURL('image/png'))",
+        ),
+        SastFindingNormalized(
+            check_id="xhr-interception", file_path="js/page.js", severity="HIGH",
+            message="overrides portal API", code_snippet="XMLHttpRequest.prototype.send = function(){}",
+        ),
+        SastFindingNormalized(
+            check_id="external-exfil", file_path="js/sw.js", severity="HIGH",
+            message="fetch sends appointment/identity data to third party",
+            code_snippet="fetch('https://app.checkvisaslots.com/push/v5')",
+        ),
+    ]
+    return SignalPack(
+        scan_id="cvs", extension_id="beepaenfejnphdgnkmccjcfiieihhogl",
+        sast=SastSignalPack(deduped_findings=findings, files_scanned=8, confidence=0.9),
+        permissions=PermissionsSignalPack(
+            api_permissions=["storage", "activeTab", "scripting"],
+            host_permissions=["https://*.usvisascheduling.com/*"],
+            total_permissions=4,
+        ),
+        network=NetworkSignalPack(enabled=True, domains=["app.checkvisaslots.com"], confidence=0.8),
+        webstore_stats=WebstoreStatsSignalPack(has_privacy_policy=False),
+    )
+
+
+class TestDeclarativeSingleSource:
+    def test_gates_reuse_declarative_domains(self):
+        """The legacy gate names must point at the declarative single source."""
+        from extension_shield.scoring import gates
+
+        assert gates.TRAVEL_DOCS_PROTECTED_DOMAINS == PROTECTED_SERVICE_DOMAINS
+        assert gates.VISA_SLOT_ECOSYSTEM_DOMAINS == ECOSYSTEM_DOMAINS
+        assert "usvisascheduling.com" in PROTECTED_SERVICE_DOMAINS
+        assert "checkvisaslots.com" in ECOSYSTEM_DOMAINS
+
+
+class TestDetector:
+    def test_detects_all_categories(self):
+        det = detect(_checkvisaslots_pack(), manifest={})
+        assert det.protected_domain
+        assert det.is_protected_service_automation
+        assert det.screenshot_capture
+        assert det.xhr_interception
+        assert det.credential_capture
+        assert det.external_exfil
+        assert det.identity_keywords
+
+
+class TestSignalEmission:
+    def test_emits_protected_service_signals(self):
+        signals = SignalExtractor().extract_from_signal_pack(_checkvisaslots_pack())
+        types = {s.type for s in signals.signals}
+        assert SignalType.PROTECTED_SERVICE_AUTOMATION in types
+        assert SignalType.CREDENTIAL_CAPTURE in types
+        assert SignalType.IDENTITY_DATA_EXFIL in types
+        assert SignalType.SCREENSHOT_CAPTURE in types
+
+
+class TestRulepackBlocks:
+    def test_rulepack_blocks_checkvisaslots(self):
+        rulepacks, errors = RulesEngine.load_rulepacks_with_report(str(RULEPACKS_DIR))
+        assert not errors, f"rulepacks failed validation: {errors}"
+
+        signals = SignalExtractor().extract_from_signal_pack(_checkvisaslots_pack())
+        engine = RulesEngine(rulepacks)
+        results = engine.evaluate(
+            scan_id="cvs",
+            facts={},
+            signals=[s.model_dump(mode="json") for s in signals.signals],
+            store_listing={},
+            context={"rulepacks": ["PROTECTED_SERVICE_AUTOMATION"]},
+        )
+        verdicts = [r.verdict for r in results.rule_results]
+        assert "BLOCK" in verdicts, f"expected BLOCK, got {verdicts}"
+        # The two BLOCK rules (R1 automation+capture, R2 credential capture) must fire.
+        blocked_ids = {r.rule_id for r in results.rule_results if r.verdict == "BLOCK"}
+        assert "PROTECTED_SERVICE_AUTOMATION::R1" in blocked_ids
+        assert "PROTECTED_SERVICE_AUTOMATION::R2" in blocked_ids
+
+    def test_new_rulepack_is_valid_and_loaded(self):
+        rulepacks, errors = RulesEngine.load_rulepacks_with_report(str(RULEPACKS_DIR))
+        ids = {rp.get("rulepack_id") for rp in rulepacks}
+        assert "PROTECTED_SERVICE_AUTOMATION" in ids
+        assert errors == []

--- a/tests/governance/test_rules_engine_failclosed.py
+++ b/tests/governance/test_rules_engine_failclosed.py
@@ -1,0 +1,171 @@
+"""
+Tests for rules-engine fail-closed behavior and rulepack validation (P1.6).
+
+A malformed rule or rulepack must NEVER silently ALLOW; it must surface as
+NEEDS_REVIEW.
+"""
+
+import textwrap
+
+import pytest
+
+from extension_shield.governance.rules_engine import (
+    ConditionEvaluator,
+    RuleConditionError,
+    RulesEngine,
+    validate_rulepack,
+)
+
+
+# =============================================================================
+# Rulepack schema validation
+# =============================================================================
+
+class TestValidateRulepack:
+    def _valid_rule(self, **over):
+        rule = {
+            "rule_id": "RP::R1",
+            "condition": "manifest.permissions contains \"tabs\"",
+            "verdict": "BLOCK",
+            "confidence": 0.9,
+        }
+        rule.update(over)
+        return rule
+
+    def test_valid_rulepack_has_no_errors(self):
+        rp = {"rulepack_id": "RP", "rules": [self._valid_rule()]}
+        assert validate_rulepack(rp) == []
+
+    def test_missing_rulepack_id(self):
+        rp = {"rules": [self._valid_rule()]}
+        assert any("rulepack_id" in e for e in validate_rulepack(rp))
+
+    def test_no_rules(self):
+        rp = {"rulepack_id": "RP", "rules": []}
+        assert any("rules" in e for e in validate_rulepack(rp))
+
+    def test_invalid_verdict(self):
+        rp = {"rulepack_id": "RP", "rules": [self._valid_rule(verdict="NUKE")]}
+        assert any("invalid verdict" in e for e in validate_rulepack(rp))
+
+    def test_empty_condition(self):
+        rp = {"rulepack_id": "RP", "rules": [self._valid_rule(condition="   ")]}
+        assert any("condition" in e for e in validate_rulepack(rp))
+
+    def test_duplicate_rule_id(self):
+        rp = {"rulepack_id": "RP", "rules": [self._valid_rule(), self._valid_rule()]}
+        assert any("duplicate" in e for e in validate_rulepack(rp))
+
+    def test_confidence_out_of_range(self):
+        rp = {"rulepack_id": "RP", "rules": [self._valid_rule(confidence=5)]}
+        assert any("confidence" in e for e in validate_rulepack(rp))
+
+
+# =============================================================================
+# Condition evaluation fails closed
+# =============================================================================
+
+class TestConditionFailsClosed:
+    def test_unknown_operator_raises(self):
+        ev = ConditionEvaluator()
+        with pytest.raises(RuleConditionError):
+            ev.evaluate("facts.foo WAT 'bar'", {"facts": {"foo": "bar"}})
+
+    def test_valid_false_condition_returns_false_not_error(self):
+        ev = ConditionEvaluator()
+        # Legitimately false (missing key) must NOT raise.
+        assert ev.evaluate('manifest.permissions contains "tabs"', {"manifest": {}}) is False
+
+    def test_malformed_block_rule_becomes_needs_review(self):
+        """A BLOCK rule whose condition cannot be parsed must NOT ALLOW."""
+        rulepack = {
+            "rulepack_id": "RP",
+            "rules": [
+                {
+                    "rule_id": "RP::BROKEN",
+                    "condition": "facts.x TOTALLY INVALID syntax here",
+                    "verdict": "BLOCK",
+                    "confidence": 0.9,
+                }
+            ],
+        }
+        engine = RulesEngine([rulepack])
+        results = engine.evaluate(
+            scan_id="s1",
+            facts={},
+            signals=[],
+            store_listing={},
+            context={"rulepacks": ["RP"]},
+        )
+        verdicts = {r.verdict for r in results.rule_results}
+        assert "ALLOW" not in verdicts
+        assert "NEEDS_REVIEW" in verdicts
+
+
+# =============================================================================
+# Loader + engine fail closed
+# =============================================================================
+
+class TestLoaderFailsClosed:
+    def test_malformed_yaml_reported_as_error(self, tmp_path):
+        (tmp_path / "broken.yaml").write_text("rulepack_id: RP\nrules: [unclosed")
+        rulepacks, errors = RulesEngine.load_rulepacks_with_report(str(tmp_path))
+        assert rulepacks == []
+        assert errors and any("broken.yaml" in e for e in errors)
+
+    def test_schema_invalid_rulepack_reported(self, tmp_path):
+        (tmp_path / "bad.yaml").write_text(
+            textwrap.dedent(
+                """
+                rulepack_id: BAD
+                rules:
+                  - rule_id: BAD::R1
+                    condition: ""
+                    verdict: NOPE
+                """
+            )
+        )
+        rulepacks, errors = RulesEngine.load_rulepacks_with_report(str(tmp_path))
+        assert rulepacks == []
+        assert errors
+
+    def test_load_errors_force_needs_review(self):
+        engine = RulesEngine([], load_errors=["could not parse pack X"])
+        results = engine.evaluate(
+            scan_id="s1", facts={}, signals=[], store_listing={}, context={"rulepacks": []}
+        )
+        assert any(r.verdict == "NEEDS_REVIEW" for r in results.rule_results)
+
+    def test_missing_requested_rulepack_fails_closed(self):
+        engine = RulesEngine([])  # no rulepacks loaded
+        results = engine.evaluate(
+            scan_id="s1",
+            facts={},
+            signals=[],
+            store_listing={},
+            context={"rulepacks": ["ENTERPRISE_GOV_BASELINE"]},
+        )
+        assert any(r.verdict == "NEEDS_REVIEW" for r in results.rule_results)
+
+    def test_valid_block_rule_still_blocks(self):
+        """Hardening must not weaken a legitimately-matching BLOCK rule."""
+        rulepack = {
+            "rulepack_id": "RP",
+            "rules": [
+                {
+                    "rule_id": "RP::MAL",
+                    "condition": "facts.security_findings.virustotal_malicious_count > 2",
+                    "verdict": "BLOCK",
+                    "confidence": 0.95,
+                }
+            ],
+        }
+        engine = RulesEngine([rulepack])
+        results = engine.evaluate(
+            scan_id="s1",
+            facts={"security_findings": {"virustotal_malicious_count": 9}},
+            signals=[],
+            store_listing={},
+            context={"rulepacks": ["RP"]},
+        )
+        assert any(r.verdict == "BLOCK" for r in results.rule_results)

--- a/tests/scoring/test_checkvisaslots_block.py
+++ b/tests/scoring/test_checkvisaslots_block.py
@@ -1,0 +1,169 @@
+"""
+Golden regression fixture: CheckVisaSlots v4.7.1 must reach BLOCK.
+
+This pins the BLOCK outcome (and the three driving detections) for a real-world
+malicious pattern: a Chrome extension that automates the U.S. visa-scheduling
+portal and exfiltrates sensitive identity data.
+
+SAFETY / DETERMINISM:
+- The signal pack below is fully SYNTHETIC. It mirrors the *shape* of the public
+  CheckVisaSlots manifest and the *categories* of behavior found by static review.
+- No live portal calls, no real credentials, no real user data, no network access.
+- SAST "findings" are descriptive placeholders, not copied source.
+
+Asserted detections (name-tolerant so this survives the P3 rulepack rename):
+- automation / terms-of-service:  TOS_VIOLATION  (a.k.a. PROTECTED_SERVICE_AUTOMATION)
+- purpose mismatch:               PURPOSE_MISMATCH
+- sensitive identity exfiltration: SENSITIVE_EXFIL (a.k.a. SENSITIVE_IDENTITY_EXFIL)
+"""
+
+import pytest
+
+from extension_shield.governance.signal_pack import (
+    NetworkSignalPack,
+    PermissionsSignalPack,
+    SastFindingNormalized,
+    SastSignalPack,
+    SignalPack,
+    WebstoreStatsSignalPack,
+)
+from extension_shield.scoring.engine import ScoringEngine
+from extension_shield.scoring.gates import HardGates
+from extension_shield.scoring.models import Decision
+
+# Name aliases bridging current gate IDs to the audit's target names.
+AUTOMATION_GATES = {"TOS_VIOLATION", "PROTECTED_SERVICE_AUTOMATION"}
+PURPOSE_GATES = {"PURPOSE_MISMATCH"}
+EXFIL_GATES = {"SENSITIVE_EXFIL", "SENSITIVE_IDENTITY_EXFIL"}
+
+CHECKVISASLOTS_EXTENSION_ID = "beepaenfejnphdgnkmccjcfiieihhogl"
+
+
+def _checkvisaslots_manifest() -> dict:
+    """Public manifest shape (no secrets) for CheckVisaSlots v4.7.1."""
+    return {
+        "name": "Check US Visa Slots - USVisaScheduling",
+        "description": "Check & share the US visa slots availability.",
+        "manifest_version": 3,
+        "version": "4.7.1",
+        "permissions": ["storage", "activeTab", "scripting"],
+        "host_permissions": ["https://*.usvisascheduling.com/*"],
+        "content_scripts": [
+            {
+                "js": ["js/html2canvas.js", "js/content.js"],
+                "matches": [
+                    "https://*.usvisascheduling.com/*/*",
+                    "https://atlasauth.b2clogin.com/*",
+                ],
+            }
+        ],
+        "externally_connectable": {"matches": ["https://*.checkvisaslots.com/*"]},
+    }
+
+
+def _checkvisaslots_signal_pack() -> SignalPack:
+    """Synthetic signal pack mirroring CheckVisaSlots behavior categories."""
+    # Descriptive (non-source) SAST findings for each observed behavior category.
+    findings = [
+        SastFindingNormalized(
+            check_id="credential-autofill",
+            file_path="js/content.js",
+            line_number=1,
+            severity="HIGH",
+            message="Writes stored username/password into login form fields on the auth page",
+            code_snippet="loginDetails: fills #signInName and #password on b2clogin login",
+        ),
+        SastFindingNormalized(
+            check_id="security-question-autofill",
+            file_path="js/content.js",
+            line_number=2,
+            severity="HIGH",
+            message="Auto-fills security question answers during login",
+            code_snippet="securityQuestions auto-fill then click continue",
+        ),
+        SastFindingNormalized(
+            check_id="screenshot-capture",
+            file_path="js/content.js",
+            line_number=3,
+            severity="HIGH",
+            message="html2canvas screenshot of appointment page, exported via toDataURL",
+            code_snippet="html2canvas(...).then(c => c.toDataURL('image/png'))",
+        ),
+        SastFindingNormalized(
+            check_id="xhr-interception",
+            file_path="js/page.js",
+            line_number=4,
+            severity="HIGH",
+            message="Overrides XMLHttpRequest.prototype.open/send to intercept portal API",
+            code_snippet="XMLHttpRequest.prototype.send = function(...)",
+        ),
+        SastFindingNormalized(
+            check_id="external-exfil-fetch",
+            file_path="js/sw.js",
+            line_number=5,
+            severity="HIGH",
+            message="fetch() sends identity/appointment data to an external third-party endpoint",
+            code_snippet="fetch('https://app.checkvisaslots.com/push/v5', {body: form})",
+        ),
+    ]
+
+    pack = SignalPack(
+        scan_id="checkvisaslots-v4-7-1",
+        extension_id=CHECKVISASLOTS_EXTENSION_ID,
+        sast=SastSignalPack(deduped_findings=findings, files_scanned=8, confidence=0.9),
+        permissions=PermissionsSignalPack(
+            api_permissions=["storage", "activeTab", "scripting"],
+            host_permissions=["https://*.usvisascheduling.com/*"],
+            has_broad_host_access=False,
+            total_permissions=4,
+        ),
+        network=NetworkSignalPack(
+            enabled=True,
+            domains=["app.checkvisaslots.com"],
+            suspicious_flags={"credential_exfil_pattern": True, "data_harvest_pattern": True},
+            confidence=0.8,
+        ),
+        # No privacy policy is part of why SENSITIVE_EXFIL fires.
+        webstore_stats=WebstoreStatsSignalPack(
+            installs=200000, rating_avg=4.5, has_privacy_policy=False
+        ),
+    )
+    return pack
+
+
+@pytest.fixture(scope="module")
+def gate_results():
+    pack = _checkvisaslots_signal_pack()
+    return HardGates().evaluate_all(pack, _checkvisaslots_manifest())
+
+
+def _triggered(gate_results, ids: set) -> bool:
+    return any(g.triggered and g.gate_id in ids for g in gate_results)
+
+
+class TestCheckVisaSlotsBlock:
+    def test_overall_verdict_is_block(self):
+        pack = _checkvisaslots_signal_pack()
+        result = ScoringEngine().calculate_scores(pack, _checkvisaslots_manifest())
+        assert result.decision == Decision.BLOCK
+        # Not flagged as insufficient data - we have real coverage here.
+        assert result.insufficient_data is False
+
+    def test_automation_tos_gate_blocks(self, gate_results):
+        assert _triggered(gate_results, AUTOMATION_GATES)
+        gate = next(g for g in gate_results if g.gate_id in AUTOMATION_GATES and g.triggered)
+        assert gate.decision == "BLOCK"
+
+    def test_purpose_mismatch_gate_triggers(self, gate_results):
+        assert _triggered(gate_results, PURPOSE_GATES)
+
+    def test_sensitive_identity_exfil_gate_triggers(self, gate_results):
+        assert _triggered(gate_results, EXFIL_GATES)
+
+    def test_all_three_required_detections_present(self):
+        pack = _checkvisaslots_signal_pack()
+        result = ScoringEngine().calculate_scores(pack, _checkvisaslots_manifest())
+        triggered = set(result.hard_gates_triggered)
+        assert triggered & AUTOMATION_GATES, f"missing automation/TOS gate in {triggered}"
+        assert triggered & PURPOSE_GATES, f"missing purpose-mismatch gate in {triggered}"
+        assert triggered & EXFIL_GATES, f"missing sensitive-exfil gate in {triggered}"

--- a/tests/scoring/test_decision_authority.py
+++ b/tests/scoring/test_decision_authority.py
@@ -1,0 +1,176 @@
+"""
+Tests for the single Decision Authority (scoring.decision.resolve) and its
+integration with the scoring engine.
+
+Covers audit fixes:
+- P1.1 one precedence chain
+- P1.2 overall_confidence never defaults to 1.0
+- P1.3 insufficient-data behavior
+- P1.4 single threshold policy (DecisionPolicy)
+"""
+
+import pytest
+
+from extension_shield.governance.signal_pack import (
+    SastSignalPack,
+    SignalPack,
+    VirusTotalSignalPack,
+)
+from extension_shield.scoring.decision import (
+    DecisionPolicy,
+    FinalDecision,
+    OrgPolicy,
+    resolve,
+)
+from extension_shield.scoring.engine import ScoringEngine
+from extension_shield.scoring.models import Decision
+
+
+class _Gate:
+    """Minimal gate-like object with reasons (duck-typed)."""
+
+    def __init__(self, *reasons):
+        self.reasons = list(reasons)
+
+
+# =============================================================================
+# Precedence chain (unit) - P1.1 / P1.4
+# =============================================================================
+
+class TestPrecedenceChain:
+    EXT = "abcdefghijklmnopqrstuvwxyzabcdef"
+
+    def _clean_kwargs(self):
+        return dict(
+            extension_id=self.EXT,
+            overall_score=95,
+            security_score=95,
+            privacy_score=95,
+            governance_score=95,
+            overall_confidence=0.9,
+        )
+
+    def test_org_block_wins_over_everything(self):
+        final = resolve(
+            **{**self._clean_kwargs()},
+            blocking_gates=[],
+            org_policy=OrgPolicy(block_ids={self.EXT}),
+        )
+        assert final.verdict == Decision.BLOCK
+        assert final.authority == "org_block"
+
+    def test_org_allow_exception_overrides_gates_and_scores(self):
+        # Even with a blocking gate and a bad score, an explicit org allow wins.
+        final = resolve(
+            extension_id=self.EXT,
+            overall_score=10,
+            security_score=10,
+            blocking_gates=[_Gate("malware")],
+            baseline_block_reasons=["governance block"],
+            overall_confidence=0.9,
+            org_policy=OrgPolicy(allow_ids={self.EXT}),
+        )
+        assert final.verdict == Decision.ALLOW
+        assert final.authority == "org_allow_exception"
+
+    def test_baseline_governance_block(self):
+        final = resolve(
+            **self._clean_kwargs(),
+            blocking_gates=[],
+            baseline_block_reasons=["Undisclosed data exfiltration"],
+        )
+        assert final.verdict == Decision.BLOCK
+        assert final.authority == "baseline_governance"
+
+    def test_hard_gate_block(self):
+        final = resolve(
+            **self._clean_kwargs(),
+            blocking_gates=[_Gate("VT malware 9/70")],
+        )
+        assert final.verdict == Decision.BLOCK
+        assert final.authority == "hard_gate"
+        assert "VT malware 9/70" in final.reasons
+
+    def test_score_threshold_block_uses_policy(self):
+        final = resolve(
+            extension_id=self.EXT,
+            overall_score=20,
+            security_score=20,
+            overall_confidence=0.9,
+            blocking_gates=[],
+        )
+        assert final.verdict == Decision.BLOCK
+        assert final.authority == "score_threshold"
+
+    def test_warning_gate_needs_review(self):
+        final = resolve(
+            **self._clean_kwargs(),
+            blocking_gates=[],
+            warning_gates=[_Gate("sensitive exfil risk")],
+        )
+        assert final.verdict == Decision.NEEDS_REVIEW
+        assert final.authority == "score_threshold"
+
+    def test_low_confidence_downgrades_allow(self):
+        final = resolve(
+            **{**self._clean_kwargs(), "overall_confidence": 0.3},
+            blocking_gates=[],
+        )
+        assert final.verdict == Decision.NEEDS_REVIEW
+        assert final.authority == "low_confidence"
+        assert final.insufficient_data is True
+
+    def test_insufficient_data_downgrades_allow(self):
+        final = resolve(
+            **self._clean_kwargs(),
+            blocking_gates=[],
+            insufficient_data=True,
+        )
+        assert final.verdict == Decision.NEEDS_REVIEW
+        assert final.authority == "insufficient_data"
+
+    def test_clean_high_confidence_allows(self):
+        final = resolve(**self._clean_kwargs(), blocking_gates=[])
+        assert final.verdict == Decision.ALLOW
+        assert final.authority == "score_pass"
+
+    def test_thresholds_are_single_source(self):
+        # Guard against reintroducing divergent thresholds.
+        assert DecisionPolicy.BLOCK_SCORE == 30
+        assert DecisionPolicy.REVIEW_SCORE == 75
+        assert 0.0 < DecisionPolicy.LOW_CONFIDENCE < 1.0
+
+
+# =============================================================================
+# Engine integration - P1.2 / P1.3
+# =============================================================================
+
+class TestEngineInsufficientData:
+    def test_zero_data_extension_not_confident_safe(self):
+        """A zero-data extension must NOT look like a confident 80/100 safe."""
+        engine = ScoringEngine()
+        pack = SignalPack(scan_id="empty", extension_id="a" * 32)
+        result = engine.calculate_scores(pack, manifest={"name": "x", "manifest_version": 3})
+
+        assert result.insufficient_data is True
+        assert result.overall_score <= 65  # pushed into the review band
+        assert result.decision == Decision.NEEDS_REVIEW
+        # P1.2: confidence must be real, never the 1.0 default.
+        assert result.overall_confidence < 1.0
+
+    def test_overall_confidence_reflects_coverage(self):
+        """With SAST + VT coverage, confidence should be clearly higher than empty."""
+        engine = ScoringEngine()
+
+        empty = SignalPack(scan_id="empty", extension_id="a" * 32)
+        empty_result = engine.calculate_scores(empty, manifest={"name": "x", "manifest_version": 3})
+
+        covered = SignalPack(scan_id="covered", extension_id="b" * 32)
+        covered.sast = SastSignalPack(deduped_findings=[], files_scanned=20, confidence=0.9)
+        covered.virustotal = VirusTotalSignalPack(enabled=True, malicious_count=0, total_engines=70)
+        covered_result = engine.calculate_scores(
+            covered, manifest={"name": "x", "manifest_version": 3}
+        )
+
+        assert covered_result.overall_confidence > empty_result.overall_confidence
+        assert covered_result.insufficient_data is False

--- a/tests/scoring/test_payload_consistency.py
+++ b/tests/scoring/test_payload_consistency.py
@@ -1,0 +1,57 @@
+"""
+Consumer-consistency contract: the API serializer (model_dump_for_api), used by
+the /recent rebuild/upgrade path, must preserve the audit fields so rebuilt rows
+match freshly-scanned payloads (see ADR 0001).
+"""
+
+from extension_shield.governance.signal_pack import (
+    SastSignalPack,
+    SignalPack,
+    VirusTotalSignalPack,
+)
+from extension_shield.scoring.engine import ScoringEngine
+
+
+def _covered_pack() -> SignalPack:
+    pack = SignalPack(scan_id="covered", extension_id="b" * 32)
+    pack.sast = SastSignalPack(deduped_findings=[], files_scanned=20, confidence=0.9)
+    pack.virustotal = VirusTotalSignalPack(enabled=True, malicious_count=0, total_engines=70)
+    return pack
+
+
+class TestModelDumpForApiPreservesAuditFields:
+    REQUIRED = (
+        "overall_confidence",
+        "insufficient_data",
+        "decision_authority",
+        "decision_reasons",
+        "decision",
+    )
+
+    def test_covered_scan_payload_has_audit_fields(self):
+        result = ScoringEngine().calculate_scores(
+            _covered_pack(), manifest={"name": "x", "manifest_version": 3}
+        )
+        payload = result.model_dump_for_api()
+        for key in self.REQUIRED:
+            assert key in payload, f"{key} missing from API payload"
+        # Confidence is real, never the 1.0 default.
+        assert payload["overall_confidence"] is not None
+        assert payload["overall_confidence"] < 1.0
+        assert payload["insufficient_data"] is False
+        # decision_reasons mirrors reasons for consumer consistency.
+        assert payload["decision_reasons"] == result.reasons
+
+    def test_insufficient_data_scan_surfaces_flag_and_reason(self):
+        # Zero-coverage pack -> insufficient_data path.
+        result = ScoringEngine().calculate_scores(
+            SignalPack(scan_id="empty", extension_id="a" * 32),
+            manifest={"name": "x", "manifest_version": 3},
+        )
+        payload = result.model_dump_for_api()
+        assert payload["insufficient_data"] is True
+        assert payload["decision"] == "NEEDS_REVIEW"
+        assert payload["overall_confidence"] < 1.0
+        assert "insufficient_data_reason" in payload
+        # decision_authority is a non-empty string (which rung decided).
+        assert isinstance(payload["decision_authority"], str) and payload["decision_authority"]

--- a/tests/scoring/test_scoring_confidence.py
+++ b/tests/scoring/test_scoring_confidence.py
@@ -118,8 +118,14 @@ class TestMissingVTDoesNotDrasticallyReduceScore:
         Since VT weight is 0.15 and missing VT has severity=0 (not high),
         the score impact should be minimal.
         """
+        # Both packs have SAST coverage so we isolate VT's *marginal* effect.
+        # (Zero-coverage behavior is covered by the insufficient-data tests; a pack
+        # whose only signal is VT is not a realistic baseline for this comparison.)
+        from extension_shield.governance.signal_pack import SastSignalPack
+
         # Pack with VT enabled and clean
         pack_with_vt = make_min_signal_pack(scan_id="with-vt")
+        pack_with_vt.sast = SastSignalPack(deduped_findings=[], files_scanned=12, confidence=0.9)
         pack_with_vt.virustotal = VirusTotalSignalPack(
             enabled=True,
             malicious_count=0,
@@ -127,11 +133,12 @@ class TestMissingVTDoesNotDrasticallyReduceScore:
             total_engines=70,
         )
         add_webstore_stats(pack_with_vt, installs=10000, rating_avg=4.5)
-        
+
         result_with_vt = engine.calculate_scores(pack_with_vt, manifest, user_count=10000)
-        
-        # Pack with VT disabled (missing)
+
+        # Pack with VT disabled (missing) but SAST coverage present
         pack_missing_vt = make_min_signal_pack(scan_id="missing-vt")
+        pack_missing_vt.sast = SastSignalPack(deduped_findings=[], files_scanned=12, confidence=0.9)
         pack_missing_vt.virustotal = VirusTotalSignalPack(enabled=False)
         add_webstore_stats(pack_missing_vt, installs=10000, rating_avg=4.5)
         

--- a/tests/test_scoring_gates.py
+++ b/tests/test_scoring_gates.py
@@ -4,6 +4,7 @@ from extension_shield.governance.signal_pack import (
     SastFindingNormalized,
     SastSignalPack,
     SignalPack,
+    VirusTotalSignalPack,
 )
 from extension_shield.scoring.engine import ScoringEngine
 from extension_shield.scoring.gates import HardGates
@@ -46,6 +47,11 @@ def test_sast_missing_coverage_caps_score_and_sets_review():
     # Ensure SAST coverage is missing: default SastSignalPack has files_scanned == 0
     assert signal_pack.sast.files_scanned == 0
     assert signal_pack.sast.deduped_findings == []
+    # Provide VirusTotal coverage so this exercises the SAST-only cap (80), not the
+    # broader insufficient-data path (which applies only when SAST+VT+network are all absent).
+    signal_pack.virustotal = VirusTotalSignalPack(
+        enabled=True, malicious_count=0, total_engines=70
+    )
 
     engine = ScoringEngine()
     result = engine.calculate_scores(signal_pack, manifest={})


### PR DESCRIPTION
## Summary

Fixes the scoring/governance audit findings and aligns all consumers with a single decision authority. Two commits:

1. **Core audit fixes** (`ffe733c`) — scoring/governance correctness.
2. **Consumer consistency** (`7817734`) — API payloads, frontend, reports, and methodology copy aligned to the new authority.

No public detection behavior is weakened; **CheckVisaSlots still BLOCKs** via both the hard gate and the rulepack.

## What changed

### Core (commit 1)
- **Single decision authority** (`scoring/decision.py`): one `resolve()` precedence chain — `org_block → org_allow_exception → baseline_governance → hard_gate → score_threshold → low_confidence/insufficient_data → allow`. Engine and governance node both use it; the competing `_determine_decision` was removed.
- **Confidence fix**: `overall_confidence` is the real layer-weighted average (never the `1.0` default).
- **Insufficient-data**: zero-coverage scans (no SAST/VT/network) are capped into the review band and forced to `NEEDS_REVIEW`.
- **Single threshold policy** (`DecisionPolicy` 30/75/0.5); gates delegate to it.
- **Layer-weight docs** corrected to the in-code `0.34/0.33/0.33`.
- **Rules engine fails closed**: malformed conditions/rulepacks → `NEEDS_REVIEW`, with `validate_rulepack()` + `load_rulepacks_with_report()`.
- **Protected-service automation** migrated to declarative config + rulepack (`config/protected_services.yaml`, `governance/protected_services.py`, `rulepacks/PROTECTED_SERVICE_AUTOMATION.yaml`). The hardcoded TOS gate is **kept as a defensive backstop** (not retired).
- **ADR**: `docs/adr/0001-scoring-governance-decision-authority.md`.

### Consumer consistency (commit 2)
- Frontend normalizer + CLI service now **prefer `final_verdict`/`governance_verdict`** over scoring-layer detail (`scoring_v2.decision`, legacy `bundle.decision.verdict`).
- `ScoringResult.model_dump_for_api` + scan/`/recent` payloads now preserve `overall_confidence`, `insufficient_data`, `decision_authority`, `decision_reasons` (rebuilt rows match fresh scans).
- Normalizer surfaces `insufficientData`/`decisionAuthority` so low-coverage scans aren't shown as confidently safe.
- Methodology/public copy: `40/35/25` → near-equal `34/33/33` + a note that hard gates override the smooth score.

## Tests
- Backend targeted suite (`tests/scoring`, `tests/governance`, `tests/workflow`, `test_scoring_gates`, `test_golden_snapshots`): **237 passed**.
- New: `tests/scoring/test_decision_authority.py`, `tests/governance/test_rules_engine_failclosed.py`, `tests/scoring/test_checkvisaslots_block.py`, `tests/governance/test_protected_service_rulepack.py`, `tests/scoring/test_payload_consistency.py`.
- Frontend: new normalizer authority/insufficient-data tests pass.

## Notes
- **Base branch** is `seo/free-extension-scanner-and-live-count` (the branch this work was forked from) so the diff is scoped to these 2 commits. Retarget to `master`/`main` if you'd rather land it there.
- Out of scope / intentionally excluded: pre-existing API/Supabase/open-core test-isolation failures (don't import changed modules; pass in isolation). See the ADR's "Note on unrelated failures".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
