### PR TITLE
feat(about): add founder backlink to Cherker + clean Person schema

### DIFF
--- a/frontend/public/sitemap.xml
+++ b/frontend/public/sitemap.xml
@@ -2,355 +2,355 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://extensionshield.com/</loc>
-    <lastmod>2026-06-08T15:38:21.231Z</lastmod>
+    <lastmod>2026-06-17T16:22:00.104Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://extensionshield.com/about</loc>
-    <lastmod>2026-06-08T15:38:21.231Z</lastmod>
+    <lastmod>2026-06-17T16:22:00.104Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://extensionshield.com/blog</loc>
-    <lastmod>2026-06-08T15:38:21.231Z</lastmod>
+    <lastmod>2026-06-17T16:22:00.104Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://extensionshield.com/blog/all-urls-chrome-extension-permission</loc>
-    <lastmod>2026-06-08T15:38:21.231Z</lastmod>
+    <lastmod>2026-06-17T16:22:00.104Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://extensionshield.com/blog/audit-crx-zip-before-release</loc>
-    <lastmod>2026-06-08T15:38:21.231Z</lastmod>
+    <lastmod>2026-06-17T16:22:00.104Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://extensionshield.com/blog/best-chrome-extension-security-scanner-tools-2026</loc>
-    <lastmod>2026-06-08T15:38:21.231Z</lastmod>
+    <lastmod>2026-06-17T16:22:00.104Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://extensionshield.com/blog/browser-extension-compliance-checklist</loc>
-    <lastmod>2026-06-08T15:38:21.231Z</lastmod>
+    <lastmod>2026-06-17T16:22:00.104Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://extensionshield.com/blog/browser-extension-supply-chain-attacks</loc>
-    <lastmod>2026-06-08T15:38:21.231Z</lastmod>
+    <lastmod>2026-06-17T16:22:00.104Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://extensionshield.com/blog/can-chrome-extensions-steal-cookies-sessions</loc>
-    <lastmod>2026-06-08T15:38:21.231Z</lastmod>
+    <lastmod>2026-06-17T16:22:00.104Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://extensionshield.com/blog/can-chrome-extensions-steal-data</loc>
-    <lastmod>2026-06-08T15:38:21.231Z</lastmod>
+    <lastmod>2026-06-17T16:22:00.104Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://extensionshield.com/blog/chrome-extension-allowlist-policy</loc>
-    <lastmod>2026-06-08T15:38:21.231Z</lastmod>
+    <lastmod>2026-06-17T16:22:00.104Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://extensionshield.com/blog/chrome-extension-scanner-vs-governance-platform</loc>
-    <lastmod>2026-06-08T15:38:21.231Z</lastmod>
+    <lastmod>2026-06-17T16:22:00.104Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://extensionshield.com/blog/chrome-web-store-ratings-do-not-prove-extension-safety</loc>
-    <lastmod>2026-06-08T15:38:21.231Z</lastmod>
+    <lastmod>2026-06-17T16:22:00.104Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://extensionshield.com/blog/crxcavator-vs-extensionshield-2026</loc>
-    <lastmod>2026-06-08T15:38:21.231Z</lastmod>
+    <lastmod>2026-06-17T16:22:00.104Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://extensionshield.com/blog/crxplorer-vs-extensionshield</loc>
-    <lastmod>2026-06-08T15:38:21.231Z</lastmod>
+    <lastmod>2026-06-17T16:22:00.104Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://extensionshield.com/blog/dangerous-chrome-extension-permissions</loc>
-    <lastmod>2026-06-08T15:38:21.231Z</lastmod>
+    <lastmod>2026-06-17T16:22:00.104Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://extensionshield.com/blog/extension-auditor-vs-extensionshield</loc>
-    <lastmod>2026-06-08T15:38:21.231Z</lastmod>
+    <lastmod>2026-06-17T16:22:00.104Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://extensionshield.com/blog/extension-security-scoring-explained</loc>
-    <lastmod>2026-06-08T15:38:21.231Z</lastmod>
+    <lastmod>2026-06-17T16:22:00.104Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://extensionshield.com/blog/how-hackers-use-browser-extensions-to-steal-data</loc>
-    <lastmod>2026-06-08T15:38:21.231Z</lastmod>
+    <lastmod>2026-06-17T16:22:00.104Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://extensionshield.com/blog/how-to-check-if-chrome-extension-is-safe</loc>
-    <lastmod>2026-06-08T15:38:21.231Z</lastmod>
+    <lastmod>2026-06-17T16:22:00.104Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://extensionshield.com/blog/manifest-v3-extension-security</loc>
-    <lastmod>2026-06-08T15:38:21.231Z</lastmod>
+    <lastmod>2026-06-17T16:22:00.104Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://extensionshield.com/blog/read-and-change-all-your-data-extension-permission</loc>
-    <lastmod>2026-06-08T15:38:21.231Z</lastmod>
+    <lastmod>2026-06-17T16:22:00.104Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://extensionshield.com/blog/spin-ai-vs-extensionshield</loc>
-    <lastmod>2026-06-08T15:38:21.231Z</lastmod>
+    <lastmod>2026-06-17T16:22:00.104Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://extensionshield.com/blog/top-risky-chrome-extensions-2026</loc>
-    <lastmod>2026-06-08T15:38:21.231Z</lastmod>
+    <lastmod>2026-06-17T16:22:00.104Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://extensionshield.com/browser-extension-risk-assessment</loc>
-    <lastmod>2026-06-08T15:38:21.231Z</lastmod>
+    <lastmod>2026-06-17T16:22:00.104Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://extensionshield.com/careers</loc>
-    <lastmod>2026-06-08T15:38:21.231Z</lastmod>
+    <lastmod>2026-06-17T16:22:00.104Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://extensionshield.com/careers/apply</loc>
-    <lastmod>2026-06-08T15:38:21.231Z</lastmod>
+    <lastmod>2026-06-17T16:22:00.104Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://extensionshield.com/chrome-extension-permissions</loc>
-    <lastmod>2026-06-08T15:38:21.231Z</lastmod>
+    <lastmod>2026-06-17T16:22:00.104Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://extensionshield.com/chrome-extension-security-scanner</loc>
-    <lastmod>2026-06-08T15:38:21.231Z</lastmod>
+    <lastmod>2026-06-17T16:22:00.104Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://extensionshield.com/community</loc>
-    <lastmod>2026-06-08T15:38:21.231Z</lastmod>
+    <lastmod>2026-06-17T16:22:00.104Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://extensionshield.com/compare</loc>
-    <lastmod>2026-06-08T15:38:21.231Z</lastmod>
+    <lastmod>2026-06-17T16:22:00.104Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://extensionshield.com/compare/crxcavator</loc>
-    <lastmod>2026-06-08T15:38:21.231Z</lastmod>
+    <lastmod>2026-06-17T16:22:00.104Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://extensionshield.com/compare/crxplorer</loc>
-    <lastmod>2026-06-08T15:38:21.231Z</lastmod>
+    <lastmod>2026-06-17T16:22:00.104Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://extensionshield.com/compare/extension-auditor</loc>
-    <lastmod>2026-06-08T15:38:21.231Z</lastmod>
+    <lastmod>2026-06-17T16:22:00.104Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://extensionshield.com/compare/spin-ai</loc>
-    <lastmod>2026-06-08T15:38:21.231Z</lastmod>
+    <lastmod>2026-06-17T16:22:00.104Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://extensionshield.com/contribute</loc>
-    <lastmod>2026-06-08T15:38:21.231Z</lastmod>
+    <lastmod>2026-06-17T16:22:00.104Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://extensionshield.com/crxcavator-alternative</loc>
-    <lastmod>2026-06-08T15:38:21.231Z</lastmod>
+    <lastmod>2026-06-17T16:22:00.104Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://extensionshield.com/enterprise</loc>
-    <lastmod>2026-06-08T15:38:21.231Z</lastmod>
+    <lastmod>2026-06-17T16:22:00.104Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://extensionshield.com/extension-governance</loc>
-    <lastmod>2026-06-08T15:38:21.231Z</lastmod>
+    <lastmod>2026-06-17T16:22:00.104Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://extensionshield.com/extension-permissions</loc>
-    <lastmod>2026-06-08T15:38:21.231Z</lastmod>
+    <lastmod>2026-06-17T16:22:00.104Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://extensionshield.com/extension-risk-score</loc>
-    <lastmod>2026-06-08T15:38:21.231Z</lastmod>
+    <lastmod>2026-06-17T16:22:00.104Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://extensionshield.com/extension-security</loc>
-    <lastmod>2026-06-08T15:38:21.231Z</lastmod>
+    <lastmod>2026-06-17T16:22:00.104Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://extensionshield.com/free-extension-scanner</loc>
-    <lastmod>2026-06-08T15:38:21.231Z</lastmod>
+    <lastmod>2026-06-17T16:22:00.104Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://extensionshield.com/glossary</loc>
-    <lastmod>2026-06-08T15:38:21.231Z</lastmod>
+    <lastmod>2026-06-17T16:22:00.104Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://extensionshield.com/gsoc/ideas</loc>
-    <lastmod>2026-06-08T15:38:21.231Z</lastmod>
+    <lastmod>2026-06-17T16:22:00.104Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://extensionshield.com/is-this-chrome-extension-safe</loc>
-    <lastmod>2026-06-08T15:38:21.231Z</lastmod>
+    <lastmod>2026-06-17T16:22:00.104Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://extensionshield.com/open-source</loc>
-    <lastmod>2026-06-08T15:38:21.231Z</lastmod>
+    <lastmod>2026-06-17T16:22:00.104Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://extensionshield.com/open-source/programs</loc>
-    <lastmod>2026-06-08T15:38:21.231Z</lastmod>
+    <lastmod>2026-06-17T16:22:00.104Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://extensionshield.com/privacy-policy</loc>
-    <lastmod>2026-06-08T15:38:21.231Z</lastmod>
+    <lastmod>2026-06-17T16:22:00.104Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://extensionshield.com/research</loc>
-    <lastmod>2026-06-08T15:38:21.231Z</lastmod>
+    <lastmod>2026-06-17T16:22:00.104Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://extensionshield.com/research/benchmarks</loc>
-    <lastmod>2026-06-08T15:38:21.231Z</lastmod>
+    <lastmod>2026-06-17T16:22:00.104Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://extensionshield.com/research/case-studies</loc>
-    <lastmod>2026-06-08T15:38:21.231Z</lastmod>
+    <lastmod>2026-06-17T16:22:00.104Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://extensionshield.com/research/case-studies/fake-ad-blockers</loc>
-    <lastmod>2026-06-08T15:38:21.231Z</lastmod>
+    <lastmod>2026-06-17T16:22:00.104Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://extensionshield.com/research/case-studies/honey</loc>
-    <lastmod>2026-06-08T15:38:21.231Z</lastmod>
+    <lastmod>2026-06-17T16:22:00.104Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://extensionshield.com/research/case-studies/pdf-converters</loc>
-    <lastmod>2026-06-08T15:38:21.231Z</lastmod>
+    <lastmod>2026-06-17T16:22:00.104Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://extensionshield.com/research/methodology</loc>
-    <lastmod>2026-06-08T15:38:21.231Z</lastmod>
+    <lastmod>2026-06-17T16:22:00.104Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://extensionshield.com/scan</loc>
-    <lastmod>2026-06-08T15:38:21.231Z</lastmod>
+    <lastmod>2026-06-17T16:22:00.104Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://extensionshield.com/scan/history</loc>
-    <lastmod>2026-06-08T15:38:21.231Z</lastmod>
+    <lastmod>2026-06-17T16:22:00.104Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://extensionshield.com/scan/upload</loc>
-    <lastmod>2026-06-08T15:38:21.231Z</lastmod>
+    <lastmod>2026-06-17T16:22:00.104Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>

