### PR TITLE
Fix recent-scan verdict mismatch, rescan stale scans, order by last scan

### DIFF
--- a/src/extension_shield/api/database.py
+++ b/src/extension_shield/api/database.py
@@ -785,7 +785,7 @@ class Database:
                             WHEN extension_id LIKE ? THEN 3
                             ELSE 4
                           END,
-                          COALESCE(updated_at, timestamp) DESC
+                          COALESCE(timestamp, updated_at) DESC
                         LIMIT ?
                     """,
                         (term, term, term_raw, term_raw, term_raw, term, limit),
@@ -804,7 +804,7 @@ class Database:
                         FROM scan_results
                         WHERE status = 'completed'
                           """ + visibility_filter + """
-                        ORDER BY COALESCE(updated_at, timestamp) DESC
+                        ORDER BY COALESCE(timestamp, updated_at) DESC
                         LIMIT ?
                     """,
                         (limit,),
@@ -1509,14 +1509,17 @@ class SupabaseDatabase:
             )
             if not include_all:
                 q = q.or_("visibility.is.null,visibility.eq.public").or_("source.is.null,source.eq.webstore")
-            q = q.order("updated_at", desc=True)
+            # Order by actual last-scan time so a re-scanned extension moves to the
+            # top; incidental updated_at bumps (report views, metadata refresh, batch
+            # scripts) must not reorder the "recently scanned" list.
+            q = q.order("scanned_at", desc=True)
             if search and search.strip():
                 term = _escape_postgrest_like_term(search.strip())
                 q = q.or_(f"extension_name.ilike.%{term}%,extension_id.ilike.%{term}%")
             resp = q.limit(limit_fetch).execute()
             rows = getattr(resp, "data", None) or []
 
-            # Rank by relevance when search is present: exact title > title starts with > title contains > id contains; then recency (query already ordered by updated_at)
+            # Rank by relevance when search is present: exact title > title starts with > title contains > id contains; then recency (query already ordered by scanned_at)
             if search and search.strip():
                 term = search.strip()
                 rows = sorted(rows, key=lambda r: _relevance_rank(r.get("extension_name"), r.get("extension_id"), term))[:limit]
@@ -1561,7 +1564,7 @@ class SupabaseDatabase:
                         self.client.table(self.table_scan_results)
                         .select(select_cols)
                         .eq("status", "completed")
-                        .order("updated_at", desc=True)
+                        .order("scanned_at", desc=True)  # actual last-scan time (see main branch)
                     )
                     if search and search.strip():
                         term = _escape_postgrest_like_term(search.strip())

--- a/src/extension_shield/api/main.py
+++ b/src/extension_shield/api/main.py
@@ -56,6 +56,7 @@ from extension_shield.api.payload_helpers import (
     ensure_description_in_meta,
     ensure_name_in_payload,
     log_scan_results_return_shape,
+    refresh_governance_decision,
     upgrade_legacy_payload,
 )
 from extension_shield.governance.tool_adapters import SignalPackBuilder
@@ -418,6 +419,19 @@ _health_start_time = datetime.now(timezone.utc)
 # -----------------------------------------------------------------------------
 DAILY_DEEP_SCAN_LIMIT = 3  # authenticated users
 ANONYMOUS_DAILY_DEEP_SCAN_LIMIT = 1  # anonymous (IP-based) users – after 1 scan, prompt login
+
+# -----------------------------------------------------------------------------
+# Scan freshness cutoff
+# -----------------------------------------------------------------------------
+# Scans completed before this instant predate the 2026-07-07 scoring/decision
+# recalibration (#257: ScoringEngine 2.0.0 -> 2.1.0 + the governance decision
+# self-heal). Serving them from cache would show pre-recalibration scores and
+# verdicts, so /api/scan/trigger treats any cached scan older than the cutoff as
+# stale and runs a fresh deep scan. This is version-agnostic: it also catches
+# legacy rows that carry no scoring_version (which the model-version gate cannot
+# see). Override with the SCAN_FRESHNESS_CUTOFF env var (ISO-8601); set it to an
+# empty string to disable the timestamp gate (the version gates still apply).
+_DEFAULT_SCAN_FRESHNESS_CUTOFF = "2026-07-08T01:37:14+00:00"  # #257 ship instant (UTC)
 # deep_scan_usage[user_id][YYYY-MM-DD] = used_count
 deep_scan_usage: Dict[str, Dict[str, int]] = {}
 # Lock to prevent race conditions when multiple concurrent requests check/increment the same counter
@@ -660,6 +674,90 @@ def _fast_live_version_check(extension_id: str, timeout_seconds: float = 2.0) ->
     except Exception as exc:
         logger.debug("[CACHED_PATH] Fast version check failed for %s: %s", extension_id, exc)
     return None
