### PR TITLE
Fix Phase 1 governance verdict correctness and display consistency

### DIFF
--- a/frontend/src/pages/reports/ReportDetailPage.jsx
+++ b/frontend/src/pages/reports/ReportDetailPage.jsx
@@ -35,6 +35,29 @@ const badgeVariantForRisk = (risk) => {
   return "outline";
 };
 
+// The headline badge / one-liner must reflect the single authoritative verdict
+// (governance Decision Authority), never a score-derived label. (Audit Fix #3.)
+const decisionLabel = (decision) => {
+  const u = String(decision || "").toUpperCase();
+  if (u === "BLOCK") return "BLOCK";
+  if (u === "WARN" || u === "NEEDS_REVIEW") return "NEEDS REVIEW";
+  if (u === "ALLOW") return "ALLOW";
+  return null;
+};
+const decisionVariant = (decision) => {
+  const u = String(decision || "").toUpperCase();
+  if (u === "BLOCK") return "destructive";
+  if (u === "WARN" || u === "NEEDS_REVIEW") return "secondary";
+  if (u === "ALLOW") return "default";
+  return "outline";
+};
+const decisionOneLiner = (decision) => {
+  const u = String(decision || "").toUpperCase();
+  if (u === "BLOCK") return "This extension was blocked by automated security checks.";
+  if (u === "WARN" || u === "NEEDS_REVIEW") return "This extension requires manual review before use.";
+  return null;
+};
+
 const ReportViewModelDetail = ({ report, rawScanResult, extensionId, onExportPdf }) => {
   const [mode, setMode] = useState("simple"); // simple | advanced
   const [layerModal, setLayerModal] = useState({ open: false, layer: null });
@@ -72,6 +95,11 @@ const ReportViewModelDetail = ({ report, rawScanResult, extensionId, onExportPdf
     overall: { score: report?.scorecard?.score, band: report?.scorecard?.score_label },
     reasons: report?.scorecard?.reasons || []
   };
+
+  // Authoritative verdict for the headline badge / one-liner (falls back to the
+  // legacy score label only when no decision is available).
+  const authVerdictLabel = decisionLabel(scores?.decision);
+  const headlineOneLiner = decisionOneLiner(scores?.decision) || scorecard?.one_liner || "";
 
   // Extract all findings by layer from raw scan results (includes SAST, factors, gates, etc.)
   const findingsByLayer = extractFindingsByLayer(rawScanResult);
@@ -119,7 +147,9 @@ const ReportViewModelDetail = ({ report, rawScanResult, extensionId, onExportPdf
               <span>{meta?.name || "Extension Report"}</span>
               <span style={{ display: "flex", gap: "0.5rem", alignItems: "center" }}>
                 <Badge variant="outline">{extensionId}</Badge>
-                <Badge variant={badgeVariantForRisk(scorecard?.score_label)}>{scorecard?.score_label || "UNKNOWN"}</Badge>
+                <Badge variant={authVerdictLabel ? decisionVariant(scores?.decision) : badgeVariantForRisk(scorecard?.score_label)}>
+                  {authVerdictLabel || scorecard?.score_label || "UNKNOWN"}
+                </Badge>
                 <Badge variant="outline">Confidence: {scorecard?.confidence || "UNKNOWN"}</Badge>
               </span>
             </CardTitle>
@@ -130,7 +160,7 @@ const ReportViewModelDetail = ({ report, rawScanResult, extensionId, onExportPdf
                 {Number.isFinite(scorecard?.score) ? scorecard.score : 0}
                 <span style={{ fontSize: "1rem", opacity: 0.7 }}>/100</span>
               </div>
-              <div style={{ fontSize: "1rem", opacity: 0.9 }}>{scorecard?.one_liner || ""}</div>
+              <div style={{ fontSize: "1rem", opacity: 0.9 }}>{headlineOneLiner}</div>
             </div>
 
             <div style={{ marginTop: "1rem", display: "flex", gap: "0.5rem" }}>

--- a/frontend/src/utils/normalizeScanResult.test.ts
+++ b/frontend/src/utils/normalizeScanResult.test.ts
@@ -266,6 +266,68 @@ describe('normalizeScanResult', () => {
       expect(result.permissions.unreasonablePermissions).toContain('scripting');
     });
 
+    // -------------------------------------------------------------------------
+    // Audit Fix #3: the overall (headline) band must reflect the authoritative
+    // verdict, never just the score. A high-scoring BLOCK/NEEDS_REVIEW must not
+    // render as a green "Safe" gauge.
+    // -------------------------------------------------------------------------
+    it('high-scoring BLOCK must produce a BAD overall band (not green/Safe)', () => {
+      const raw: RawScanResult = {
+        extension_id: 'blockhigh',
+        extension_name: 'High Score Blocked',
+        scoring_v2: {
+          security_score: 92,
+          privacy_score: 95,
+          governance_score: 90,
+          overall_score: 92, // would be GOOD by score alone
+          overall_confidence: 0.9,
+          decision: 'BLOCK',
+          decision_reasons: ['Visa-slot automation detected'],
+        },
+      };
+      const result = normalizeScanResult(raw);
+      expect(result.scores.decision).toBe('BLOCK');
+      expect(result.scores.overall.band).toBe('BAD');
+    });
+
+    it('high-scoring NEEDS_REVIEW must produce at least a WARN overall band', () => {
+      const raw: RawScanResult = {
+        extension_id: 'reviewhigh',
+        extension_name: 'High Score Review',
+        scoring_v2: {
+          security_score: 88,
+          privacy_score: 90,
+          governance_score: 85,
+          overall_score: 88, // GOOD by score alone
+          overall_confidence: 0.6,
+          decision: 'NEEDS_REVIEW',
+          decision_reasons: ['Insufficient analysis coverage'],
+        },
+      };
+      const result = normalizeScanResult(raw);
+      expect(result.scores.decision).toBe('WARN');
+      expect(result.scores.overall.band).toBe('WARN');
+    });
+
+    it('high-scoring ALLOW keeps its score band (no verdict downgrade)', () => {
+      const raw: RawScanResult = {
+        extension_id: 'allowhigh',
+        extension_name: 'High Score Allow',
+        scoring_v2: {
+          security_score: 95,
+          privacy_score: 95,
+          governance_score: 95,
+          overall_score: 95,
+          overall_confidence: 0.9,
+          decision: 'ALLOW',
+          decision_reasons: ['All checks passed'],
+        },
+      };
+      const result = normalizeScanResult(raw);
+      expect(result.scores.decision).toBe('ALLOW');
+      expect(result.scores.overall.band).toBe('GOOD');
+    });
+
     it('should handle legacy raw result without scoring_v2', () => {
       const result = normalizeScanResult(legacyRawResult);
       
@@ -363,28 +425,29 @@ describe('normalizeScanResult', () => {
   });
 
   describe('band calculation', () => {
-    it('should use score-based bands (decision does not affect band)', () => {
-      // Score 40 in 0-49, so band is BAD regardless of decision
+    it('overall band reflects the authoritative verdict (Fix #3)', () => {
+      // ALLOW does not downgrade: score 40 is already BAD by score.
       const allowResult = normalizeScanResult({
         extension_id: 'test',
         scoring_v2: { decision: 'ALLOW', overall_score: 40 },
       });
       expect(allowResult.scores.overall.band).toBe('BAD');
-      expect(allowResult.scores.decision).toBe('ALLOW'); // Decision is separate
+      expect(allowResult.scores.decision).toBe('ALLOW');
 
-      // Score 70 in 50-74, so band is WARN
+      // NEEDS_REVIEW with a mid score stays WARN.
       const warnResult = normalizeScanResult({
         extension_id: 'test',
         scoring_v2: { decision: 'NEEDS_REVIEW', overall_score: 70 },
       });
       expect(warnResult.scores.overall.band).toBe('WARN');
 
-      // Score 80 >= 75, so band is GOOD (even if decision is BLOCK - gate override would apply to layer, not overall)
+      // A high-scoring BLOCK must NOT render green/Safe: the verdict forces BAD.
+      // (Previously this returned GOOD — the audit #3 "green Safe BLOCK" bug.)
       const blockResult = normalizeScanResult({
         extension_id: 'test',
         scoring_v2: { decision: 'BLOCK', overall_score: 80 },
       });
-      expect(blockResult.scores.overall.band).toBe('GOOD');
+      expect(blockResult.scores.overall.band).toBe('BAD');
     });
 
     it('should use score-based bands when no decision exists', () => {

--- a/frontend/src/utils/normalizeScanResult.ts
+++ b/frontend/src/utils/normalizeScanResult.ts
@@ -1018,6 +1018,14 @@ export function normalizeScanResult(raw: RawScanResult): ReportViewModel {
   const securityEffectiveBand = computeEffectiveBand(securityScoreBand, gateBandsByLayer.security);
   const privacyEffectiveBand = computeEffectiveBand(privacyScoreBand, gateBandsByLayer.privacy);
   const governanceEffectiveBand = computeEffectiveBand(governanceScoreBand, gateBandsByLayer.governance);
+
+  // The headline (overall) gauge MUST reflect the authoritative verdict, never
+  // just the score. A BLOCK or NEEDS_REVIEW with a high score must not render as
+  // a green "Safe" gauge. Map the final decision to a band and take the more
+  // severe of (score band, verdict band). ALLOW maps to null (no override) so a
+  // genuinely-clean extension still uses its score band. (Audit Fix #3.)
+  const verdictBand = gateDecisionToBand(decision);
+  const overallEffectiveBand = computeEffectiveBand(overallScoreBand, verdictBand);
   
   const scores: ScoresVM = {
     security: {
@@ -1037,7 +1045,7 @@ export function normalizeScanResult(raw: RawScanResult): ReportViewModel {
     },
     overall: {
       score: overallScore,
-      band: overallScoreBand, // Overall doesn't get gate override (it's a composite)
+      band: overallEffectiveBand, // headline gauge reflects the authoritative verdict
       confidence: overallConfidence,
     },
     decision,

--- a/src/extension_shield/core/report_generator.py
+++ b/src/extension_shield/core/report_generator.py
@@ -83,6 +83,95 @@ class ReportGenerator:
         }
         return risk_colors.get(risk_level.lower(), colors.HexColor('#6b7280'))
 
+    # -- Authoritative verdict ------------------------------------------------
+    # The PDF MUST display the single authoritative verdict (BLOCK / NEEDS_REVIEW
+    # / ALLOW) produced by scoring.decision.resolve() and surfaced as
+    # governance_bundle.decision.final_verdict. It must never recompute a verdict
+    # from the score. See ADR 0001 and audit finding #14.
+
+    _VERDICT_COLORS = {
+        "BLOCK": '#dc2626',
+        "NEEDS_REVIEW": '#f59e0b',
+        "ALLOW": '#22c55e',
+    }
+    _VERDICT_LABELS = {
+        "BLOCK": "BLOCK — Do not install",
+        "NEEDS_REVIEW": "NEEDS REVIEW — Manual review required",
+        "ALLOW": "ALLOW — No blocking issues found",
+    }
+
+    @staticmethod
+    def _resolve_authoritative_verdict(scan_results: Dict) -> Dict[str, Any]:
+        """Extract the authoritative verdict/reasons from scan results.
+
+        Prefers the governance bundle's Decision Authority output
+        (``governance_bundle.decision.final_verdict`` / ``final_reasons``) and
+        falls back to the top-level ``governance_verdict``. Never derived from the
+        numeric score.
+        """
+        bundle = scan_results.get("governance_bundle") or {}
+        decision = bundle.get("decision") or {}
+        verdict = decision.get("final_verdict") or scan_results.get("governance_verdict")
+        reasons = decision.get("final_reasons") or []
+        authority = decision.get("final_authority")
+        return {
+            "verdict": (verdict or "").upper() or None,
+            "reasons": list(reasons) if isinstance(reasons, (list, tuple)) else [],
+            "authority": authority,
+        }
+
+    def _create_verdict_section(self, scan_results: Dict) -> List:
+        """Create the authoritative verdict banner (headline of the report)."""
+        elements: List = []
+        info = self._resolve_authoritative_verdict(scan_results)
+        verdict = info["verdict"]
+
+        if not verdict:
+            # No governance verdict available (e.g. governance did not run). Be
+            # explicit rather than implying a passing verdict.
+            elements.append(Paragraph(
+                "<b>Verdict:</b> Not available (governance decision did not run). "
+                "This report is informational only.",
+                self.styles['BodyTextCustom'],
+            ))
+            elements.append(Spacer(1, 20))
+            return elements
+
+        color = colors.HexColor(self._VERDICT_COLORS.get(verdict, '#6b7280'))
+        label = self._VERDICT_LABELS.get(verdict, verdict)
+
+        banner = Table(
+            [[Paragraph(
+                f"<b>{label}</b>",
+                ParagraphStyle('VerdictStyle', fontSize=18, textColor=colors.white,
+                               alignment=TA_CENTER, leading=22),
+            )]],
+            colWidths=[6.5 * inch],
+        )
+        banner.setStyle(TableStyle([
+            ('BACKGROUND', (0, 0), (-1, -1), color),
+            ('ALIGN', (0, 0), (-1, -1), 'CENTER'),
+            ('VALIGN', (0, 0), (-1, -1), 'MIDDLE'),
+            ('TOPPADDING', (0, 0), (-1, -1), 14),
+            ('BOTTOMPADDING', (0, 0), (-1, -1), 14),
+        ]))
+        elements.append(banner)
+        elements.append(Spacer(1, 10))
+
+        # Reasons that justify the verdict (from the Decision Authority).
+        reasons = info["reasons"]
+        if reasons:
+            elements.append(Paragraph("Why this verdict:", self.styles['BodyTextCustom']))
+            for reason in reasons[:8]:
+                elements.append(Paragraph(f"  - {reason}", self.styles['SmallText']))
+        if info["authority"]:
+            elements.append(Spacer(1, 4))
+            elements.append(Paragraph(
+                f"Deciding authority: {info['authority']}", self.styles['SmallText']
+            ))
+        elements.append(Spacer(1, 20))
+        return elements
+
     def _create_header(self, extension_name: str, extension_id: str, timestamp: str) -> List:
         """Create report header elements."""
         elements = []
@@ -454,6 +543,9 @@ class ReportGenerator:
         # Build document elements
         elements = []
         elements.extend(self._create_header(extension_name, extension_id, timestamp))
+        # Authoritative verdict banner FIRST (the headline). Sourced from the
+        # single Decision Authority, never recomputed from the score.
+        elements.extend(self._create_verdict_section(scan_results))
         elements.extend(self._create_score_section(security_score, risk_level))
         elements.extend(self._create_executive_summary(summary))
         elements.extend(self._create_virustotal_section(vt_analysis))

--- a/src/extension_shield/governance/rules_engine.py
+++ b/src/extension_shield/governance/rules_engine.py
@@ -66,6 +66,23 @@ def validate_rulepack(rulepack: Any) -> List[str]:
         cond = rule.get("condition")
         if not cond or not isinstance(cond, str) or not cond.strip():
             errors.append(f"{where} ('{rid}'): missing or empty 'condition'")
+        else:
+            # Dry-run parse/evaluate the condition so malformed, unevaluable, or
+            # non-round-trippable conditions FAIL VALIDATION here instead of
+            # silently degrading an intended BLOCK to NEEDS_REVIEW at runtime
+            # (audit finding #1). A well-formed condition evaluates to a bool
+            # against an empty context without raising; only a parse/operator
+            # error raises RuleConditionError. Eager evaluation (see _parse_or)
+            # guarantees every sub-branch is parsed even when it short-circuits.
+            try:
+                ConditionEvaluator().evaluate(cond, {})
+            except RuleConditionError as exc:
+                errors.append(f"{where} ('{rid}'): unevaluable condition: {exc}")
+            except Exception as exc:  # pragma: no cover - defensive
+                errors.append(
+                    f"{where} ('{rid}'): condition raised "
+                    f"{type(exc).__name__}: {exc}"
+                )
         verdict = rule.get("verdict")
         if verdict not in VALID_VERDICTS:
             errors.append(
@@ -121,15 +138,22 @@ class ConditionEvaluator:
         # Split on OR that's not inside parentheses
         parts = self._split_on_operator(expr, "OR")
         if len(parts) > 1:
-            return any(self._parse_and(part.strip()) for part in parts)
+            # Evaluate every branch eagerly (no short-circuit) so a malformed
+            # sub-condition always raises RuleConditionError instead of being
+            # skipped by short-circuiting — this lets validate_rulepack catch it
+            # and the engine fail closed (audit finding #1).
+            results = [self._parse_and(part.strip()) for part in parts]
+            return any(results)
         return self._parse_and(expr)
-    
+
     def _parse_and(self, expr: str) -> bool:
         """Parse AND expressions."""
         # Split on AND that's not inside parentheses
         parts = self._split_on_operator(expr, "AND")
         if len(parts) > 1:
-            return all(self._parse_and(part.strip()) for part in parts)
+            # Eager evaluation (no short-circuit) — see _parse_or for rationale.
+            results = [self._parse_and(part.strip()) for part in parts]
+            return all(results)
         return self._parse_comparison(expr)
     
     def _parse_comparison(self, expr: str) -> bool:
@@ -175,33 +199,91 @@ class ConditionEvaluator:
         raise RuleConditionError(f"Unknown comparison operator in: {expr}")
     
     def _split_on_operator(self, expr: str, operator: str) -> List[str]:
-        """Split expression on operator, respecting parentheses."""
-        parts = []
+        """Split an expression on a logical operator (``AND`` / ``OR``).
+
+        Only splits on a *standalone* operator token. The operator must be:
+        - at parenthesis depth 0 (not inside a sub-expression),
+        - NOT inside a quoted string, and
+        - bounded by a non-word character (or a string boundary) on both sides.
+
+        This prevents the historical bug (audit finding #1) where the operator
+        was matched as a bare substring and split inside quoted signal names or
+        larger words — e.g. the ``OR`` in ``type="COMPETITOR_SABOTAGE"`` or in
+        the domain ``"*.NORTON.com"``, and the ``AND`` in any quoted value —
+        which silently downgraded intended BLOCK rules to NEEDS_REVIEW.
+        """
+        parts: List[str] = []
         current = ""
         paren_depth = 0
-        
+        quote_char: Optional[str] = None  # the ' or " we are currently inside
+        op_len = len(operator)
+
         i = 0
-        while i < len(expr):
-            if expr[i] == "(":
+        n = len(expr)
+        while i < n:
+            ch = expr[i]
+
+            # Inside a quoted string: copy verbatim until the matching close quote.
+            if quote_char is not None:
+                current += ch
+                if ch == quote_char:
+                    quote_char = None
+                i += 1
+                continue
+
+            if ch in ('"', "'"):
+                quote_char = ch
+                current += ch
+                i += 1
+                continue
+
+            if ch == "(":
                 paren_depth += 1
-                current += expr[i]
-            elif expr[i] == ")":
+                current += ch
+                i += 1
+                continue
+
+            if ch == ")":
                 paren_depth -= 1
-                current += expr[i]
-            elif paren_depth == 0 and expr[i:i+len(operator)] == operator:
-                # Found operator at top level
+                current += ch
+                i += 1
+                continue
+
+            if (
+                paren_depth == 0
+                and expr[i:i + op_len] == operator
+                and self._is_standalone_operator(expr, i, op_len)
+            ):
+                # Found a real top-level logical operator.
                 if current.strip():
                     parts.append(current)
                 current = ""
-                i += len(operator) - 1
-            else:
-                current += expr[i]
+                i += op_len
+                continue
+
+            current += ch
             i += 1
-        
+
         if current.strip():
             parts.append(current)
-        
+
         return parts
+
+    @staticmethod
+    def _is_standalone_operator(expr: str, start: int, op_len: int) -> bool:
+        """True if the substring at ``expr[start:start+op_len]`` is a standalone
+        token (bounded by a non-word character or a string boundary on each side).
+
+        A "word" character is alphanumeric or underscore, so ``OR`` inside
+        ``COMPETITOR`` / ``NORTON`` and ``AND`` inside e.g. ``BRAND`` are not
+        treated as operators.
+        """
+        before = expr[start - 1] if start > 0 else " "
+        after_idx = start + op_len
+        after = expr[after_idx] if after_idx < len(expr) else " "
+        before_is_word = before.isalnum() or before == "_"
+        after_is_word = after.isalnum() or after == "_"
+        return not before_is_word and not after_is_word
     
     def _get_value(self, path: str) -> Any:
         """Get value from context using dot notation.

--- a/src/extension_shield/scoring/engine.py
+++ b/src/extension_shield/scoring/engine.py
@@ -337,6 +337,14 @@ class ScoringEngine:
         insufficient_data = (not sast_ran) and (not vt_available) and (not network_ran)
         insufficient_data_reason: Optional[str] = None
 
+        # Partial-coverage guard (audit finding #11): even when SAST ran, an
+        # extension whose malware scan (VirusTotal) AND network/exfiltration
+        # analysis BOTH did not run must not be cleared as a confident high-score
+        # ALLOW. SAST finding nothing is not evidence of safety when the two
+        # highest-signal analyzers are absent. This is distinct from the
+        # all-or-nothing insufficient_data case above.
+        threat_coverage_missing = (not vt_available) and (not network_ran)
+
         if insufficient_data:
             insufficient_data_reason = (
                 "Insufficient analysis coverage (no SAST, VirusTotal, or network signals)"
@@ -344,6 +352,18 @@ class ScoringEngine:
             if overall_score > INSUFFICIENT_DATA_SCORE_CAP:
                 overall_score = INSUFFICIENT_DATA_SCORE_CAP
             extra_review_reasons.append(insufficient_data_reason)
+        elif threat_coverage_missing:
+            # SAST ran, but neither VirusTotal nor network analysis did. Cap into
+            # the review band and force NEEDS_REVIEW so a clean SAST pass alone
+            # cannot produce a high-score ALLOW without malware/exfil coverage.
+            if overall_score > INSUFFICIENT_DATA_SCORE_CAP:
+                overall_score = INSUFFICIENT_DATA_SCORE_CAP
+            coverage_cap_applied = True
+            coverage_cap_reason = (
+                "Limited threat coverage: neither VirusTotal nor network analysis "
+                "ran; cannot clear as safe without malware/exfiltration coverage"
+            )
+            extra_review_reasons.append(coverage_cap_reason)
         elif sast_missing_coverage and overall_score > 80:
             # SAST-only coverage gap (other analyzers present): cap at 80 + review.
             overall_score = 80

--- a/tests/governance/test_rules_engine_parser.py
+++ b/tests/governance/test_rules_engine_parser.py
@@ -1,0 +1,184 @@
+"""
+Regression tests for the rules-engine DSL operator-splitting fix (audit finding #1).
+
+The historical bug: ``_split_on_operator`` matched ``OR`` / ``AND`` as bare
+substrings, so it split inside quoted signal names and larger words — e.g. the
+``OR`` in ``type="COMPETITOR_SABOTAGE"`` or the domain ``"*.NORTON.com"`` — which
+raised a parse error that was caught and silently downgraded an intended BLOCK
+rule to NEEDS_REVIEW (and meant the condition never actually evaluated).
+
+These tests pin:
+1. Operators are only split as standalone, unquoted, top-level tokens.
+2. The exact COMPETITOR_SABOTAGE case from the audit evaluates correctly.
+3. A BLOCK rule referencing such a value still BLOCKs when its signal is present.
+4. validate_rulepack rejects unevaluable conditions instead of degrading them.
+5. The shipped rulepacks all load cleanly under the stricter validation.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from extension_shield.governance.rules_engine import (
+    ConditionEvaluator,
+    RuleConditionError,
+    RulesEngine,
+    validate_rulepack,
+)
+
+RULEPACKS_DIR = Path(__file__).resolve().parents[2] / "src" / "extension_shield" / "governance" / "rulepacks"
+
+
+def _sig(t):
+    return [{"type": t}]
+
+
+# =============================================================================
+# Operator splitting: words and quoted strings must not be split
+# =============================================================================
+
+class TestOperatorSplitting:
+    def test_or_inside_quoted_signal_name_not_split(self):
+        """'OR' inside the quoted value COMPETITOR_SABOTAGE must not split."""
+        ev = ConditionEvaluator()
+        cond = 'signals contains type="COMPETITOR_SABOTAGE"'
+        # Present -> True (rule would fire), absent -> False. Never raises.
+        assert ev.evaluate(cond, {"signals": _sig("COMPETITOR_SABOTAGE")}) is True
+        assert ev.evaluate(cond, {"signals": _sig("SOMETHING_ELSE")}) is False
+        assert ev.evaluate(cond, {}) is False
+
+    def test_or_inside_quoted_domain_not_split(self):
+        """The 'OR' in NORTON (*.NORTON.com) must not split the expression."""
+        ev = ConditionEvaluator()
+        cond = 'facts.host_access_patterns contains "*.NORTON.com"'
+        assert ev.evaluate(cond, {"facts": {"host_access_patterns": ["*.NORTON.com"]}}) is True
+        assert ev.evaluate(cond, {"facts": {"host_access_patterns": ["*.example.com"]}}) is False
+
+    def test_and_inside_quoted_value_not_split(self):
+        """'AND' inside a quoted value (e.g. BRAND) must not split."""
+        ev = ConditionEvaluator()
+        cond = 'manifest.name contains "BRAND_GUARD"'
+        assert ev.evaluate(cond, {"manifest": {"name": "BRAND_GUARD"}}) is True
+        assert ev.evaluate(cond, {"manifest": {"name": "other"}}) is False
+
+    def test_real_top_level_or_still_splits(self):
+        ev = ConditionEvaluator()
+        cond = 'manifest.permissions contains "tabs" OR manifest.permissions contains "cookies"'
+        assert ev.evaluate(cond, {"manifest": {"permissions": ["cookies"]}}) is True
+        assert ev.evaluate(cond, {"manifest": {"permissions": ["storage"]}}) is False
+
+    def test_real_top_level_and_still_splits(self):
+        ev = ConditionEvaluator()
+        cond = 'manifest.permissions contains "tabs" AND manifest.permissions contains "cookies"'
+        assert ev.evaluate(cond, {"manifest": {"permissions": ["tabs", "cookies"]}}) is True
+        assert ev.evaluate(cond, {"manifest": {"permissions": ["tabs"]}}) is False
+
+    def test_nested_paren_or_inside_and(self):
+        """Mirrors PROTECTED_SERVICE_AUTOMATION::R1 shape."""
+        ev = ConditionEvaluator()
+        cond = (
+            'signals contains type="PROTECTED_SERVICE_AUTOMATION" AND '
+            '(signals contains type="CREDENTIAL_CAPTURE" OR '
+            'signals contains type="IDENTITY_DATA_EXFIL")'
+        )
+        assert ev.evaluate(cond, {"signals": [
+            {"type": "PROTECTED_SERVICE_AUTOMATION"}, {"type": "IDENTITY_DATA_EXFIL"}]}) is True
+        # automation but no capture/exfil -> False
+        assert ev.evaluate(cond, {"signals": [{"type": "PROTECTED_SERVICE_AUTOMATION"}]}) is False
+
+
+# =============================================================================
+# A BLOCK rule whose value contains 'OR'/'AND' must still BLOCK
+# =============================================================================
+
+class TestBlockRuleWithOperatorishValue:
+    def test_block_rule_referencing_competitor_sabotage_blocks(self):
+        """If a BLOCK rule keys on COMPETITOR_SABOTAGE it must BLOCK, not degrade."""
+        rulepack = {
+            "rulepack_id": "RP",
+            "rules": [{
+                "rule_id": "RP::SABOTAGE",
+                "condition": 'signals contains type="COMPETITOR_SABOTAGE"',
+                "verdict": "BLOCK",
+                "confidence": 0.9,
+            }],
+        }
+        # validation must accept it
+        assert validate_rulepack(rulepack) == []
+        engine = RulesEngine([rulepack])
+        results = engine.evaluate(
+            scan_id="s1",
+            facts={},
+            signals=[{"type": "COMPETITOR_SABOTAGE"}],
+            store_listing={},
+            context={"rulepacks": ["RP"]},
+        )
+        verdicts = {r.verdict for r in results.rule_results}
+        assert "BLOCK" in verdicts, f"expected BLOCK, got {verdicts}"
+
+    def test_same_rule_allows_when_signal_absent(self):
+        rulepack = {
+            "rulepack_id": "RP",
+            "rules": [{
+                "rule_id": "RP::SABOTAGE",
+                "condition": 'signals contains type="COMPETITOR_SABOTAGE"',
+                "verdict": "BLOCK",
+                "confidence": 0.9,
+            }],
+        }
+        engine = RulesEngine([rulepack])
+        results = engine.evaluate(
+            scan_id="s1", facts={}, signals=[{"type": "OTHER"}],
+            store_listing={}, context={"rulepacks": ["RP"]},
+        )
+        # Rule did not match -> ALLOW (condition genuinely false, not an error)
+        assert all(r.verdict == "ALLOW" for r in results.rule_results)
+
+
+# =============================================================================
+# Validation rejects unevaluable conditions
+# =============================================================================
+
+class TestValidationRejectsUnevaluable:
+    def test_unknown_operator_condition_fails_validation(self):
+        rp = {"rulepack_id": "RP", "rules": [{
+            "rule_id": "RP::BAD",
+            "condition": "facts.x TOTALLY INVALID syntax",
+            "verdict": "BLOCK",
+            "confidence": 0.9,
+        }]}
+        errors = validate_rulepack(rp)
+        assert any("unevaluable" in e for e in errors), errors
+
+    def test_malformed_branch_in_and_fails_validation(self):
+        """Eager eval: a broken branch is caught even if the first branch is false."""
+        rp = {"rulepack_id": "RP", "rules": [{
+            "rule_id": "RP::BAD2",
+            "condition": 'manifest.permissions contains "tabs" AND facts.y WHAT 3',
+            "verdict": "BLOCK",
+            "confidence": 0.9,
+        }]}
+        errors = validate_rulepack(rp)
+        assert any("unevaluable" in e for e in errors), errors
+
+    def test_valid_condition_passes_validation(self):
+        rp = {"rulepack_id": "RP", "rules": [{
+            "rule_id": "RP::OK",
+            "condition": 'signals contains type="COMPETITOR_SABOTAGE" OR manifest.permissions contains "tabs"',
+            "verdict": "NEEDS_REVIEW",
+            "confidence": 0.7,
+        }]}
+        assert validate_rulepack(rp) == []
+
+
+# =============================================================================
+# Shipped rulepacks must still load cleanly under stricter validation
+# =============================================================================
+
+class TestShippedRulepacksLoad:
+    def test_all_shipped_rulepacks_load_without_errors(self):
+        rulepacks, errors = RulesEngine.load_rulepacks_with_report(str(RULEPACKS_DIR))
+        assert errors == [], f"shipped rulepacks failed validation: {errors}"
+        assert len(rulepacks) >= 3
+        ids = {rp.get("rulepack_id") for rp in rulepacks}
+        assert "PROTECTED_SERVICE_AUTOMATION" in ids

--- a/tests/scoring/test_partial_coverage_matrix.py
+++ b/tests/scoring/test_partial_coverage_matrix.py
@@ -1,0 +1,129 @@
+"""
+Regression tests for the partial-coverage guard (audit finding #11).
+
+The bug: insufficient-data handling was all-or-nothing — it only fired when SAST,
+VirusTotal, AND network analysis ALL produced no coverage. So a SAST-only scan
+(SAST ran, found nothing) with NO VirusTotal and NO network analysis produced a
+high-score clean ALLOW (~96/100), even though the two highest-signal analyzers
+(malware + exfiltration) never ran.
+
+The fix: when VirusTotal AND network coverage are both missing, the score is
+capped into the review band and the verdict is forced to NEEDS_REVIEW — even when
+SAST ran. This file pins that across the full coverage matrix.
+
+Note: the in-repo network analyzer does not yet populate network signals, so in
+practice "no network" is the common case; this guard means a scan without
+VirusTotal cannot self-clear as a confident high-score ALLOW.
+"""
+
+import pytest
+
+from extension_shield.scoring.engine import ScoringEngine
+from extension_shield.scoring.models import Decision
+from extension_shield.scoring.decision import DecisionPolicy
+from extension_shield.governance.signal_pack import SastSignalPack, VirusTotalSignalPack
+from tests.scoring.utils import (
+    make_min_signal_pack,
+    add_vt_detections,
+    add_network_analysis,
+    add_webstore_stats,
+    make_test_manifest,
+)
+
+
+def _sast_clean(pack, files=12):
+    pack.sast = SastSignalPack(deduped_findings=[], files_scanned=files, confidence=0.9)
+    return pack
+
+
+def _build(sast, vt, network):
+    """Build an otherwise-clean, high-install pack with selectable coverage."""
+    pack = make_min_signal_pack(scan_id=f"cov-{sast}-{vt}-{network}")
+    if sast:
+        _sast_clean(pack)
+    if vt:
+        add_vt_detections(pack, malicious_count=0, total_engines=70)
+    else:
+        pack.virustotal = VirusTotalSignalPack(enabled=False)
+    if network:
+        add_network_analysis(pack, domains=[], confidence=0.7)
+    add_webstore_stats(
+        pack, installs=500000, rating_avg=4.8, rating_count=5000,
+        has_privacy_policy=True, last_updated="2025-12-01",
+    )
+    return pack
+
+
+class TestPartialCoverageGuard:
+    def test_sast_only_no_vt_no_network_is_not_clean_high_score_allow(self):
+        """The exact audit #11 case: SAST-only, no VT, no network."""
+        engine = ScoringEngine()
+        pack = _build(sast=True, vt=False, network=False)
+        result = engine.calculate_scores(pack, make_test_manifest())
+
+        assert result.decision != Decision.ALLOW, "must not ALLOW without VT+network coverage"
+        assert result.decision == Decision.NEEDS_REVIEW
+        assert result.overall_score <= DecisionPolicy.REVIEW_SCORE
+        assert result.coverage_cap_applied is True
+        assert result.coverage_cap_reason and "coverage" in result.coverage_cap_reason.lower()
+
+    def test_sast_plus_vt_can_allow(self):
+        """With VT coverage present, a clean pack may ALLOW (cap does not fire)."""
+        engine = ScoringEngine()
+        pack = _build(sast=True, vt=True, network=False)
+        result = engine.calculate_scores(pack, make_test_manifest())
+
+        assert result.coverage_cap_applied is not True
+        assert result.decision == Decision.ALLOW
+        assert result.overall_score > DecisionPolicy.REVIEW_SCORE
+
+    def test_sast_plus_network_can_allow(self):
+        """With network coverage present (VT missing), the threat cap does not fire."""
+        engine = ScoringEngine()
+        pack = _build(sast=True, vt=False, network=True)
+        result = engine.calculate_scores(pack, make_test_manifest())
+
+        # The dedicated threat-coverage cap must not apply (network is present).
+        assert result.coverage_cap_reason is None or "Limited threat coverage" not in (
+            result.coverage_cap_reason or ""
+        )
+        assert result.decision == Decision.ALLOW
+
+    def test_all_coverage_allows(self):
+        engine = ScoringEngine()
+        pack = _build(sast=True, vt=True, network=True)
+        result = engine.calculate_scores(pack, make_test_manifest())
+        assert result.decision == Decision.ALLOW
+        assert result.coverage_cap_applied is not True
+
+    def test_no_coverage_at_all_is_insufficient_data(self):
+        """Existing all-or-nothing insufficient-data path still works."""
+        engine = ScoringEngine()
+        pack = _build(sast=False, vt=False, network=False)
+        result = engine.calculate_scores(pack, make_test_manifest())
+        assert result.insufficient_data is True
+        assert result.decision == Decision.NEEDS_REVIEW
+        assert result.overall_score <= 65
+
+    @pytest.mark.parametrize(
+        "sast,vt,network,expect_allow",
+        [
+            (True, False, False, False),   # audit #11 case
+            (True, True, False, True),
+            (True, False, True, True),
+            (True, True, True, True),
+            (False, False, False, False),  # insufficient data
+        ],
+    )
+    def test_coverage_matrix(self, sast, vt, network, expect_allow):
+        engine = ScoringEngine()
+        pack = _build(sast=sast, vt=vt, network=network)
+        result = engine.calculate_scores(pack, make_test_manifest())
+        if expect_allow:
+            assert result.decision == Decision.ALLOW, (
+                f"sast={sast} vt={vt} net={network}: expected ALLOW, got {result.decision}"
+            )
+        else:
+            assert result.decision != Decision.ALLOW, (
+                f"sast={sast} vt={vt} net={network}: must NOT ALLOW (got {result.decision})"
+            )

--- a/tests/scoring/test_scoring_confidence.py
+++ b/tests/scoring/test_scoring_confidence.py
@@ -24,6 +24,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 from scoring.utils import (
     make_min_signal_pack,
     add_webstore_stats,
+    add_network_analysis,
     make_test_manifest,
 )
 from extension_shield.scoring.engine import ScoringEngine
@@ -121,6 +122,10 @@ class TestMissingVTDoesNotDrasticallyReduceScore:
         # Both packs have SAST coverage so we isolate VT's *marginal* effect.
         # (Zero-coverage behavior is covered by the insufficient-data tests; a pack
         # whose only signal is VT is not a realistic baseline for this comparison.)
+        # Both packs also have network coverage so the partial-coverage guard
+        # (audit #11: missing VT AND missing network -> cap into review band) does
+        # NOT fire here — this test isolates VT's marginal *formula weight*, not
+        # the coverage policy (which is covered by test_partial_coverage_matrix).
         from extension_shield.governance.signal_pack import SastSignalPack
 
         # Pack with VT enabled and clean
@@ -132,14 +137,16 @@ class TestMissingVTDoesNotDrasticallyReduceScore:
             suspicious_count=0,
             total_engines=70,
         )
+        add_network_analysis(pack_with_vt, domains=[], confidence=0.7)
         add_webstore_stats(pack_with_vt, installs=10000, rating_avg=4.5)
 
         result_with_vt = engine.calculate_scores(pack_with_vt, manifest, user_count=10000)
 
-        # Pack with VT disabled (missing) but SAST coverage present
+        # Pack with VT disabled (missing) but SAST + network coverage present
         pack_missing_vt = make_min_signal_pack(scan_id="missing-vt")
         pack_missing_vt.sast = SastSignalPack(deduped_findings=[], files_scanned=12, confidence=0.9)
         pack_missing_vt.virustotal = VirusTotalSignalPack(enabled=False)
+        add_network_analysis(pack_missing_vt, domains=[], confidence=0.7)
         add_webstore_stats(pack_missing_vt, installs=10000, rating_avg=4.5)
         
         result_missing_vt = engine.calculate_scores(pack_missing_vt, manifest, user_count=10000)

--- a/tests/scoring/test_scoring_resolution.py
+++ b/tests/scoring/test_scoring_resolution.py
@@ -93,14 +93,19 @@ class TestScoringResolution:
         
         All findings same severity, but different counts.
         """
+        # Both packs get clean VT coverage so the partial-coverage guard
+        # (audit #11: missing VT AND missing network caps into the review band)
+        # does not fire — this test isolates SAST-count -> score resolution.
         # Few findings
         pack_few = make_min_signal_pack(scan_id="few-findings")
         add_sast_findings(pack_few, n=2, severity="HIGH")
+        add_vt_detections(pack_few, malicious_count=0, total_engines=70)
         add_webstore_stats(pack_few, installs=5000)
-        
+
         # Many findings
         pack_many = make_min_signal_pack(scan_id="many-findings")
         add_sast_findings(pack_many, n=20, severity="HIGH")
+        add_vt_detections(pack_many, malicious_count=0, total_engines=70)
         add_webstore_stats(pack_many, installs=5000)
         
         result_few = engine.calculate_scores(pack_few, manifest, user_count=5000)

--- a/tests/test_pdf_report_verdict.py
+++ b/tests/test_pdf_report_verdict.py
@@ -1,0 +1,128 @@
+"""
+Regression tests for the PDF report authoritative-verdict banner (audit #14, Fix #3).
+
+The PDF must display the single authoritative verdict (BLOCK / NEEDS_REVIEW /
+ALLOW) from governance_bundle.decision.final_verdict and its reasons, and must
+NOT recompute or imply a conflicting verdict from the score. A high-scoring BLOCK
+must render as BLOCK, never as a clean/safe-looking report.
+
+These tests assert on the generated ReportLab flowables (no PDF-text-parsing
+dependency). An optional deep-text check runs only if pdfminer.six is installed.
+"""
+
+import pytest
+
+pytest.importorskip("reportlab")
+
+from reportlab.platypus import Paragraph, Table
+
+from extension_shield.core.report_generator import ReportGenerator
+
+
+def _collect_text(flowables) -> str:
+    """Recursively collect plain text from Paragraph / Table flowables."""
+    parts = []
+    for f in flowables or []:
+        if isinstance(f, Paragraph):
+            parts.append(f.getPlainText())
+        elif isinstance(f, Table):
+            for row in getattr(f, "_cellvalues", []) or []:
+                for cell in row:
+                    if isinstance(cell, (list, tuple)):
+                        parts.append(_collect_text(cell))
+                    else:
+                        parts.append(_collect_text([cell]))
+    return "\n".join(parts)
+
+
+def _results(verdict, reasons, *, overall_score=92, risk_level="low"):
+    return {
+        "extension_id": "abcdefghabcdefghabcdefghabcdefgh",
+        "extension_name": "Test Extension",
+        "overall_security_score": overall_score,
+        "risk_level": risk_level,
+        "governance_verdict": verdict,
+        "governance_bundle": {
+            "decision": {
+                "final_verdict": verdict,
+                "final_authority": "hard_gate",
+                "final_reasons": reasons,
+            }
+        },
+        "summary": {"summary": "Test summary."},
+        "sast_results": {},
+        "virustotal_analysis": {},
+        "entropy_analysis": {},
+        "permissions_analysis": {},
+    }
+
+
+class TestVerdictResolution:
+    def test_resolve_prefers_bundle_decision(self):
+        info = ReportGenerator._resolve_authoritative_verdict(
+            _results("BLOCK", ["automation of a protected portal"])
+        )
+        assert info["verdict"] == "BLOCK"
+        assert info["reasons"] == ["automation of a protected portal"]
+
+    def test_resolve_falls_back_to_top_level(self):
+        info = ReportGenerator._resolve_authoritative_verdict({"governance_verdict": "needs_review"})
+        assert info["verdict"] == "NEEDS_REVIEW"
+
+    def test_resolve_none_when_absent(self):
+        info = ReportGenerator._resolve_authoritative_verdict({})
+        assert info["verdict"] is None
+
+
+class TestVerdictSection:
+    def test_high_score_block_section_shows_block_and_reason(self):
+        """A BLOCK with a high score (92) must render BLOCK + reason, not Safe."""
+        gen = ReportGenerator()
+        section = gen._create_verdict_section(
+            _results("BLOCK", ["Visa-slot automation detected"], overall_score=92, risk_level="low")
+        )
+        text = _collect_text(section)
+        assert "BLOCK" in text
+        assert "Visa-slot automation detected" in text
+        assert "No blocking issues found" not in text  # the ALLOW label must not appear
+
+    def test_needs_review_section(self):
+        gen = ReportGenerator()
+        text = _collect_text(gen._create_verdict_section(
+            _results("NEEDS_REVIEW", ["Insufficient analysis coverage"])
+        ))
+        assert "NEEDS REVIEW" in text
+        assert "Insufficient analysis coverage" in text
+
+    def test_allow_section(self):
+        gen = ReportGenerator()
+        text = _collect_text(gen._create_verdict_section(
+            _results("ALLOW", ["All checks passed"])
+        ))
+        assert "ALLOW" in text
+
+    def test_missing_verdict_does_not_imply_pass(self):
+        gen = ReportGenerator()
+        text = _collect_text(gen._create_verdict_section({"extension_id": "x" * 32}))
+        assert "Not available" in text
+        assert "No blocking issues found" not in text
+
+
+class TestGeneratePdfSmoke:
+    @pytest.mark.parametrize("verdict", ["BLOCK", "NEEDS_REVIEW", "ALLOW"])
+    def test_generate_pdf_returns_pdf_bytes(self, verdict):
+        gen = ReportGenerator()
+        pdf = gen.generate_pdf(_results(verdict, ["reason one"]))
+        assert isinstance(pdf, bytes) and pdf.startswith(b"%PDF")
+
+
+class TestPdfDeepText:
+    """Optional: verify the rendered PDF text if pdfminer.six is installed."""
+
+    def test_block_appears_in_rendered_pdf(self):
+        high_level = pytest.importorskip("pdfminer.high_level")
+        import io
+        gen = ReportGenerator()
+        pdf = gen.generate_pdf(_results("BLOCK", ["Visa-slot automation detected"], overall_score=92))
+        text = high_level.extract_text(io.BytesIO(pdf))
+        assert "BLOCK" in text


### PR DESCRIPTION
## Summary

This PR implements the three Phase 1 post-audit fixes:

1. Harden rules DSL parsing and rulepack validation.
2. Prevent partial analyzer coverage from producing a clean high-score `ALLOW`.
3. Make PDF/frontend consumers display the authoritative governance verdict.

No Phase 2 detection work is included. `scoring/decision.py` is unchanged.

## Changes

### Rules DSL parser + validation

`governance/rules_engine.py`

- `_split_on_operator` now splits `AND` / `OR` only when they are standalone, unquoted, top-level operators.
- This prevents false splits inside values such as `type="COMPETITOR_SABOTAGE"` or `"*.NORTON.com"`.
- `_parse_or` and `_parse_and` now evaluate all branches so malformed sub-branches are not skipped by short-circuiting.
- `validate_rulepack()` now dry-runs conditions so malformed or unevaluable rule conditions fail validation before runtime.

### Partial coverage guard

`scoring/engine.py`

- If both VirusTotal and network coverage are missing, the score is capped into the review band and the result is forced to `NEEDS_REVIEW`.
- A SAST-only clean scan can no longer become a high-score `ALLOW` without malware/network coverage.

### Authoritative verdict display

`core/report_generator.py`  
`frontend/src/utils/normalizeScanResult.ts`  
`frontend/src/pages/reports/ReportDetailPage.jsx`

- PDF reports now show `governance_bundle.decision.final_verdict` and reasons as the headline verdict.
- The PDF does not recompute the verdict from score.
- Frontend headline gauge/badge/summary now follow the authoritative verdict.
- A high-scoring `BLOCK` or `NEEDS_REVIEW` can no longer render as green/safe.

## Non-changes

- `scoring/decision.py` precedence is unchanged.
- TOS/protected-service backstop remains intact.
- CheckVisaSlots still blocks via both hard gate and rulepack.
- No second decision authority was introduced.
- No Phase 2 detection work is included.
- No env/secrets, generated artifacts, ADR edits, or unrelated refactors.

## Tests

Python:

```bash
PYTHONPATH=src .venv/bin/python -m pytest tests/scoring tests/governance tests/workflow