### PR TITLE
docs: correct ThreatXtension provenance and attribution wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ In **Cloud mode** you also get auth, scan history, telemetry, and enterprise fea
 
 ## **License & attribution**
 
-- **Core** (scanner, CLI, local analysis): **MIT** — see <a href="LICENSE" style="color:#2ea043;">LICENSE</a>; the core is derived in part from ThreatXtension — see <a href="docs/NOTICE" style="color:#2ea043;">NOTICE</a> for attribution  
+- **Core** (scanner, CLI, local analysis): **MIT** — see <a href="LICENSE" style="color:#2ea043;">LICENSE</a>. The core is derived from ThreatXtension (MIT per its upstream README); see <a href="docs/NOTICE" style="color:#2ea043;">NOTICE</a> for the full scope and license basis.  
 - **Cloud** (auth, Supabase, telemetry admin, community queue, enterprise forms): **proprietary**, available via <a href="https://extensionshield.com" style="color:#2ea043;">ExtensionShield Cloud</a>  
 
 ---
@@ -113,4 +113,4 @@ We build ExtensionShield in the open so security tools stay transparent and easy
 
 Feedback, issue reports, docs fixes, tests, and rule improvements are welcome. If ExtensionShield helps you, consider opening a PR, sharing your use case, or supporting the project.
 
-**Acknowledgments & attribution**: ExtensionShield began as a fork of <a href="https://github.com/barvhaim/ThreatXtension" style="color:#2ea043;">ThreatXtension</a> (MIT, declared in its upstream README) and builds substantially on its open-source scanner core — including the permissions database, sensitive-domains config, entropy analysis, and Semgrep malware rules. On top of that core, ExtensionShield adds original work: the governance engine, the V2 scoring engine, ExtensionShield Cloud, and an expanded frontend. See <a href="docs/NOTICE" style="color:#2ea043;">NOTICE</a> for the full scope of what is derived versus original.
+**Acknowledgments & attribution**: ExtensionShield began as a derivative of <a href="https://github.com/barvhaim/ThreatXtension" style="color:#2ea043;">ThreatXtension</a> — it started from ThreatXtension's open-source scanner codebase and still incorporates substantial parts of it (the permissions database, config, entropy analysis, the Semgrep ruleset, and parts of the scanner pipeline and scan-result schema). On top of that base it adds substantial original work: the V2 scoring engine, the governance layer, ExtensionShield Cloud, the browser extension, and a redesigned frontend. ThreatXtension's README declares MIT (no separate upstream LICENSE file is published). See <a href="docs/NOTICE" style="color:#2ea043;">NOTICE</a> for the file-level breakdown of what is derived versus original.

--- a/docs/NOTICE
+++ b/docs/NOTICE
@@ -8,28 +8,26 @@ This project is licensed under the MIT License. See the LICENSE file for the ful
 Third-party attributions
 -----------------------
 
