### PR TITLE
Make consumer report copy verdict-driven (Phase 1 follow-up)

### DIFF
--- a/frontend/src/components/report/LayerModal.jsx
+++ b/frontend/src/components/report/LayerModal.jsx
@@ -49,7 +49,19 @@ const LAYER_CONFIG = {
   },
 };
 
-function humanizeFactor(factor) {
+/**
+ * A check whose underlying analysis did not run has no coverage and must not be
+ * shown as "Clear" (that overstates certainty). The network/exfil analyzer
+ * reports this via details.network_analysis_enabled === false.
+ */
+export function isNotAnalyzed(factor) {
+  const details = factor?.details;
+  if (!details || typeof details !== 'object') return false;
+  if (details.network_analysis_enabled === false) return true;
+  return false;
+}
+
+export function humanizeFactor(factor) {
   const info = FACTOR_HUMAN[factor.name] || {
     label: factor.name,
     category: 'other',
@@ -60,6 +72,9 @@ function humanizeFactor(factor) {
   if (severity >= 0.4) {
     status = 'Issue';
     statusType = 'issues';
+  } else if (isNotAnalyzed(factor)) {
+    status = 'Not analyzed';
+    statusType = 'unknown';
   } else {
     status = 'Clear';
     statusType = 'clear';
@@ -159,6 +174,8 @@ const LayerModal = ({
                         <span className="lm-status-wrap">
                           {item.statusType === 'clear' ? (
                             <CheckCircle className="lm-status-icon" size={14} strokeWidth={2} aria-hidden />
+                          ) : item.statusType === 'unknown' ? (
+                            <Info className="lm-status-icon" size={14} strokeWidth={2} aria-hidden />
                           ) : (
                             <AlertCircle className="lm-status-icon" size={14} strokeWidth={2} aria-hidden />
                           )}

--- a/frontend/src/components/report/LayerModal.scss
+++ b/frontend/src/components/report/LayerModal.scss
@@ -319,11 +319,21 @@
   background: var(--risk-warn-bg);
 }
 
+// Neutral "Not analyzed" status — no coverage, so neither safe nor flagged.
+.lm-status-unknown {
+  color: var(--theme-text-secondary);
+  border-color: var(--theme-border);
+  background: var(--theme-bg-tertiary);
+}
+
 .lm-check-card.lm-check-clear .lm-status-icon {
   color: var(--risk-good);
 }
 .lm-check-card.lm-check-issues .lm-status-icon {
   color: var(--risk-warn);
+}
+.lm-check-card.lm-check-unknown .lm-status-icon {
+  color: var(--theme-text-secondary);
 }
 
 // ---------------------------------------------------------------------------

--- a/frontend/src/components/report/LayerModal.test.jsx
+++ b/frontend/src/components/report/LayerModal.test.jsx
@@ -1,0 +1,61 @@
+/**
+ * LayerModal status-mapping tests (Phase 1 follow-up).
+ *
+ * A check whose underlying analysis did not run has no coverage and must read as
+ * "Not analyzed", never "Clear" (which overstates certainty). The network/exfil
+ * analyzer reports this via details.network_analysis_enabled === false.
+ *
+ * These exercise the pure status mapping only — no rendering required.
+ */
+import { describe, it, expect } from 'vitest';
+import { humanizeFactor, isNotAnalyzed } from './LayerModal';
+
+describe('LayerModal status mapping', () => {
+  it('Data Sharing with no network coverage is "Not analyzed", not "Clear"', () => {
+    const factor = {
+      name: 'NetworkExfil',
+      severity: 0,
+      confidence: 0.5,
+      details: { network_analysis_enabled: false },
+    };
+    const result = humanizeFactor(factor);
+    expect(result.status).toBe('Not analyzed');
+    expect(result.statusType).toBe('unknown');
+    expect(result.label).toBe('Data Sharing');
+  });
+
+  it('Data Sharing WITH coverage and no findings reads "Clear"', () => {
+    const factor = {
+      name: 'NetworkExfil',
+      severity: 0,
+      confidence: 0.7,
+      details: { network_analysis_enabled: true, domains_analyzed: 3 },
+    };
+    const result = humanizeFactor(factor);
+    expect(result.status).toBe('Clear');
+    expect(result.statusType).toBe('clear');
+  });
+
+  it('an actual ISSUE-level finding wins over the not-analyzed flag', () => {
+    const factor = {
+      name: 'NetworkExfil',
+      severity: 0.6,
+      details: { network_analysis_enabled: false },
+    };
+    const result = humanizeFactor(factor);
+    expect(result.status).toBe('Issue');
+    expect(result.statusType).toBe('issues');
+  });
+
+  it('a normal sub-threshold factor without coverage flags is "Clear"', () => {
+    const factor = { name: 'CaptureSignals', severity: 0.1, details: {} };
+    expect(humanizeFactor(factor).status).toBe('Clear');
+  });
+
+  it('isNotAnalyzed only fires on the explicit coverage flag', () => {
+    expect(isNotAnalyzed({ details: { network_analysis_enabled: false } })).toBe(true);
+    expect(isNotAnalyzed({ details: { network_analysis_enabled: true } })).toBe(false);
+    expect(isNotAnalyzed({ details: {} })).toBe(false);
+    expect(isNotAnalyzed({})).toBe(false);
+  });
+});

--- a/frontend/src/components/report/SummaryPanel.jsx
+++ b/frontend/src/components/report/SummaryPanel.jsx
@@ -59,6 +59,28 @@ const SummaryPanel = ({
     );
   };
 
+  // Placeholder copy must never soften the authoritative verdict: a BLOCK must
+  // read as blocked, a review verdict as unresolved — not "review before installing".
+  const getPlaceholderLines = () => {
+    const decision = scores?.decision;
+    if (decision === 'BLOCK') {
+      return [
+        'Blocked — do not install without a security review.',
+        'This extension failed automated security checks.',
+      ];
+    }
+    if (decision === 'WARN') {
+      return [
+        'Not safe yet — review unresolved risks before installing.',
+        'Avoid on sensitive sites (banking/email).',
+      ];
+    }
+    return [
+      'Review this extension before installing.',
+      'Avoid on sensitive sites (banking/email).',
+    ];
+  };
+
   if (showPlaceholder) {
     return (
       <section className="summary-panel summary-panel--unified">
@@ -71,8 +93,9 @@ const SummaryPanel = ({
         </div>
         <div className="summary-content">
           <div className="summary-placeholder-wrapper">
-            <p className="summary-placeholder-line">Review this extension before installing.</p>
-            <p className="summary-placeholder-line">Avoid on sensitive sites (banking/email).</p>
+            {getPlaceholderLines().map((line, idx) => (
+              <p key={idx} className="summary-placeholder-line">{line}</p>
+            ))}
           </div>
           {(onViewRiskyPermissions || onViewNetworkDomains) && (
             <div className="summary-action-buttons">

--- a/frontend/src/utils/normalizeScanResult.test.ts
+++ b/frontend/src/utils/normalizeScanResult.test.ts
@@ -725,6 +725,88 @@ describe('normalizeScanResult - decision authority consistency', () => {
 });
 
 // =============================================================================
+// LAYER BAND <-> ISSUE ROW CONSISTENCY (Phase 1 follow-up)
+// A layer tile must not present as "Safe" (GOOD) when it lists an ISSUE-level
+// factor row (severity >= 0.4) — the threshold the LayerModal rows and the tile
+// finding-count both use.
+// =============================================================================
+
+describe('normalizeScanResult - layer band issue consistency', () => {
+  it('a privacy layer with an ISSUE-level factor is not GOOD/Safe', () => {
+    const raw: RawScanResult = {
+      extension_id: 'privacy-issue',
+      scoring_v2: {
+        decision: 'ALLOW',
+        overall_score: 90,
+        privacy_score: 80,
+        privacy_layer: {
+          layer_name: 'privacy',
+          score: 80,
+          risk_level: 'low', // GOOD by score/risk alone
+          factors: [
+            // e.g. Screen Capture flagged but layer score still high
+            { name: 'CaptureSignals', severity: 0.6, confidence: 0.8, weight: 0.15, contribution: 0.072 },
+          ],
+        },
+        security_layer: { factors: [] },
+        governance_layer: { factors: [] },
+      },
+    };
+    const result = normalizeScanResult(raw);
+    expect(result.scores.privacy.band).toBe('WARN');
+  });
+
+  it('a layer with only sub-threshold factors keeps its GOOD score band', () => {
+    const raw: RawScanResult = {
+      extension_id: 'privacy-clean',
+      scoring_v2: {
+        decision: 'ALLOW',
+        overall_score: 90,
+        privacy_score: 80,
+        privacy_layer: {
+          layer_name: 'privacy',
+          score: 80,
+          risk_level: 'low',
+          factors: [
+            { name: 'CaptureSignals', severity: 0.1, confidence: 0.8, weight: 0.15, contribution: 0.012 },
+          ],
+        },
+        security_layer: { factors: [] },
+        governance_layer: { factors: [] },
+      },
+    };
+    const result = normalizeScanResult(raw);
+    expect(result.scores.privacy.band).toBe('GOOD');
+  });
+
+  it('a BLOCK gate on a layer still wins over the issue bump (BAD, not WARN)', () => {
+    const raw: RawScanResult = {
+      extension_id: 'privacy-gate',
+      scoring_v2: {
+        decision: 'BLOCK',
+        overall_score: 80,
+        privacy_score: 80,
+        privacy_layer: {
+          layer_name: 'privacy',
+          score: 80,
+          risk_level: 'low',
+          factors: [
+            { name: 'CaptureSignals', severity: 0.6, confidence: 0.8, weight: 0.15, contribution: 0.072 },
+          ],
+        },
+        security_layer: { factors: [] },
+        governance_layer: { factors: [] },
+        gate_results: [
+          { gate_id: 'SENSITIVE_EXFIL', decision: 'BLOCK', triggered: true, confidence: 0.9, reasons: ['exfil'] },
+        ],
+      },
+    };
+    const result = normalizeScanResult(raw);
+    expect(result.scores.privacy.band).toBe('BAD');
+  });
+});
+
+// =============================================================================
 // RUNTIME ASSERTIONS (can be run independently)
 // =============================================================================
 

--- a/frontend/src/utils/normalizeScanResult.ts
+++ b/frontend/src/utils/normalizeScanResult.ts
@@ -494,6 +494,19 @@ function gateDecisionToBand(decision: string | null | undefined): ScoreBand | nu
 }
 
 /**
+ * Issue-level band for a layer: if any factor has an ISSUE-level severity
+ * (>= 0.4, the same threshold the LayerModal rows and the tile finding-count
+ * use), the layer tile must not present as "Safe". Returns WARN so the tile
+ * shows at least "Needs Review"; never downgrades (a BLOCK gate still wins via
+ * computeEffectiveBand). Returns null when the layer has no issue-level factor.
+ */
+function factorIssueBand(layer: RawLayerScore | null | undefined): ScoreBand | null {
+  const factors = layer?.factors;
+  if (!Array.isArray(factors)) return null;
+  return factors.some((f) => (f?.severity ?? 0) >= 0.4) ? 'WARN' : null;
+}
+
+/**
  * Compute effective band by combining score-based band with gate-based band
  * Uses ordering: GOOD < WARN < BAD
  * Returns the more severe of the two bands
@@ -1015,9 +1028,20 @@ export function normalizeScanResult(raw: RawScanResult): ReportViewModel {
   const governanceScoreBand = getLayerBand(scoringV2?.governance_layer, governanceScore);
   const overallScoreBand = getOverallBand();
   
-  const securityEffectiveBand = computeEffectiveBand(securityScoreBand, gateBandsByLayer.security);
-  const privacyEffectiveBand = computeEffectiveBand(privacyScoreBand, gateBandsByLayer.privacy);
-  const governanceEffectiveBand = computeEffectiveBand(governanceScoreBand, gateBandsByLayer.governance);
+  // Effective band = max(scoreBand, gateBand, factorIssueBand). The last term
+  // prevents a layer that lists an ISSUE-level row from rendering as "Safe".
+  const securityEffectiveBand = computeEffectiveBand(
+    computeEffectiveBand(securityScoreBand, gateBandsByLayer.security),
+    factorIssueBand(scoringV2?.security_layer),
+  );
+  const privacyEffectiveBand = computeEffectiveBand(
+    computeEffectiveBand(privacyScoreBand, gateBandsByLayer.privacy),
+    factorIssueBand(scoringV2?.privacy_layer),
+  );
+  const governanceEffectiveBand = computeEffectiveBand(
+    computeEffectiveBand(governanceScoreBand, gateBandsByLayer.governance),
+    factorIssueBand(scoringV2?.governance_layer),
+  );
 
   // The headline (overall) gauge MUST reflect the authoritative verdict, never
   // just the score. A BLOCK or NEEDS_REVIEW with a high score must not render as

--- a/src/extension_shield/core/report_view_model.py
+++ b/src/extension_shield/core/report_view_model.py
@@ -111,6 +111,40 @@ def _map_score_label_from_risk_level(risk_level: str) -> str:
     return "LOW RISK"
 
 
+def _normalize_verdict(decision: Any) -> str:
+    """
+    Map a scoring/governance decision to the authoritative verdict bucket.
+
+    Returns one of BLOCK | NEEDS_REVIEW | ALLOW | UNKNOWN. Accepts an enum
+    (with a .value), a string, or None.
+    """
+    val = getattr(decision, "value", decision)
+    s = str(val or "").upper()
+    if s == "BLOCK":
+        return "BLOCK"
+    if s in ("WARN", "NEEDS_REVIEW", "REVIEW"):
+        return "NEEDS_REVIEW"
+    if s == "ALLOW":
+        return "ALLOW"
+    return "UNKNOWN"
+
+
+def _reconcile_score_label(score_label: str, verdict: str) -> str:
+    """
+    Keep the score-derived risk label from contradicting the authoritative verdict.
+
+    The numeric score stays visible, but a BLOCK/NEEDS_REVIEW verdict must never
+    present as a lower-risk label (which is what produced "Review before
+    installing" / "appears safe" copy on a blocked extension). This only ever
+    raises the label, never lowers it.
+    """
+    if verdict == "BLOCK":
+        return "HIGH RISK"
+    if verdict == "NEEDS_REVIEW" and score_label == "LOW RISK":
+        return "MEDIUM RISK"
+    return score_label
+
+
 def _coerce_list(value: Any) -> List[Any]:
     if isinstance(value, list):
         return value
@@ -252,9 +286,16 @@ def build_consumer_summary(
     score = scorecard.get("score", 0)
     score_label = scorecard.get("score_label", "UNKNOWN")
     one_liner = scorecard.get("one_liner", "")
+    final_verdict = _normalize_verdict((scoring_v2 or {}).get("decision"))
 
     # --- Verdict (max 12 words) ---
-    if score_label == "HIGH RISK":
+    # Authoritative verdict owns the headline; score label only decides tone for
+    # ALLOW/unknown extensions. A BLOCK/NEEDS_REVIEW is stated unambiguously.
+    if final_verdict == "BLOCK":
+        verdict = "Blocked — do not install without review."
+    elif final_verdict == "NEEDS_REVIEW":
+        verdict = "Not safe yet — review unresolved risks before installing."
+    elif score_label == "HIGH RISK":
         verdict = one_liner if one_liner and len(one_liner.split()) <= 12 else "High risk — avoid unless necessary."
     elif score_label == "MEDIUM RISK":
         verdict = one_liner if one_liner and len(one_liner.split()) <= 12 else "Some caution needed before using this extension."
@@ -316,8 +357,13 @@ def build_consumer_summary(
         access_bullet = "No special data access detected."
 
     # --- What to do (1 bullet) ---
+    # Blocking/review verdicts take precedence over any softer "what to watch" hint.
     what_to_watch = highlights.get("what_to_watch", [])
-    if isinstance(what_to_watch, list) and what_to_watch:
+    if final_verdict == "BLOCK":
+        action_bullet = "Do not install without a manual security review."
+    elif final_verdict == "NEEDS_REVIEW":
+        action_bullet = "Do not treat as safe; review the flagged risks before installing."
+    elif isinstance(what_to_watch, list) and what_to_watch:
         action_bullet = str(what_to_watch[0])
     elif score_label == "HIGH RISK":
         action_bullet = "Avoid installing unless absolutely necessary."
@@ -366,6 +412,7 @@ def build_unified_consumer_summary(
     
     score = scorecard.get("score", 0)
     score_label = scorecard.get("score_label", "UNKNOWN")
+    verdict = _normalize_verdict((scoring_v2 or {}).get("decision"))
     host_access = evidence.get("host_access_summary", {})
     capability_flags = evidence.get("capability_flags", {})
     
@@ -562,6 +609,18 @@ def build_unified_consumer_summary(
                     raise ValueError("Summary contradicts LOW RISK score")
                 if score_label == "HIGH RISK" and any(x in text_to_check for x in ["safe", "low risk", "no concerns"]):
                     raise ValueError("Summary contradicts HIGH RISK score")
+                # The authoritative verdict overrides the score: a BLOCK/NEEDS_REVIEW
+                # extension must never be softened into review/safe wording.
+                if verdict == "BLOCK" and any(
+                    x in text_to_check
+                    for x in ["appears safe", "safe for general use", "review before installing",
+                              "needs some attention", "moderate issues", "no concerns"]
+                ):
+                    raise ValueError("Summary contradicts BLOCK verdict")
+                if verdict == "NEEDS_REVIEW" and any(
+                    x in text_to_check for x in ["appears safe", "safe for general use", "no concerns"]
+                ):
+                    raise ValueError("Summary contradicts NEEDS_REVIEW verdict")
 
                 logger.info("Unified consumer summary generated via LLM")
                 return {
@@ -584,6 +643,7 @@ def build_unified_consumer_summary(
         layer_details=layer_details,
         highlights=highlights,
         extension_name=ext_name,
+        verdict=verdict,
     )
 
 
@@ -595,15 +655,24 @@ def _fallback_unified_consumer_summary(
     layer_details: Dict[str, Any],
     highlights: Dict[str, Any],
     extension_name: str,
+    verdict: str = "UNKNOWN",
 ) -> Dict[str, Any]:
     """
     Deterministic fallback for unified consumer summary.
     Uses plain English and avoids technical jargon.
+
+    The authoritative ``verdict`` (BLOCK / NEEDS_REVIEW / ALLOW) takes precedence
+    over the numeric score label for the headline and recommendation so a blocked
+    extension is never described as "review"/"appears safe".
     """
     host_scope = host_access.get("host_scope_label", "NONE")
-    
-    # Headline based on score
-    if score_label == "HIGH RISK":
+
+    # Headline: authoritative verdict first, score label only as a fallback.
+    if verdict == "BLOCK":
+        headline = f"Not safe — {extension_name} was blocked by automated security checks."
+    elif verdict == "NEEDS_REVIEW":
+        headline = f"Do not install yet — {extension_name} has unresolved risks that need review."
+    elif score_label == "HIGH RISK":
         headline = f"Be careful — {extension_name} has significant security concerns."
     elif score_label == "MEDIUM RISK":
         headline = f"Review before installing — {extension_name} needs some attention."
@@ -630,7 +699,11 @@ def _fallback_unified_consumer_summary(
         tldr_parts.append("It can see and modify your web traffic.")
     
     if not tldr_parts:
-        if score_label == "LOW RISK":
+        if verdict == "BLOCK":
+            tldr_parts.append("This extension was blocked by automated security checks and is not considered safe to install.")
+        elif verdict == "NEEDS_REVIEW":
+            tldr_parts.append("This extension has unresolved risks that must be reviewed before it can be considered safe.")
+        elif score_label == "LOW RISK":
             tldr_parts.append("No major concerns were found during the security scan.")
         elif score_label == "MEDIUM RISK":
             tldr_parts.append("Some permissions and behaviors need review before installing.")
@@ -684,8 +757,12 @@ def _fallback_unified_consumer_summary(
         if isinstance(why_this_score, list):
             concerns = [_sanitize_concern(str(r)) for r in why_this_score if r and str(r).strip()][:3]
     
-    # Recommendation
-    if score_label == "HIGH RISK":
+    # Recommendation: authoritative verdict first.
+    if verdict == "BLOCK":
+        recommendation = "Do not install this extension without a manual security review; it was blocked by automated checks."
+    elif verdict == "NEEDS_REVIEW":
+        recommendation = "Do not treat this as safe yet — review the flagged risks before installing."
+    elif score_label == "HIGH RISK":
         recommendation = "Consider using an alternative extension with fewer permissions."
     elif score_label == "MEDIUM RISK":
         recommendation = "Check the permissions carefully and avoid using on sensitive websites."
@@ -1459,6 +1536,14 @@ def build_report_view_model(
     score_label = _map_score_label_from_risk_level(
         getattr(scoring_result, "risk_level", None).value if getattr(scoring_result, "risk_level", None) else ""
     )
+
+    # The authoritative verdict (governance Decision Authority) — not the numeric
+    # score — owns the headline tone. Reconcile the score label up to the verdict
+    # so all downstream copy (executive summary, scorecard, consumer summaries)
+    # cannot soften a BLOCK/NEEDS_REVIEW into "review"/"appears safe". The score
+    # number itself is unchanged and still rendered. (Phase 1 follow-up.)
+    verdict = _normalize_verdict(getattr(scoring_result, "decision", None))
+    score_label = _reconcile_score_label(score_label, verdict)
 
     # -------------------------------------------------------------------------
     # Deterministic context (for evidence + fallbacks)

--- a/tests/test_report_view_model_verdict_copy.py
+++ b/tests/test_report_view_model_verdict_copy.py
@@ -1,0 +1,156 @@
+"""
+Regression tests for verdict-driven consumer copy (Phase 1 follow-up).
+
+The bug: report_view_model summary copy was keyed on the numeric score label,
+so a BLOCKed extension whose score landed in the "medium" band rendered as
+"Review before installing — … needs some attention." (see the Check US Visa
+Slots report). The authoritative governance verdict — not the score — must own
+the headline, TL;DR, recommendation, verdict, and action copy.
+
+These tests pin the deterministic fallbacks (the LLM-free path) and the label
+reconciliation helpers. They do NOT touch decision.resolve() precedence or any
+detection logic.
+"""
+
+import pytest
+
+from extension_shield.core.report_view_model import (
+    _normalize_verdict,
+    _reconcile_score_label,
+    _fallback_unified_consumer_summary,
+    build_consumer_summary,
+)
+
+# Phrases that must never appear for a BLOCK verdict (they soften a block).
+SOFTENING_PHRASES = [
+    "review before installing",
+    "needs some attention",
+    "moderate issues",
+    "appears safe",
+    "safe for general use",
+    "some permissions and behaviors need review",
+]
+
+BLOCKING_PHRASES = ["blocked", "not safe", "do not install"]
+
+
+def _has_any(text: str, needles) -> bool:
+    t = (text or "").lower()
+    return any(n in t for n in needles)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+class TestVerdictHelpers:
+    @pytest.mark.parametrize(
+        "raw,expected",
+        [
+            ("BLOCK", "BLOCK"),
+            ("block", "BLOCK"),
+            ("NEEDS_REVIEW", "NEEDS_REVIEW"),
+            ("WARN", "NEEDS_REVIEW"),
+            ("ALLOW", "ALLOW"),
+            ("", "UNKNOWN"),
+            (None, "UNKNOWN"),
+        ],
+    )
+    def test_normalize_verdict(self, raw, expected):
+        assert _normalize_verdict(raw) == expected
+
+    def test_normalize_verdict_accepts_enum_like(self):
+        class _D:
+            value = "BLOCK"
+
+        assert _normalize_verdict(_D()) == "BLOCK"
+
+    def test_reconcile_only_raises_label(self):
+        # BLOCK forces HIGH RISK regardless of the score-derived label.
+        assert _reconcile_score_label("MEDIUM RISK", "BLOCK") == "HIGH RISK"
+        assert _reconcile_score_label("LOW RISK", "BLOCK") == "HIGH RISK"
+        # NEEDS_REVIEW lifts LOW RISK to MEDIUM but never lowers.
+        assert _reconcile_score_label("LOW RISK", "NEEDS_REVIEW") == "MEDIUM RISK"
+        assert _reconcile_score_label("HIGH RISK", "NEEDS_REVIEW") == "HIGH RISK"
+        # ALLOW / unknown never change the label.
+        assert _reconcile_score_label("LOW RISK", "ALLOW") == "LOW RISK"
+        assert _reconcile_score_label("MEDIUM RISK", "UNKNOWN") == "MEDIUM RISK"
+
+
+# ---------------------------------------------------------------------------
+# Unified consumer summary fallback (the exact path that produced the bug)
+# ---------------------------------------------------------------------------
+
+class TestUnifiedFallbackVerdictCopy:
+    def _summary(self, verdict, score_label="MEDIUM RISK"):
+        # The Check US Visa Slots shape: BLOCK verdict but a mid-band score label.
+        return _fallback_unified_consumer_summary(
+            score=53,
+            score_label=score_label,
+            host_access={"host_scope_label": "SINGLE_DOMAIN"},
+            capability_flags={},
+            layer_details={},
+            highlights={},
+            extension_name="Check US Visa Slots",
+            verdict=verdict,
+        )
+
+    def test_block_never_softens(self):
+        out = self._summary("BLOCK", score_label="MEDIUM RISK")
+        blob = " ".join([out["headline"], out["narrative"], out["tldr"], out["recommendation"]])
+        assert not _has_any(blob, SOFTENING_PHRASES), f"softening copy leaked: {blob}"
+        # And it must read as a block.
+        assert _has_any(out["headline"] + out["recommendation"], BLOCKING_PHRASES)
+
+    def test_block_even_with_low_risk_label(self):
+        out = self._summary("BLOCK", score_label="LOW RISK")
+        blob = " ".join([out["headline"], out["narrative"], out["tldr"], out["recommendation"]])
+        assert not _has_any(blob, SOFTENING_PHRASES)
+        assert _has_any(out["headline"], ["not safe", "blocked"])
+
+    def test_needs_review_not_shown_as_safe(self):
+        out = self._summary("NEEDS_REVIEW", score_label="LOW RISK")
+        blob = " ".join([out["headline"], out["narrative"], out["tldr"], out["recommendation"]])
+        assert not _has_any(blob, ["appears safe", "safe for general use"])
+        assert "review" in blob.lower()
+
+    def test_allow_unchanged_low_risk(self):
+        # ALLOW must still be allowed to read as safe (no over-warning).
+        out = self._summary("ALLOW", score_label="LOW RISK")
+        assert "appears safe" in out["headline"].lower()
+
+
+# ---------------------------------------------------------------------------
+# Compact consumer summary (verdict + action)
+# ---------------------------------------------------------------------------
+
+class TestConsumerSummaryVerdictCopy:
+    def _rvm(self, score_label="MEDIUM RISK"):
+        return {
+            "scorecard": {"score": 53, "score_label": score_label, "one_liner": ""},
+            "highlights": {"why_this_score": ["x"], "what_to_watch": ["Watch for updates."]},
+            "evidence": {"host_access_summary": {}, "capability_flags": {}},
+            "consumer_insights": {},
+            "layer_details": {},
+        }
+
+    def test_block_verdict_and_action(self):
+        out = build_consumer_summary(self._rvm(), scoring_v2={"decision": "BLOCK"})
+        assert _has_any(out["verdict"], BLOCKING_PHRASES)
+        assert not _has_any(out["verdict"], SOFTENING_PHRASES)
+        # Action must not defer to the softer "Watch for updates." highlight.
+        assert _has_any(out["action"], ["do not install", "security review"])
+
+    def test_needs_review_action(self):
+        out = build_consumer_summary(self._rvm(), scoring_v2={"decision": "NEEDS_REVIEW"})
+        assert "review" in out["verdict"].lower()
+        assert not _has_any(out["verdict"], ["appears safe", "safe for general use"])
+
+    def test_allow_keeps_score_driven_copy(self):
+        out = build_consumer_summary(self._rvm(score_label="LOW RISK"), scoring_v2={"decision": "ALLOW"})
+        # ALLOW falls through to the what_to_watch / score-label copy.
+        assert not _has_any(out["verdict"], BLOCKING_PHRASES)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
Phase 1 (#235) made the PDF verdict banner and the normalized overall band follow the authoritative verdict. The live results page could still print score-driven wording that contradicts a BLOCK, e.g. "Review before installing - needs some attention" on the Check US Visa Slots report. This finishes that work by pointing the rest of the consumer copy at the same verdict (`scores.decision` / `governance_bundle.decision.final_verdict`).

`ScanResultsPageV2.jsx` didn't need a change - it reads `scores.overall.band`, `scores.<layer>.band`, and renders `SummaryPanel`, so it's fixed through its data.

## Changes

Backend (`core/report_view_model.py`):
- Added `_normalize_verdict()` / `_reconcile_score_label()`. The label is reconciled up to the verdict before any copy is built, so it can only get more severe, never less. The numeric score is unchanged.
- `_fallback_unified_consumer_summary` and `build_consumer_summary` pick BLOCK/NEEDS_REVIEW copy first for headline, TL;DR, recommendation, verdict and action.
- `build_unified_consumer_summary` drops to the deterministic fallback if the LLM returns softened wording for a BLOCK/NEEDS_REVIEW.

Frontend:
- `normalizeScanResult.ts`: a layer with any factor at issue severity (>=0.4, same threshold the modal rows and tile count use) renders at least WARN, so a tile can't say "Safe" while listing an issue row (e.g. Privacy "Safe" with a Screen Capture issue). A BLOCK gate still wins and shows BAD.
- `SummaryPanel.jsx`: placeholder copy now depends on the decision.
- `LayerModal.jsx` / `.scss`: shows "Not analyzed" instead of "Clear" when network/exfil coverage is missing (`details.network_analysis_enabled === false`).

## Strings changed (BLOCK, score 53)

| Surface | Before | After |
|---|---|---|
| Unified headline | Review before installing - {name} needs some attention. | Not safe - {name} was blocked by automated security checks. |
| Unified recommendation | Check the permissions carefully and avoid using on sensitive websites. | Do not install this extension without a manual security review; it was blocked by automated checks. |
| Consumer verdict | Some caution needed before using this extension. | Blocked - do not install without review. |
| Consumer action | Review permissions before installing; disable on sensitive sites. | Do not install without a manual security review. |
| Placeholder | Review this extension before installing. | Blocked - do not install without a security review. |
| Privacy tile (issue row) | Safe | Needs Review |
| Data Sharing (no coverage) | Clear | Not analyzed |

NEEDS_REVIEW headline becomes "Do not install yet - {name} has unresolved risks that need review." ALLOW copy is unchanged.

## Tests

New/updated:
- `tests/test_report_view_model_verdict_copy.py` - a BLOCK can't produce "Review before installing" / "needs some attention" / "Moderate issues" / "appears safe"; NEEDS_REVIEW isn't shown as safe; ALLOW unchanged.
- `normalizeScanResult.test.ts` (+3) - issue layer isn't Safe; sub-threshold stays GOOD; BLOCK gate still BAD.
- `LayerModal.test.jsx` - no coverage shows "Not analyzed"; with coverage shows "Clear"; a real finding still wins.

Ran locally:
- `tests/test_report_view_model_verdict_copy.py`: 16 passed
- scoring + governance + workflow + trust-contract + golden-snapshots + PDF verdict + gates + open-core + (mocked) LLM validators: 396 passed, 1 skipped
- consumer_insights (pure) + fallback + layer_details: 36 passed
- `test_checkvisaslots_block`: passes (visa still blocks)
- frontend band logic via node type-strip: 4/4; changed FE files parse clean

`tests/api/` and one `consumer_insights` test hit the live LLM and hang here (no network/key); both are pre-existing and unrelated to these copy changes. Frontend vitest also hangs on cold start locally - CI's frontend job runs `npm run build`, not vitest.

## Phase 1 follow-up, not Phase 2
This is copy and status mapping on the existing verdict only. No detection logic, scoring weights, gates, or `decision.resolve()` precedence changed, and the TOS/visa-slot BLOCK is untouched. Making the network analyzer actually populate exfil signals is Phase 2 and not part of this - until then, missing coverage just reads "Not analyzed" instead of "Clear".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Factors without analysis now properly display as "Not analyzed" instead of "Clear"
  * Verdict-driven decision text now correctly reflects blocking and review-required states across all consumer messaging

* **New Features**
  * Placeholder messaging now varies based on decision type (BLOCK, WARN, or default)
  * Layer status calculation now accounts for issue-level factor severity

* **Tests**
  * Added comprehensive test coverage for status mapping logic, layer band consistency, and verdict-driven copy

<!-- end of auto-generated comment: release notes by coderabbit.ai -->