+
+
+def _as_utc(dt: Optional[datetime]) -> Optional[datetime]:
+    """Normalize a datetime to an aware UTC value (assume UTC when naive)."""
+    if dt is None:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
+def _get_scan_freshness_cutoff() -> Optional[datetime]:
+    """Resolve the configured scan-freshness cutoff as an aware UTC datetime.
+
+    Reads SCAN_FRESHNESS_CUTOFF (ISO-8601) with the ship-instant default. An
+    empty value disables the timestamp gate; an invalid value is ignored (logged)
+    so a bad env var never silently rescans everything.
+    """
+    raw = os.getenv("SCAN_FRESHNESS_CUTOFF", _DEFAULT_SCAN_FRESHNESS_CUTOFF)
+    raw = raw.strip() if isinstance(raw, str) else ""
+    if not raw:
+        return None
+    cutoff = _as_utc(_parse_iso_datetime(raw))
+    if cutoff is None:
+        logger.warning(
+            "[FRESHNESS] Invalid SCAN_FRESHNESS_CUTOFF=%r; timestamp rescan gate disabled",
+            raw,
+        )
+    return cutoff
+
+
+def _scan_payload_time(payload: Dict[str, Any]) -> Optional[datetime]:
+    """Best-effort last-scan time from a cached scan payload, as aware UTC.
+
+    Both DB backends normalize their scan time onto ``timestamp`` (Supabase maps
+    scanned_at; SQLite has a native column) and in-memory payloads stamp an ISO
+    ``timestamp`` at completion — the extra keys are defensive fallbacks.
+    """
+    if not isinstance(payload, dict):
+        return None
+    for key in ("timestamp", "scanned_at", "updated_at", "last_scanned", "created_at"):
+        dt = _as_utc(_parse_iso_datetime(payload.get(key)))
+        if dt is not None:
+            return dt
+    return None
+
+
+def _scan_predates_freshness_cutoff(payload: Dict[str, Any]) -> bool:
+    """True when a cached scan is older than the configured freshness cutoff.
+
+    Unknown/unparseable scan times return False (the version gates still apply) so
+    we never trigger a rescan storm on rows we cannot reliably date.
+    """
+    cutoff = _get_scan_freshness_cutoff()
+    if cutoff is None:
+        return False
+    scanned = _scan_payload_time(payload)
+    if scanned is None:
+        return False
+    return scanned < cutoff
+
+
+# Best-effort in-process cooldown. When a staleness-driven refresh FAILS we keep the
+# prior good report, but that report keeps its original (pre-cutoff) scan time and
+# would otherwise re-trigger a rescan on every subsequent lookup. Recording the failed
+# attempt lets the gate serve the cached report for a cooldown window instead of
+# rescanning an unfetchable/delisted extension endlessly. Per-process and cleared on
+# restart — purely a resource guard, never affects correctness of what is served.
+_FAILED_REFRESH_COOLDOWN = timedelta(hours=6)
+_failed_refresh_at: Dict[str, datetime] = {}
+
+
+def _note_failed_refresh(extension_id: str) -> None:
+    try:
+        _failed_refresh_at[extension_id] = datetime.now(timezone.utc)
+    except Exception:
+        pass
+
+
+def _in_failed_refresh_cooldown(extension_id: str) -> bool:
+    last = _failed_refresh_at.get(extension_id)
+    if last is None:
+        return False
+    return (datetime.now(timezone.utc) - last) < _FAILED_REFRESH_COOLDOWN
 
 
 def _hydrate_db_scan_result(results: Dict[str, Any], identifier: str) -> Dict[str, Any]:
@@ -1412,6 +1510,56 @@ def _find_icon_path_on_disk(
     return None
 
 
+def _persist_scan_failure(extension_id: str, failed_payload: Dict[str, Any]) -> None:
+    """Record a scan failure WITHOUT destroying a previously-good cached report.
+
+    A staleness-driven rescan (the "Safe forced rescan" path) of an extension that
+    has since become unfetchable — delisted, region-blocked, or a transient download
+    error — must not replace a good ``completed`` report with a score-0 ``failed``
+    placeholder. When a prior completed result exists (DB first, then memory), we
+    keep it and leave the status ``completed`` so users still see the last good
+    report; only when there is no prior good result do we store the failure.
+    """
+    prior_good = False
+    try:
+        row = db.get_scan_result(extension_id)
+        if isinstance(row, dict) and str(row.get("status")) == "completed":
+            prior_good = True
+    except Exception:
+        prior_good = False
+    if not prior_good:
+        mem = scan_results.get(extension_id)
+        if isinstance(mem, dict) and str(mem.get("status")) == "completed" and not mem.get("error"):
+            prior_good = True
+
+    if prior_good:
+        logger.warning(
+            "[SCAN_FAILURE] Rescan failed for %s; preserving previous good result "
+            "(not overwriting with a failed placeholder).",
+            extension_id,
+        )
+        # Drop any transient in-memory failed payload so the next GET reloads the
+        # good row from the DB; the last good report remains the served result.
+        scan_results.pop(extension_id, None)
+        scan_status[extension_id] = "completed"
+        # The preserved report keeps its (possibly pre-cutoff) scan time, so record
+        # this failed attempt to suppress endless re-rescans of an unfetchable ext.
+        _note_failed_refresh(extension_id)
+        return
+
+    scan_results[extension_id] = failed_payload
+    scan_status[extension_id] = "failed"
+    try:
+        db.save_scan_result(failed_payload)
+        logger.info("[TIMELINE] saved failed scan to database → extension_id=%s", extension_id)
+    except Exception as save_err:
+        logger.warning(
+            "[TIMELINE] failed to save failed scan to database → extension_id=%s, error=%s",
+            extension_id,
+            save_err,
+        )
+
+
 async def run_analysis_workflow(url: str, extension_id: str):
     """Run the analysis workflow in the background."""
     workflow_start = datetime.now()
@@ -1679,12 +1827,9 @@ async def run_analysis_workflow(url: str, extension_id: str):
                 "risk_distribution": {"high": 0, "medium": 0, "low": 0},
                 "timestamp": datetime.now(timezone.utc).isoformat(),
             }