-ExtensionShield is a derivative work. It began as a fork of ThreatXtension and
-retains substantial portions of that project's source code and data, alongside
-ideas, rules, and schema patterns adapted from it. The notes below describe what
-was carried over and on what license basis.
+ExtensionShield is a derivative work. It began as a copied and rebranded working
+tree of ThreatXtension (not a GitHub fork — the repositories share no git
+history) and retains substantial portions of that project's source code and
+data, alongside ideas, rules, and schemas adapted or ported from it. The notes
+below describe what was carried over and on what license basis.
 
 - ThreatXtension (https://github.com/barvhaim/ThreatXtension)
-  Authors: the ThreatXtension contributors (GitHub: barvhaim).
 
   License status (important):
   ThreatXtension's README declares the "MIT License" and links to a LICENSE
-  file, but the upstream repository does not actually publish a LICENSE file,
-  and GitHub reports its license as unspecified. There is therefore a
-  declared-but-unformalized MIT intent, with no upstream copyright-holder name
-  and no canonical license text to reproduce here. ExtensionShield relies in
-  good faith on that stated MIT intent. We note this as a residual risk: because
-  no formal grant or copyright line was published upstream, the permission is
-  weaker than a conventional MIT project, and exposure scales with the amount of
-  code reused (see scope below). We would replace this reliance with an explicit
-  grant if upstream formalizes a LICENSE or a maintainer requests changes.
+  file, but the upstream repository does not currently publish a separate
+  LICENSE file, and GitHub reports its license as unspecified. There is
+  therefore a declared-but-unformalized MIT intent, with no upstream
+  copyright-holder name and no canonical license text to reproduce here.
+  ExtensionShield relies in good faith on that stated MIT intent, and would
+  update this attribution to an explicit grant if upstream publishes a LICENSE
+  file or a maintainer requests changes.
 
   Scope of derivation (carried over, not merely "inspired by"):
-  The upstream Python package was forked and renamed (threatxtension ->
+  The upstream Python package was copied and renamed (threatxtension ->
   extension_shield). The following are reproduced verbatim or near-verbatim and
   remain present in this codebase:
 
@@ -49,10 +47,9 @@ was carried over and on what license basis.
         - src/extension_shield/cli/main.py
         - the mcp_server, api, and workflow layers
 
-      Where the file format allows comments, these files carry an in-file
-      provenance header pointing back to ThreatXtension and to this NOTICE; the
-      verbatim JSON data files (which cannot carry comments) are attributed
-      here.
+      Some carried-over source files include in-file provenance headers pointing
+      back to ThreatXtension and to this NOTICE; the verbatim JSON data files
+      (which cannot carry comments) are attributed here.
 
     * Security-score aggregation: the original risk-points-by-category logic
       originates from ThreatXtension. ExtensionShield additionally adds a V2
@@ -66,16 +63,21 @@ was carried over and on what license basis.
       tracking) were adapted from ThreatXtension's Semgrep ruleset; see the
       in-file section header.
 
-    * Supabase migration and schema files in supabase/migrations/ and
-      supabase/schemas/ were derived from ThreatXtension's SQLite schema (with
-      deliberate changes such as TEXT -> JSONB and timestamp text ->
-      timestamptz); see the per-file provenance comments.
+    * The scan_results and statistics Supabase schema/migration files in
+      supabase/schemas/ and supabase/migrations/ were ported from
+      ThreatXtension's SQLite schema (column names/order based on upstream, with
+      deliberate type changes such as TEXT -> JSONB and timestamp text ->
+      timestamptz); see the per-file provenance comments. Other Supabase tables
+      (e.g. page_views_daily) are ExtensionShield-original and are not part of
+      ThreatXtension's upstream schema.
 
   Work that is original to ExtensionShield (not derived from upstream) includes
   the V2 ScoringEngine and governance layers (extension_shield.scoring,
-  extension_shield.governance), the cloud/auth/telemetry API surface, and the
-  web frontend. ExtensionShield as a whole should nonetheless be understood as a
-  derivative of ThreatXtension, not an independent reimplementation.
+  extension_shield.governance), the cloud/auth/telemetry API surface
+  (ExtensionShield Cloud), the browser-extension package, and a substantially
+  redesigned frontend. ExtensionShield as a whole should nonetheless be
+  understood as a derivative of ThreatXtension, not an independent
+  reimplementation.
 
 Other dependencies are governed by their respective licenses; see
 pyproject.toml and frontend/package.json.