--- a/frontend/src/pages/AboutUsPage.jsx
+++ b/frontend/src/pages/AboutUsPage.jsx
@@ -4,13 +4,25 @@ import SEOHead from "../components/SEOHead";
 import stanImage from "../assets/stanzin.png";
 import "./AboutUsPage.scss";
 
+const FOUNDER_SCHEMA = {
+  "@context": "https://schema.org",
+  "@type": "Person",
+  "name": "Stanzin Norzang",
+  "jobTitle": "Founder & Engineer",
+  "sameAs": [
+    "https://github.com/Stanzin7",
+    "https://www.linkedin.com/in/stanzin-norzang7/"
+  ]
+};
+
 const AboutUsPage = () => {
   return (
     <>
       <SEOHead
-        title="About Us | ExtensionShield"
-        description="Learn about ExtensionShield's founder, Stanzin, and why this project was created to help users understand browser extension security."
+        title="Stanzin Norzang | Founder of ExtensionShield"
+        description="Stanzin Norzang is the founder of ExtensionShield, an open-source browser extension security scanner. He also co-founded Cherker, a Himalayan sea buckthorn brand from Ladakh."
         pathname="/about"
+        schema={FOUNDER_SCHEMA}
       />
 
       <div className="about-us-page">
@@ -19,7 +31,7 @@ const AboutUsPage = () => {
             <div className="profile-image-container">
               <img 
                 src={stanImage} 
-                alt="Stanzin - Founder of ExtensionShield"
+                alt="Stanzin Norzang - Founder of ExtensionShield"
                 className="profile-image"
                 onError={(e) => {
                   // Fallback to placeholder if image doesn't exist
@@ -38,7 +50,7 @@ const AboutUsPage = () => {
                 <span>ST</span>
               </div>
             </div>
-            <h1>Stanzin</h1>
+            <h1>Stanzin Norzang</h1>
             <p className="founder-title">Founder & Engineer</p>
           </div>
 
@@ -69,6 +81,24 @@ const AboutUsPage = () => {
               <h2>Background</h2>
               <p>
                 I got my start in open source (Google Summer of Code, Drupal), then worked on enterprise systems at Hanover Insurance—where security, privacy, and compliance aren't optional. That's how ExtensionShield ended up practical: less vibes, more evidence.
+              </p>
+            </div>
+
+            <div className="story-section">
+              <h2>Beyond ExtensionShield</h2>
+              <p>
+                I'm from Ladakh, India, and a big part of my work is about building useful products that connect technology, trust, and local economic growth.
+              </p>
+              <p>
+                Outside cybersecurity, I also co-founded{" "}
+                <a
+                  href="https://cherker.in/"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Cherker
+                </a>
+                , a Himalayan sea buckthorn brand from Ladakh focused on wild-grown sea buckthorn juice, tea, and wellness products sourced from the Himalayan region.
               </p>
             </div>
           </div>

--- a/frontend/src/routes/routes.jsx
+++ b/frontend/src/routes/routes.jsx
@@ -697,8 +697,8 @@ export const routes = [
     path: "/about",
     element: <AboutUsPage />,
     seo: {
-      title: "About Us | ExtensionShield",
-      description: "Learn about ExtensionShield's founder, Stanzin, and why this project was created to help users understand browser extension security.",
+      title: "Stanzin Norzang | Founder of ExtensionShield",
+      description: "Stanzin Norzang is the founder of ExtensionShield, an open-source browser extension security scanner. He also co-founded Cherker, a Himalayan sea buckthorn brand from Ladakh.",
       canonical: "/about"
     },
     priority: 0.7,


### PR DESCRIPTION
Adds a "Beyond ExtensionShield" section to the about page with a natural backlink to [Cherker](https://cherker.in/) and Person structured data for the founder.

## Changes
- New "Beyond ExtensionShield" section with clean `<a href="https://cherker.in/">` backlink — no `nofollow`, no keyword stuffing
- Person JSON-LD schema with `sameAs` pointing to GitHub and LinkedIn
- SEO title/description updated to surface "Stanzin Norzang" as a named entity
- H1 updated to full name for consistency with title and schema
- `routes.jsx` seo block synced with new title/description

## Schema fixes (from review)
- Removed `Person.founder` (not a valid Schema.org property on Person)
- Removed `cherker.in` from `sameAs` (brand homepage ≠ person identity page; causes entity conflation)
- Removed `og:type="profile"` (incomplete without `profile:*` namespace properties)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Enhanced About Us page with updated founder information and fuller biographical details.
  * Added new story section describing company origins and background in Ladakh region.
  * Improved SEO metadata for better search visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->