-            scan_results[extension_id] = failed_payload
-            try:
-                db.save_scan_result(failed_payload)
-                logger.info("[TIMELINE] saved failed scan to database → extension_id=%s", extension_id)
-            except Exception as save_err:
-                logger.warning("[TIMELINE] failed to save failed scan to database → extension_id=%s, error=%s", extension_id, save_err)
+            # Preserve a previously-good report instead of clobbering it with a
+            # failed placeholder (matters for staleness rescans of delisted exts).
+            _persist_scan_failure(extension_id, failed_payload)
 
     except Exception as e:
         scan_status[extension_id] = "failed"
@@ -1726,7 +1871,9 @@ async def run_analysis_workflow(url: str, extension_id: str):
         else:
             logger.error("[WORKFLOW] Unknown error: %s", error_str)
         
-        scan_results[extension_id] = {
+        # Preserve a previously-good report instead of clobbering it with a failed
+        # placeholder (matters for staleness rescans of now-unfetchable extensions).
+        _persist_scan_failure(extension_id, {
             "extension_id": extension_id,
             "extension_name": extension_id,
             "url": url,
@@ -1740,12 +1887,7 @@ async def run_analysis_workflow(url: str, extension_id: str):
             "total_findings": 0,
             "risk_distribution": {"high": 0, "medium": 0, "low": 0},
             "timestamp": datetime.now(timezone.utc).isoformat(),
-        }
-        try:
-            db.save_scan_result(scan_results[extension_id])
-            logger.info("[TIMELINE] saved failed scan to database → extension_id=%s", extension_id)
-        except Exception as save_err:
-            logger.warning("[TIMELINE] failed to save failed scan to database → extension_id=%s, error=%s", extension_id, save_err)
+        })
 
 
 def get_extracted_files(extracted_path: Optional[str]) -> list[str]:
@@ -2356,6 +2498,12 @@ async def trigger_scan(scan_request: ScanRequest, background_tasks: BackgroundTa
         except Exception:
             cached_payload = None
 
+    # True when we fall through to a rescan only because an EXISTING cached scan is
+    # stale (store version / scoring model / freshness cutoff) rather than because
+    # the user asked for a brand-new scan. A staleness refresh is system-initiated:
+    # it must not spend the user's daily quota or 429 them on what was a cached lookup.
+    system_refresh = False
+
     # If we already have results, use a fast version check only (no blocking store refresh)
     # so cached lookups return immediately. Full store refresh runs on GET when needed.
     if cached_payload:
@@ -2381,6 +2529,13 @@ async def trigger_scan(scan_request: ScanRequest, background_tasks: BackgroundTa
             and cached_scoring_version != ScoringEngine.VERSION
         )
 
+        # Freshness-cutoff rescan: any scan completed before the recalibration
+        # cutoff predates the current scoring/decision logic and must be rescanned
+        # so users never see pre-change results (catches legacy rows with no
+        # scoring_version, which model_stale cannot detect). See
+        # _DEFAULT_SCAN_FRESHNESS_CUTOFF / SCAN_FRESHNESS_CUTOFF.
+        cutoff_stale = _scan_predates_freshness_cutoff(cached_payload)
+
         # Temporary force-rescan: honored only in dev, or with a matching admin
         # token header. Never for anonymous prod callers (prevents abuse).
         force_requested = bool(getattr(scan_request, "force", False))
@@ -2394,7 +2549,13 @@ async def trigger_scan(scan_request: ScanRequest, background_tasks: BackgroundTa
         if force_requested and not force_allowed:
             logger.info("[FORCE_RESCAN] force ignored for %s (not permitted in this environment)", extension_id)
 
-        if (not version_changed) and (not model_stale) and (not force_allowed):
+        stale = version_changed or model_stale or cutoff_stale
+        # Suppress a staleness rescan when we recently tried and failed to refresh
+        # this extension (its preserved good report is still pre-cutoff) — serve the
+        # cached report instead of rescanning an unfetchable extension on every lookup.
+        suppressed_by_cooldown = stale and not force_allowed and _in_failed_refresh_cooldown(extension_id)
+
+        if (not stale or suppressed_by_cooldown) and (not force_allowed):
             # Bump extension to top of recent scans (for both auth and anonymous users)
             try:
                 db.touch_scan_result(extension_id)
@@ -2409,8 +2570,8 @@ async def trigger_scan(scan_request: ScanRequest, background_tasks: BackgroundTa
                     pass
             scan_status[extension_id] = "completed"
             logger.info(
-                "[CACHED_PATH] Returning cached results for %s (no version change)",
-                extension_id,
+                "[CACHED_PATH] Returning cached results for %s (stale=%s, suppressed_by_cooldown=%s)",
+                extension_id, stale, suppressed_by_cooldown,
             )
             return {
                 "message": "Cached results available",
@@ -2419,9 +2580,12 @@ async def trigger_scan(scan_request: ScanRequest, background_tasks: BackgroundTa
                 "already_scanned": True,
                 "scan_type": "lookup",
             }
+        # Staleness-driven refresh of an existing cached scan (not an admin force):
+        # system-initiated, so it is exempt from the daily limit / credit consumption.
+        system_refresh = stale and not force_allowed
         logger.info(
-            "[CACHED_PATH] Rescan for %s (version_changed=%s, model_stale=%s [%s->%s], force=%s); starting deep rescan",
-            extension_id, version_changed, model_stale, cached_scoring_version, ScoringEngine.VERSION, force_allowed,
+            "[CACHED_PATH] Rescan for %s (version_changed=%s, model_stale=%s [%s->%s], cutoff_stale=%s, force=%s, system_refresh=%s); starting deep rescan",
+            extension_id, version_changed, model_stale, cached_scoring_version, ScoringEngine.VERSION, cutoff_stale, force_allowed, system_refresh,
         )
         logger.info(
             "[CACHED_PATH] Version change detected for %s (%s -> %s); starting deep rescan",
@@ -2430,25 +2594,37 @@ async def trigger_scan(scan_request: ScanRequest, background_tasks: BackgroundTa
             live_version,
         )
     elif _has_cached_results(extension_id):
-        # File-only fallback: we know we have cached results but cannot safely inspect version.
-        try:
-            db.touch_scan_result(extension_id)
-        except Exception:
-            pass
-        user_id = getattr(getattr(request, "state", None), "user_id", None)
-        if user_id:
+        # File-only / uninspectable fallback: results exist but we could not load a
+        # payload above to check store version or scoring freshness. When the freshness
+        # gate is enabled we cannot prove this row is post-recalibration, so fall
+        # through to a system refresh (free, non-destructive) rather than serving
+        # possibly-stale data; when the gate is disabled, keep the legacy instant-cached
+        # behavior.
+        if _get_scan_freshness_cutoff() is not None:
+            system_refresh = True
+            logger.info(
+                "[CACHED_PATH] Uninspectable cached results for %s; freshness gate on → system refresh",
+                extension_id,
+            )
+        else:
             try:
-                db.add_user_scan_history(user_id=user_id, extension_id=extension_id)
+                db.touch_scan_result(extension_id)
             except Exception:
                 pass
-        scan_status[extension_id] = "completed"
-        return {
-            "message": "Cached results available",
-            "extension_id": extension_id,
-            "status": "completed",
-            "already_scanned": True,
-            "scan_type": "lookup",
-        }
+            user_id = getattr(getattr(request, "state", None), "user_id", None)
+            if user_id:
+                try:
+                    db.add_user_scan_history(user_id=user_id, extension_id=extension_id)
+                except Exception:
+                    pass
+            scan_status[extension_id] = "completed"
+            return {
+                "message": "Cached results available",
+                "extension_id": extension_id,
+                "status": "completed",
+                "already_scanned": True,
+                "scan_type": "lookup",
+            }
 
     # Check if already scanning
     if extension_id in scan_status and scan_status[extension_id] == "running":
@@ -2466,24 +2642,30 @@ async def trigger_scan(scan_request: ScanRequest, background_tasks: BackgroundTa
     # Enforce daily deep-scan limit - skip in development
     # Uses rate_limit_key (user_id for authenticated users, IP for anonymous)
     is_anonymous = rate_limit_key.startswith("ip:")
-    if settings.is_prod():
-        limit_status = _deep_scan_limit_status(rate_limit_key)
-        if limit_status["remaining"] <= 0:
-            limit_num = limit_status.get("limit", 1)
-            scans_word = "scan" if limit_num == 1 else "scans"
-            raise HTTPException(
-                status_code=429,
-                detail={
-                    "error_code": "DAILY_DEEP_SCAN_LIMIT",
-                    "message": f"You've reached your daily scan limit ({limit_num} {scans_word}). Sign in to get more scans or try again tomorrow.",
-                    "is_anonymous": is_anonymous,
-                    "requires_login": is_anonymous,
-                    **limit_status,
-                },
-            )
+    if system_refresh:
+        # System-initiated staleness refresh of an already-cached scan: the user did
+        # not request a new scan, so it neither counts against nor consumes the daily
+        # deep-scan quota. Report current usage without decrementing.
+        after_consume = _deep_scan_limit_status(rate_limit_key)
+    else:
+        if settings.is_prod():
+            limit_status = _deep_scan_limit_status(rate_limit_key)
+            if limit_status["remaining"] <= 0:
+                limit_num = limit_status.get("limit", 1)
+                scans_word = "scan" if limit_num == 1 else "scans"
+                raise HTTPException(
+                    status_code=429,
+                    detail={
+                        "error_code": "DAILY_DEEP_SCAN_LIMIT",
+                        "message": f"You've reached your daily scan limit ({limit_num} {scans_word}). Sign in to get more scans or try again tomorrow.",
+                        "is_anonymous": is_anonymous,
+                        "requires_login": is_anonymous,
+                        **limit_status,
+                    },
+                )
 
-    # Consume one deep scan since we are starting a new analysis run
-    after_consume = _consume_deep_scan(rate_limit_key)
+        # Consume one deep scan since we are starting a new analysis run
+        after_consume = _consume_deep_scan(rate_limit_key)
 
     # Start background analysis
     scan_user_ids[extension_id] = getattr(getattr(request, "state", None), "user_id", None)
@@ -3411,6 +3593,7 @@ async def get_recent_scans(limit: int = 10, search: str = None):
         # If legacy recent rows are missing layer scores, backfill from full scan result dynamically.
         for scan in recent:
             try:
+                _refresh_recent_scan_verdict(scan)
                 mapping = _extract_risk_and_signals(scan)
                 signals = mapping.get("signals", {})
                 missing_layers = any(k not in signals for k in ("security", "privacy", "gov"))
@@ -3442,6 +3625,38 @@ async def get_recent_scans(limit: int = 10, search: str = None):
     except Exception as e:
         logger.error(f"[get_recent_scans] Error fetching recent scans: {e}", exc_info=True)
         return {"recent": [], "db_backend": db_backend}
+
+
+def _refresh_recent_scan_verdict(scan: Dict[str, Any]) -> bool:
+    """Keep recent-row verdicts aligned with the scan-results detail endpoint.
+
+    Never raises: a verdict-refresh failure (or a malformed/legacy governance_bundle
+    that is not a dict) must not bubble up and blank the row's risk/signals — the
+    caller only wants an aligned verdict, best-effort.
+    """
+    if not isinstance(scan, dict):
+        return False
+
+    try:
+        changed = refresh_governance_decision(scan)
+    except Exception as exc:  # malformed persisted bundle — degrade, don't crash the row
+        logger.warning(
+            "[recent] governance verdict refresh failed for %s: %s",
+            scan.get("extension_id"),
+            exc,
+        )
+        changed = False
+
+    gb = scan.get("governance_bundle")
+    decision = gb.get("decision") if isinstance(gb, dict) else None
+    final_verdict = decision.get("final_verdict") if isinstance(decision, dict) else None
+    if final_verdict:
+        scan["final_verdict"] = final_verdict
+        scan["governance_verdict"] = final_verdict
+        summary = scan.get("summary")
+        if isinstance(summary, dict):
+            summary["governance_verdict"] = final_verdict
+    return changed
 
 
 @app.get("/api/diagnostic/scans", dependencies=[require_cloud_dep("telemetry")])

--- a/tests/api/test_governance_decision_selfheal.py
+++ b/tests/api/test_governance_decision_selfheal.py
@@ -87,3 +87,35 @@ def test_missing_inputs_leaves_verdict_untouched():
 def test_no_governance_bundle_is_noop():
     assert refresh_governance_decision({"extension_id": "x"}) is False
     assert refresh_governance_decision(None) is False
+
+
+def test_recent_scan_refresh_exposes_current_final_verdict(monkeypatch):
+    """Recent rows must use the same refreshed final verdict as detail pages."""
+    from extension_shield.api import main
+
+    scan = {
+        "extension_id": "recentrowextensionidxxxxxxxxxxxx",
+        "final_verdict": "NEEDS_REVIEW",
+        "governance_verdict": "NEEDS_REVIEW",
+        "summary": {
+            "governance_bundle": {
+                "decision": {"final_verdict": "NEEDS_REVIEW"},
+            },
+        },
+    }
+    scan["governance_bundle"] = scan["summary"]["governance_bundle"]
+
+    def fake_refresh(payload):
+        payload["governance_bundle"]["decision"]["final_verdict"] = "ALLOW"
+        payload["governance_bundle"]["decision"]["decision_version"] = DECISION_VERSION
+        return True
+
+    monkeypatch.setattr(main, "refresh_governance_decision", fake_refresh)
+
+    changed = main._refresh_recent_scan_verdict(scan)
+
+    assert changed is True
+    assert scan["final_verdict"] == "ALLOW"
+    assert scan["governance_verdict"] == "ALLOW"
+    assert scan["summary"]["governance_verdict"] == "ALLOW"
+    assert scan["summary"]["governance_bundle"]["decision"]["final_verdict"] == "ALLOW"

--- a/tests/api/test_recent_scans_ordering.py
+++ b/tests/api/test_recent_scans_ordering.py
@@ -1,0 +1,49 @@
+"""Recent scans must be ordered by ACTUAL last-scan time, not updated_at.
+
+A re-scanned extension (newer scan timestamp) must appear above one that was
+merely touched/refreshed more recently (newer updated_at but older scan time).
+This guards against reverting the ORDER BY to updated_at, which let non-scan
+events (report views, metadata refresh, batch scripts) reorder the list.
+"""
+from extension_shield.api.database import Database
+
+
+def _completed(ext_id, name, timestamp):
+    return {
+        "extension_id": ext_id,
+        "extension_name": name,
+        "url": f"https://chromewebstore.google.com/detail/{name}/{ext_id}",
+        "timestamp": timestamp,        # actual scan time -> scanned_at / timestamp col
+        "status": "completed",
+        "overall_security_score": 80,
+        "overall_risk": "low",
+        "total_findings": 0,
+    }
+
+
+def test_recent_ordered_by_scan_time_not_updated_at(tmp_path):
+    db = Database(db_path=str(tmp_path / "order.db"))
+
+    # 'older_scan' is scanned earlier; 'newer_scan' is scanned later.
+    db.save_scan_result(_completed("a" * 32, "older-scan", "2026-06-01T00:00:00+00:00"))
+    db.save_scan_result(_completed("b" * 32, "newer-scan", "2026-06-10T00:00:00+00:00"))
+
+    # Now bump the OLDER-scanned row's updated_at to "just now" (simulates a report
+    # view / metadata refresh / batch script touch — NOT a re-scan).
+    db.touch_scan_result("a" * 32)
+
+    names = [r["extension_name"] for r in db.get_recent_scans(limit=10)]
+    # Scan time wins: the more-recently-SCANNED extension is on top, even though the
+    # other one has a fresher updated_at.
+    assert names.index("newer-scan") < names.index("older-scan")
+
+
+def test_rescan_moves_extension_to_top(tmp_path):
+    db = Database(db_path=str(tmp_path / "rescan.db"))
+    db.save_scan_result(_completed("a" * 32, "ext-a", "2026-06-01T00:00:00+00:00"))
+    db.save_scan_result(_completed("b" * 32, "ext-b", "2026-06-02T00:00:00+00:00"))
+    assert db.get_recent_scans(limit=10)[0]["extension_name"] == "ext-b"
+
+    # Re-scan ext-a with a newer scan time -> it must jump to the top.
+    db.save_scan_result(_completed("a" * 32, "ext-a", "2026-06-05T00:00:00+00:00"))
+    assert db.get_recent_scans(limit=10)[0]["extension_name"] == "ext-a"

--- a/tests/api/test_scan_freshness_cutoff.py
+++ b/tests/api/test_scan_freshness_cutoff.py
@@ -1,0 +1,95 @@
+"""/api/scan/trigger must re-scan (not serve from cache) any scan that predates
+the 2026-07-07 scoring/decision recalibration.
+
+The cached path already re-scans on a store-version change or a stale
+scoring_version. Those gates miss scans whose scoring_version is absent (very old
+rows) or whose only stale field is the independently-versioned governance
+decision. The freshness-cutoff gate closes that gap: any cached scan whose scan
+time is before SCAN_FRESHNESS_CUTOFF is treated as stale and deep-rescanned, so
+users never see pre-recalibration results.
+"""
+import importlib
+
+import pytest
+
+main = importlib.import_module("extension_shield.api.main")
+
+# A fixed, unambiguous cutoff used by every test so results never depend on the
+# shipped default constant.
+CUTOFF = "2026-07-08T00:00:00+00:00"
+
+
+@pytest.fixture(autouse=True)
+def _pin_cutoff(monkeypatch):
+    monkeypatch.setenv("SCAN_FRESHNESS_CUTOFF", CUTOFF)
+
+
+def test_scan_before_cutoff_is_stale():
+    payload = {"extension_id": "x" * 32, "timestamp": "2026-07-05T12:00:00+00:00"}
+    assert main._scan_predates_freshness_cutoff(payload) is True
+
+
+def test_scan_after_cutoff_is_fresh():
+    payload = {"extension_id": "x" * 32, "timestamp": "2026-07-09T12:00:00+00:00"}
+    assert main._scan_predates_freshness_cutoff(payload) is False
+
+
+def test_scan_exactly_at_cutoff_is_fresh():
+    # Strictly-before is stale; the cutoff instant itself is current.
+    payload = {"extension_id": "x" * 32, "timestamp": CUTOFF}
+    assert main._scan_predates_freshness_cutoff(payload) is False
+
+
+def test_zulu_suffix_is_parsed():
+    payload = {"extension_id": "x" * 32, "timestamp": "2026-07-05T12:00:00Z"}
+    assert main._scan_predates_freshness_cutoff(payload) is True
+
+
+def test_naive_timestamp_treated_as_utc():
+    payload = {"extension_id": "x" * 32, "timestamp": "2026-07-05T12:00:00"}
+    assert main._scan_predates_freshness_cutoff(payload) is True
+
+
+def test_supabase_style_scanned_at_fallback():
+    # No top-level "timestamp"; falls back to scanned_at.
+    payload = {"extension_id": "x" * 32, "scanned_at": "2026-07-01T00:00:00+00:00"}
+    assert main._scan_predates_freshness_cutoff(payload) is True
+
+
+def test_missing_timestamp_is_not_stale():
+    # Unknown scan time must NOT force a rescan (avoids a rescan storm); the
+    # version gates still apply on their own.
+    assert main._scan_predates_freshness_cutoff({"extension_id": "x" * 32}) is False
+
+
+def test_unparseable_timestamp_is_not_stale():
+    payload = {"extension_id": "x" * 32, "timestamp": "not-a-date"}
+    assert main._scan_predates_freshness_cutoff(payload) is False
+
+
+def test_non_dict_payload_is_not_stale():
+    assert main._scan_predates_freshness_cutoff(None) is False
+
+
+def test_empty_cutoff_disables_gate(monkeypatch):
+    # Operators can disable the timestamp gate; even ancient scans then pass it.
+    monkeypatch.setenv("SCAN_FRESHNESS_CUTOFF", "")
+    payload = {"extension_id": "x" * 32, "timestamp": "2000-01-01T00:00:00+00:00"}
+    assert main._scan_predates_freshness_cutoff(payload) is False
+
+
+def test_invalid_cutoff_disables_gate(monkeypatch):
+    # A malformed cutoff must fail safe (disabled), never rescan everything.
+    monkeypatch.setenv("SCAN_FRESHNESS_CUTOFF", "garbage")
+    assert main._get_scan_freshness_cutoff() is None
+    payload = {"extension_id": "x" * 32, "timestamp": "2000-01-01T00:00:00+00:00"}
+    assert main._scan_predates_freshness_cutoff(payload) is False
+
+
+def test_default_cutoff_is_valid_and_utc(monkeypatch):
+    # The shipped default must parse to an aware UTC instant.
+    monkeypatch.delenv("SCAN_FRESHNESS_CUTOFF", raising=False)
+    cutoff = main._get_scan_freshness_cutoff()
+    assert cutoff is not None
+    assert cutoff.tzinfo is not None
+    assert cutoff.utcoffset().total_seconds() == 0

--- a/tests/api/test_scan_freshness_gate_integration.py
+++ b/tests/api/test_scan_freshness_gate_integration.py
@@ -1,0 +1,206 @@
+"""Endpoint-level guards for the recent-list self-heal and the Safe forced rescan.
+
+These exercise the wiring that unit tests of the helpers cannot:
+  * GET /api/recent must self-heal a stale governance verdict on the emitted row.
+  * POST /api/scan/trigger must deep-rescan a cached scan that predates the
+    freshness cutoff (incl. legacy rows with no scoring_version that model_stale
+    misses), and must NOT rescan a post-cutoff row.
+  * A cutoff/model staleness rescan is system-initiated: it must not consume the
+    user's daily deep-scan credit.
+  * A failed rescan must not overwrite a previously-good cached report.
+"""
+import copy
+import importlib
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+main = importlib.import_module("extension_shield.api.main")
+from extension_shield.scoring.engine import ScoringEngine
+
+EXT_ID = "a" * 32
+STORE_URL = f"https://chromewebstore.google.com/detail/test/{EXT_ID}"
+CUTOFF = "2026-07-08T00:00:00+00:00"
+PRE_CUTOFF = "2026-07-01T00:00:00+00:00"
+POST_CUTOFF = "2026-07-20T00:00:00+00:00"
+
+
+@pytest.fixture
+def client():
+    return TestClient(main.app)
+
+
+@pytest.fixture(autouse=True)
+def _pin_cutoff(monkeypatch):
+    monkeypatch.setenv("SCAN_FRESHNESS_CUTOFF", CUTOFF)
+
+
+@pytest.fixture(autouse=True)
+def _clean_caches():
+    for d in (main.scan_results, main.scan_status, main._failed_refresh_at):
+        d.pop(EXT_ID, None)
+    yield
+    for d in (main.scan_results, main.scan_status, main._failed_refresh_at):
+        d.pop(EXT_ID, None)
+
+
+def _dataflow_bundle(stale_final="BLOCK", decision_version=None):
+    """A real, recomputable bundle: DATAFLOW_TRACE + no declared categories recomputes
+    a stale BLOCK to NEEDS_REVIEW under the current rulepacks (see the sibling
+    test_governance_decision_selfheal scenario)."""
+    decision = {"final_verdict": stale_final, "final_authority": "stale", "final_reasons": []}
+    if decision_version is not None:
+        decision["decision_version"] = decision_version
+    return {
+        "signals": {"signals": [{"type": "DATAFLOW_TRACE"}]},
+        "store_listing": {
+            "extraction": {"status": "ok"},
+            "declared_third_parties": [],
+            "declared_data_categories": [],
+        },
+        "facts": {},
+        "context": {"rulepacks": ["CWS_LIMITED_USE", "ENTERPRISE_GOV_BASELINE"]},
+        "scoring_v2": {
+            "overall_score": 90, "security_score": 90,
+            "privacy_score": 90, "governance_score": 90,
+            "overall_confidence": 0.85, "decision": "ALLOW",
+            "gate_results": [], "scoring_version": "2.0.0",
+            "security_layer": {"score": 90, "factors": []},
+            "privacy_layer": {"score": 90, "factors": []},
+            "governance_layer": {"score": 90, "factors": []},
+        },
+        "decision": decision,
+    }
+
+
+# --------------------------------------------------------------------------- #
+# GET /api/recent self-heal
+# --------------------------------------------------------------------------- #
+def test_recent_endpoint_selfheals_stale_verdict(client):
+    bundle = _dataflow_bundle(stale_final="BLOCK")  # no decision_version -> stale
+    row = {
+        "extension_id": EXT_ID,
+        "extension_name": "Dataflow Ext",
+        "governance_bundle": bundle,               # DB lifts summary.governance_bundle here
+        "summary": {"governance_bundle": bundle},
+        "scoring_v2": bundle["scoring_v2"],
+    }
+    with patch.object(main.db, "get_recent_scans", return_value=[copy.deepcopy(row)]):
+        r = client.get("/api/recent?limit=5")
+    assert r.status_code == 200
+    emitted = r.json()["recent"][0]
+    # The endpoint must serve the RECOMPUTED verdict, not the stale stored BLOCK.
+    assert emitted["final_verdict"] == "NEEDS_REVIEW"
+    assert emitted["governance_verdict"] == "NEEDS_REVIEW"
+    assert emitted["governance_bundle"]["decision"]["final_verdict"] == "NEEDS_REVIEW"
+
+
+# --------------------------------------------------------------------------- #
+# POST /api/scan/trigger freshness gate
+# --------------------------------------------------------------------------- #
+def _seed_cached(timestamp, scoring_version):
+    sv2 = {"scoring_version": scoring_version} if scoring_version is not None else {}
+    main.scan_results[EXT_ID] = {
+        "extension_id": EXT_ID,
+        "url": STORE_URL,
+        "status": "completed",
+        "timestamp": timestamp,
+        "manifest": {"version": "1.0.0"},
+        "scoring_v2": sv2,
+    }
+
+
+def test_trigger_rescans_precutoff_cached_row_without_consuming_credit(client):
+    # Current scoring_version (model_stale=False) + pre-cutoff timestamp: only the
+    # freshness cutoff makes it stale.
+    _seed_cached(PRE_CUTOFF, ScoringEngine.VERSION)
+    consume = MagicMock()
+    with patch.object(main, "_fast_live_version_check", return_value=None), \
+         patch.object(main, "run_analysis_workflow", MagicMock()), \
+         patch.object(main, "_consume_deep_scan", consume):
+        r = client.post("/api/scan/trigger", json={"url": STORE_URL})
+    assert r.status_code == 200
+    body = r.json()
+    # A rescan was started (NOT an instant cached lookup) — this is the gate contract.
+    assert body["already_scanned"] is False
+    assert body["scan_type"] == "deep_scan"
+    # System-initiated staleness refresh must not spend the user's daily credit.
+    consume.assert_not_called()
+
+
+def test_trigger_rescans_none_version_precutoff_row(client):
+    # scoring_version=None: model_stale can NOT see this row; only cutoff_stale can.
+    _seed_cached(PRE_CUTOFF, None)
+    with patch.object(main, "_fast_live_version_check", return_value=None), \
+         patch.object(main, "run_analysis_workflow", MagicMock()), \
+         patch.object(main, "_consume_deep_scan", MagicMock()):
+        r = client.post("/api/scan/trigger", json={"url": STORE_URL})
+    assert r.status_code == 200
+    assert r.json()["already_scanned"] is False
+
+
+def test_failed_refresh_cooldown_suppresses_repeat_rescan(client):
+    # A recently-failed staleness refresh of a still-pre-cutoff row must NOT rescan
+    # again on the next lookup — serve the preserved cached report instead.
+    _seed_cached(PRE_CUTOFF, ScoringEngine.VERSION)
+    main._note_failed_refresh(EXT_ID)
+    with patch.object(main, "_fast_live_version_check", return_value=None), \
+         patch.object(main, "run_analysis_workflow", MagicMock()) as rw:
+        r = client.post("/api/scan/trigger", json={"url": STORE_URL})
+    assert r.status_code == 200
+    body = r.json()
+    assert body["already_scanned"] is True
+    assert body["scan_type"] == "lookup"
+    rw.assert_not_called()
+
+
+def test_persist_scan_failure_records_cooldown_when_preserving():
+    failed = {"extension_id": EXT_ID, "status": "failed"}
+    good_row = {"extension_id": EXT_ID, "status": "completed"}
+    with patch.object(main.db, "get_scan_result", return_value=good_row), \
+         patch.object(main.db, "save_scan_result", MagicMock()):
+        main._persist_scan_failure(EXT_ID, failed)
+    assert main._in_failed_refresh_cooldown(EXT_ID) is True
+
+
+def test_trigger_serves_postcutoff_cached_row_instantly(client):
+    _seed_cached(POST_CUTOFF, ScoringEngine.VERSION)
+    with patch.object(main, "_fast_live_version_check", return_value=None), \
+         patch.object(main, "run_analysis_workflow", MagicMock()) as rw:
+        r = client.post("/api/scan/trigger", json={"url": STORE_URL})
+    assert r.status_code == 200
+    body = r.json()
+    # Fresh cached scan: instant lookup, no rescan queued.
+    assert body["already_scanned"] is True
+    assert body["scan_type"] == "lookup"
+    rw.assert_not_called()
+
+
+# --------------------------------------------------------------------------- #
+# Non-destructive failure guard
+# --------------------------------------------------------------------------- #
+def test_persist_scan_failure_preserves_prior_good_result():
+    failed = {"extension_id": EXT_ID, "status": "failed", "overall_security_score": 0}
+    good_row = {"extension_id": EXT_ID, "status": "completed", "security_score": 80}
+    save = MagicMock()
+    with patch.object(main.db, "get_scan_result", return_value=good_row), \
+         patch.object(main.db, "save_scan_result", save):
+        main._persist_scan_failure(EXT_ID, failed)
+    # The good result must NOT be overwritten with the failed placeholder...
+    save.assert_not_called()
+    assert main.scan_results.get(EXT_ID) != failed
+    # ...and the status stays completed so users still see the last good report.
+    assert main.scan_status.get(EXT_ID) == "completed"
+
+
+def test_persist_scan_failure_stores_when_no_prior_result():
+    failed = {"extension_id": EXT_ID, "status": "failed", "overall_security_score": 0}
+    save = MagicMock()
+    with patch.object(main.db, "get_scan_result", return_value=None), \
+         patch.object(main.db, "save_scan_result", save):
+        main._persist_scan_failure(EXT_ID, failed)
+    # No prior good result -> the failure is recorded as before.
+    save.assert_called_once()
+    assert main.scan_results.get(EXT_ID) == failed
+    assert main.scan_status.get(EXT_ID) == "failed"


### PR DESCRIPTION
## What
Three related fixes to the `/scan` recent-scans list and scan cache:

1. **Verdict mismatch** — `/api/recent` now self-heals the governance verdict like `/api/scan/results`, so the list badge matches the report (Web Clipper showed **Review** in the list but **Safe/Allowed** on the report).
2. **Stale scans re-scan** — cached scans older than `SCAN_FRESHNESS_CUTOFF` (default = recalibration ship instant, env-overridable) are re-scanned instead of served stale.
3. **Ordering** — recent list sorts by actual last-scan time (`scanned_at`/`timestamp`) instead of `updated_at`, so a re-scan moves to the top and non-scan bumps (views, metadata refresh, batch scripts) don't reorder it.

## Notes for reviewers
- Staleness re-scans are system-initiated: no daily-credit consumption, exempt from the 429 limit.
- A failed re-scan never overwrites a good cached report with a score-0 placeholder (`_persist_scan_failure`); a cooldown stops delisted extensions re-scanning on every lookup.
- The fix aligns the verdict badge; list scores/signals refresh once an extension is actually re-scanned.
- `SCAN_FRESHNESS_CUTOFF` defaults to the ship instant (nearly every extension re-scans on next lookup); set it empty to disable.

## Tests
New: `test_scan_freshness_cutoff.py`, `test_scan_freshness_gate_integration.py`, `test_recent_scans_ordering.py`. Endpoint tests guard each regression (removing the self-heal, dropping the cutoff gate, or reverting the ordering all fail). Full backend + frontend suites pass.