--- a/frontend/src/pages/research/MethodologyPage.jsx
+++ b/frontend/src/pages/research/MethodologyPage.jsx
@@ -17,7 +17,7 @@ const faqItems = [
   },
   {
     question: "What is ThreatXtension?",
-    answer: "ThreatXtension is an open-source (MIT) Chrome extension security scanner. ExtensionShield's Security (SAST) pipeline is built on it — adapting its Semgrep ruleset and category-based risk aggregation as a baseline — while ExtensionShield's V2 scoring engine and governance pipeline are our own work."
+    answer: "ThreatXtension is an open-source Chrome extension security scanner (MIT per its README; no separate upstream LICENSE file is published). ExtensionShield began as a derivative of ThreatXtension: our Security (SAST) pipeline builds on its Semgrep ruleset and category-based risk aggregation, while ExtensionShield's V2 scoring engine and governance pipeline are our own work."
   },
   {
     question: "What does the aggregate risk score mean?",
@@ -138,7 +138,7 @@ const MethodologyPage = () => {
                           <button
                             type="button"
                             className="pipeline-open-source-trigger"
-                            aria-label="Open source credit — built on ThreatXtension"
+                            aria-label="Open source credit — based on ThreatXtension"
                           >
                             <Info className="pipeline-open-source-trigger-icon" aria-hidden />
                           </button>
@@ -152,9 +152,10 @@ const MethodologyPage = () => {
                             </div>
                             <h3>Built on Open Source</h3>
                             <p>
-                              Pipeline 1 is our Security (SAST) pipeline. It builds on <strong>ThreatXtension</strong>,
-                              an open-source (MIT) Chrome extension security scanner: we adapted its Semgrep ruleset and
-                              risk-point aggregation as our baseline and extended it with ExtensionShield's own rules and V2 scoring.
+                              ExtensionShield began as a derivative of <strong>ThreatXtension</strong>
+                              (open-source, MIT per its README). Pipeline 1, our Security (SAST) pipeline, builds
+                              directly on its Semgrep ruleset and risk-point aggregation; the V2 scoring engine and
+                              governance pipeline are ExtensionShield's own.
                             </p>
                             <div className="credit-links">
                               <a href="https://github.com/barvhaim/ThreatXtension" target="_blank" rel="noopener noreferrer" className="credit-link">
@@ -170,7 +171,7 @@ const MethodologyPage = () => {
                     </div>
                     <h3>Security Analysis</h3>
                     <h4 className="tech-credit">
-                      Built on <a href="https://github.com/barvhaim/ThreatXtension" target="_blank" rel="noopener noreferrer">ThreatXtension</a> (MIT)
+                      Based on <a href="https://github.com/barvhaim/ThreatXtension" target="_blank" rel="noopener noreferrer">ThreatXtension</a> (MIT per its README)
                     </h4>
                     <p>Static application security testing (SAST) with custom Semgrep rules detecting malicious patterns, obfuscation, and data exfiltration.</p>
                     

--- a/src/extension_shield/config/custom_semgrep_rules.yaml
+++ b/src/extension_shield/config/custom_semgrep_rules.yaml
@@ -251,12 +251,12 @@ rules:
           navigator\.sendBeacon\s*\(\s*["']https?://[a-zA-Z0-9][a-zA-Z0-9.-]*\.[a-zA-Z]{2,}[^\s"\'`)]*["']
 
   ##########################################################################
-  # MALWARE-DETECTION RULES — adapted from ThreatXtension
-  # (MIT per upstream README; no LICENSE file is published upstream)
+  # MALWARE-DETECTION RULES — adapted from ThreatXtension's Semgrep ruleset.
+  # Substantially the upstream rule set, plus ExtensionShield additions.
+  # MIT per upstream README; no separate upstream LICENSE file is published.
   # Source: https://github.com/barvhaim/ThreatXtension
-  # Credential theft, cookie theft, C2/exfiltration, keylogger, clipboard,
-  # URL hijacking, and tracking. Adapted into the ExtensionShield ruleset
-  # after auditing coverage against the ThreatXtension baseline.
+  # Covers: credential theft, cookie theft, C2/exfiltration, keylogger,
+  # clipboard, URL hijacking, and tracking.
   # Attribution: see docs/NOTICE.
   ##########################################################################
   - id: credential.theft.storage_access

--- a/supabase/migrations/20260205000000_scan_results.sql
+++ b/supabase/migrations/20260205000000_scan_results.sql
@@ -1,6 +1,9 @@
 -- 001_scan_results.sql
 -- Global scan results cache (RLS enabled, no policies - backend uses service role).
--- Schema derived from the ThreatXtension SQLite schema (MIT per upstream README; no LICENSE file published upstream).
+-- Schema ported from the ThreatXtension SQLite schema.
+-- Column names/order are based on upstream, with Postgres/Supabase type changes.
+-- MIT per upstream README; no separate upstream LICENSE file is published.
+-- See docs/NOTICE.
 -- Note: JSON fields stored as JSONB in Supabase (better than TEXT in SQLite).
 
 create table if not exists public.scan_results (

--- a/supabase/migrations/20260205000003_page_views_daily.sql
+++ b/supabase/migrations/20260205000003_page_views_daily.sql
@@ -1,6 +1,6 @@
 -- 003_page_views_daily.sql
 -- Privacy-first analytics: daily page view counts (no PII, no user_id).
--- Schema derived from the ThreatXtension SQLite schema (MIT per upstream README; no LICENSE file published upstream).
+-- ExtensionShield-original table; not part of ThreatXtension's upstream SQLite schema (which defines only scan_results and statistics).
 
 create table if not exists public.page_views_daily (
   day text not null,

--- a/supabase/migrations/20260205000005_statistics.sql
+++ b/supabase/migrations/20260205000005_statistics.sql
@@ -1,6 +1,9 @@
 -- 004_statistics.sql
 -- Statistics table for aggregated metrics.
--- Schema derived from the ThreatXtension SQLite schema (MIT per upstream README; no LICENSE file published upstream).
+-- Schema ported from the ThreatXtension SQLite schema.
+-- Column names/order are based on upstream, with Postgres/Supabase type changes.
+-- MIT per upstream README; no separate upstream LICENSE file is published.
+-- See docs/NOTICE.
 
 create table if not exists public.statistics (
   id bigserial primary key,

--- a/supabase/schemas/analytics.sql
+++ b/supabase/schemas/analytics.sql
@@ -1,5 +1,5 @@
 -- Privacy-first analytics: daily page view counts (no PII, no user_id).
--- Schema derived from the ThreatXtension SQLite schema (MIT per upstream README; no LICENSE file published upstream).
+-- ExtensionShield-original table; not part of ThreatXtension's upstream SQLite schema (which defines only scan_results and statistics).
 
 create table "public"."page_views_daily" (
   "day" text not null,

--- a/supabase/schemas/scan_results.sql
+++ b/supabase/schemas/scan_results.sql
@@ -1,5 +1,8 @@
 -- Global scan results cache (RLS enabled, no policies - backend uses service role).
--- Schema derived from the ThreatXtension SQLite schema (MIT per upstream README; no LICENSE file published upstream).
+-- Schema ported from the ThreatXtension SQLite schema.
+-- Column names/order are based on upstream, with Postgres/Supabase type changes.
+-- MIT per upstream README; no separate upstream LICENSE file is published.
+-- See docs/NOTICE.
 -- Note: JSON fields stored as JSONB in Supabase (better than TEXT in SQLite).
 
 create table "public"."scan_results" (

--- a/supabase/schemas/statistics.sql
+++ b/supabase/schemas/statistics.sql
@@ -1,5 +1,8 @@
 -- Statistics table for aggregated metrics.
--- Schema derived from the ThreatXtension SQLite schema (MIT per upstream README; no LICENSE file published upstream).
+-- Schema ported from the ThreatXtension SQLite schema.
+-- Column names/order are based on upstream, with Postgres/Supabase type changes.
+-- MIT per upstream README; no separate upstream LICENSE file is published.
+-- See docs/NOTICE.
 
 create table "public"."statistics" (
   "id" bigserial primary key,


### PR DESCRIPTION
ExtensionShield began as a derivative of ThreatXtension. This PR corrects the public attribution wording so it is accurate and consistent across public docs and provenance comments.

## What changed

- README — the core is described as `derived from ThreatXtension`; acknowledgments now say ExtensionShield `began as a derivative of` ThreatXtension and point readers to `NOTICE`.
- `docs/NOTICE` — keeps the detailed record: copied and rebranded working tree, not a GitHub fork, file-level derived-vs-original scope, and the `MIT per upstream README` / no separate upstream `LICENSE` file caveat.
- `MethodologyPage` — now matches the README register.

Docs-only change; no code or behavior changes.