### PR TITLE
Honor skip_llm in build_report_view_model (no LLM on retrieval path)

### DIFF
--- a/src/extension_shield/core/report_view_model.py
+++ b/src/extension_shield/core/report_view_model.py
@@ -386,6 +386,7 @@ def build_unified_consumer_summary(
     analysis_results: Optional[Dict[str, Any]] = None,
     manifest: Optional[Dict[str, Any]] = None,
     extension_name: Optional[str] = None,
+    skip_llm: bool = False,
 ) -> Dict[str, Any]:
     """
     Build a unified, LLM-powered consumer summary with plain English insights.
@@ -419,7 +420,21 @@ def build_unified_consumer_summary(
     # Build the name
     meta = report_view_model.get("meta", {})
     ext_name = extension_name or meta.get("name", "This extension")
-    
+
+    # Retrieval/skip paths must not call the LLM (avoids network dependency and
+    # latency). Use the deterministic, verdict-aware fallback directly.
+    if skip_llm:
+        return _fallback_unified_consumer_summary(
+            score=score,
+            score_label=score_label,
+            host_access=host_access,
+            capability_flags=capability_flags,
+            layer_details=layer_details,
+            highlights=highlights,
+            extension_name=ext_name,
+            verdict=verdict,
+        )
+
     # Try LLM-powered generation first
     try:
         prompts = get_prompts("summary_generation")
@@ -1736,18 +1751,20 @@ def build_report_view_model(
     # -------------------------------------------------------------------------
     # Layer Details Generation (LLM with deterministic fallback)
     # -------------------------------------------------------------------------
+    # Gate results feed both the LLM generator and the deterministic fallback.
+    gate_results = []
+    if scoring_result and hasattr(scoring_engine, '_last_gate_results'):
+        gate_results = scoring_engine._last_gate_results or []
+
     # Prefer already-computed pipeline outputs to avoid duplicate LLM calls.
+    # When skip_llm=True (retrieval path), never call the LLM - use the
+    # deterministic fallback below.
     layer_details_raw: Any = (
         analysis_results.get("layer_details")
         or analysis_results.get("layerDetails")
     )
-    if not (isinstance(layer_details_raw, dict) and layer_details_raw):
+    if not (isinstance(layer_details_raw, dict) and layer_details_raw) and not skip_llm:
         try:
-            # Extract gate results for layer details generation
-            gate_results = []
-            if scoring_result and hasattr(scoring_engine, '_last_gate_results'):
-                gate_results = scoring_engine._last_gate_results or []
-            
             layer_details_generator = LayerDetailsGenerator()
             layer_details_raw = layer_details_generator.generate(
                 scoring_result=scoring_result,
@@ -1758,7 +1775,7 @@ def build_report_view_model(
         except Exception:
             layer_details_raw = None
 
-    # Use deterministic fallback if LLM failed
+    # Use deterministic fallback if LLM was skipped or failed
     layer_details = (
         layer_details_raw
         if isinstance(layer_details_raw, dict) and layer_details_raw
@@ -1766,7 +1783,7 @@ def build_report_view_model(
             scoring_result=scoring_result,
             analysis_results=analysis_results,
             manifest=manifest,
-            gate_results=gate_results if 'gate_results' in locals() else [],
+            gate_results=gate_results,
         )
     )
 
@@ -1853,6 +1870,7 @@ def build_report_view_model(
         analysis_results=analysis_results,
         manifest=manifest,
         extension_name=manifest.get("name") or metadata.get("title") or metadata.get("name"),
+        skip_llm=skip_llm,
     )
 
     return report_view_model

--- a/tests/test_report_view_model_skip_llm.py
+++ b/tests/test_report_view_model_skip_llm.py
@@ -1,0 +1,85 @@
+"""
+Regression tests for `build_report_view_model(skip_llm=True)`.
+
+The retrieval/rebuild path passes skip_llm=True to avoid LLM latency and network
+dependency. Previously two surfaces ignored the flag and called the LLM anyway:
+the layer-details generator and the unified consumer summary. This pins that
+skip_llm=True takes the deterministic path for every LLM-backed surface, while
+the default (skip_llm=False) still attempts the LLM.
+"""
+
+import pytest
+
+import extension_shield.core.report_view_model as rvm
+
+VALID_EXT_ID = "abcdefghijklmnopabcdefghijklmnop"  # 32 chars in [a-p]
+MANIFEST = {
+    "name": "Skip LLM Example",
+    "version": "1.0.0",
+    "manifest_version": 3,
+    "permissions": ["storage"],
+    "host_permissions": [],
+}
+
+
+def _rig_llm_to_explode(monkeypatch):
+    """Make every LLM entry point raise, so any LLM call fails the test."""
+    def boom(*args, **kwargs):
+        raise AssertionError("LLM must not be called when skip_llm=True")
+
+    monkeypatch.setattr(rvm.SummaryGenerator, "generate", boom)
+    monkeypatch.setattr(rvm.ImpactAnalyzer, "generate", boom)
+    monkeypatch.setattr(rvm.PrivacyComplianceAnalyzer, "generate", boom)
+    monkeypatch.setattr(rvm.LayerDetailsGenerator, "generate", boom)
+    import extension_shield.llm.clients.fallback as fb
+    monkeypatch.setattr(fb, "invoke_with_fallback", boom)
+
+
+def test_skip_llm_build_uses_only_deterministic_fallbacks(monkeypatch):
+    _rig_llm_to_explode(monkeypatch)
+
+    report = rvm.build_report_view_model(
+        manifest=MANIFEST,
+        analysis_results={},
+        metadata={},
+        extension_id=VALID_EXT_ID,
+        scan_id="s1",
+        skip_llm=True,
+    )
+
+    # Unified summary came from the deterministic fallback, not the LLM.
+    assert report["unified_summary"]["source"] == "fallback"
+    # Layer details still fully populated by the deterministic generator.
+    assert set(report["layer_details"].keys()) == {"security", "privacy", "governance"}
+    # Core surfaces are present.
+    assert "scorecard" in report
+    assert "consumer_summary" in report
+    assert set(report["consumer_insights"].keys()) == {"safety_label", "scenarios", "top_drivers"}
+
+
+def test_skip_llm_unified_summary_helper_short_circuits(monkeypatch):
+    """build_unified_consumer_summary(skip_llm=True) returns the fallback directly."""
+    import extension_shield.llm.clients.fallback as fb
+    monkeypatch.setattr(
+        fb, "invoke_with_fallback",
+        lambda *a, **k: (_ for _ in ()).throw(AssertionError("LLM called")),
+    )
+    out = rvm.build_unified_consumer_summary(
+        report_view_model={
+            "scorecard": {"score": 40, "score_label": "MEDIUM RISK"},
+            "evidence": {"host_access_summary": {}, "capability_flags": {}},
+            "layer_details": {},
+            "highlights": {},
+            "meta": {"name": "X"},
+        },
+        scoring_v2={"decision": "BLOCK"},
+        skip_llm=True,
+    )
+    assert out["source"] == "fallback"
+    # Verdict-aware: a BLOCK must not be softened.
+    blob = (out["headline"] + " " + out["recommendation"]).lower()
+    assert any(p in blob for p in ["blocked", "not safe", "do not install"])
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
`build_report_view_model(skip_llm=True)` still invoked the LLM through the layer-details generator and unified consumer summary. That made retrieval/rebuild paths pay unnecessary LLM latency and hang when no LLM endpoint was reachable. Other generators already honored `skip_llm`; these two did not.

What this does
- Skips the layer-details LLM generator when `skip_llm=True`, while still building deterministic `layer_details`.
- Adds a `skip_llm` path to `build_unified_consumer_summary` so it returns the deterministic fallback before any LLM call.
- Passes `skip_llm` through from `build_report_view_model`.
- Leaves the default path (`skip_llm=False`) unchanged.

Implementation notes (`core/report_view_model.py`)
- `gate_results` is extracted up front so both the LLM path and the deterministic fallback can use the same data.
- `build_unified_consumer_summary(..., skip_llm=True)` now short-circuits directly to `_fallback_unified_consumer_summary`.

Verified locally
- With `skip_llm=True` and all LLM entry points forced to raise, a full `build_report_view_model` completes immediately with `unified_summary.source == "fallback"` and populated `layer_details`.
- New `tests/test_report_view_model_skip_llm.py` covers this behavior.
- Related report/summary regression suites remain green: verdict-copy, consumer_insights, trust-contract, golden-snapshots, and CheckVisaSlots.

Why
This is a retrieval-path correctness and latency fix only. No detection logic, scoring, gates, or `decision.resolve()` precedence changed.