### PR TITLE
Remove provenance chip from scan list; add admin force re-scan

### DIFF
--- a/frontend/src/components/report/AdminRescanButton.jsx
+++ b/frontend/src/components/report/AdminRescanButton.jsx
@@ -1,0 +1,45 @@
+import React, { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { Button } from "../ui/button";
+import realScanService from "../../services/realScanService";
+
+/**
+ * Admin-only "Force re-scan" action for a report.
+ *
+ * Renders nothing unless an admin rescan token is present in localStorage
+ * (`es_rescan_admin_token`). Clicking triggers a forced deep rescan of the
+ * extension (bypassing the freshness cache) and navigates to the progress page.
+ * The server still verifies the token against RESCAN_ADMIN_TOKEN, so this button
+ * is a convenience — the real gate is server-side.
+ */
+const AdminRescanButton = ({ url, scanId }) => {
+  const navigate = useNavigate();
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState("");
+
+  // Only render for admins who have set the token (server enforces the match).
+  if (!realScanService.getAdminRescanToken() || !url) return null;
+
+  const handleClick = async () => {
+    setBusy(true);
+    setError("");
+    try {
+      await realScanService.triggerScan(url, { force: true });
+      navigate(`/scan/progress/${scanId}`);
+    } catch (e) {
+      setError(e?.message || "Force re-scan failed");
+      setBusy(false);
+    }
+  };
+
+  return (
+    <span style={{ display: "inline-flex", alignItems: "center", gap: "0.5rem" }}>
+      <Button variant="outline" onClick={handleClick} disabled={busy} title="Admin: bypass cache and run a fresh deep scan">
+        {busy ? "Re-scanning…" : "⟳ Force re-scan"}
+      </Button>
+      {error && <span style={{ color: "#EF4444", fontSize: "0.8rem" }}>{error}</span>}
+    </span>
+  );
+};
+
+export default AdminRescanButton;

--- a/frontend/src/pages/ScanHistoryPage.jsx
+++ b/frontend/src/pages/ScanHistoryPage.jsx
@@ -6,7 +6,6 @@ import {
   getSignalColorClass,
   getSignalDisplayLabel,
   resolveScanVerdict,
-  resolveRowProvenance,
 } from "../utils/signalMapper";
 import RiskVerdictBadge from "../components/report/RiskVerdictBadge";
 import { enrichScans } from "../utils/scanEnrichment";
@@ -517,7 +516,7 @@ const ScanHistoryPage = () => {
                               )}
                             </td>
                             <td>
-                              <RiskVerdictBadge level={scan.risk_level} score={scan.score} decision={resolveScanVerdict(scan)} warnings={resolveRowProvenance(scan).warnings} />
+                              <RiskVerdictBadge level={scan.risk_level} score={scan.score} decision={resolveScanVerdict(scan)} />
                             </td>
                             <td className="signals-cell">
                               <div className="signals-container">

--- a/frontend/src/pages/scanner/ScanResultsPageV2.jsx
+++ b/frontend/src/pages/scanner/ScanResultsPageV2.jsx
@@ -36,6 +36,7 @@ import SEOHead from "../../components/SEOHead";
 import ScanActivityIndicator from "../../components/ScanActivityIndicator";
 import { useScan } from "../../context/ScanContext";
 import realScanService from "../../services/realScanService";
+import AdminRescanButton from "../../components/report/AdminRescanButton";
 import { normalizeScanResultSafe, validateEvidenceIntegrity, gateIdToLayer, extractFindingsByLayer } from "../../utils/normalizeScanResult";
 import { getExtensionIconUrl, EXTENSION_ICON_PLACEHOLDER } from "../../utils/constants";
 import { isUUID } from "../../utils/extensionId";
@@ -640,6 +641,7 @@ const ScanResultsPageV2 = () => {
         <Link to="/scan" className="nav-back">
           ← Back
         </Link>
+        <AdminRescanButton url={isPrivateScan ? null : chromeStoreUrl} scanId={scanId} />
       </nav>
 
       {/* Status Messages */}

--- a/frontend/src/pages/scanner/ScannerPage.jsx
+++ b/frontend/src/pages/scanner/ScannerPage.jsx
@@ -8,7 +8,6 @@ import {
   getSignalColorClass,
   getSignalDisplayLabel,
   resolveScanVerdict,
-  resolveRowProvenance,
 } from "../../utils/signalMapper";
 import RiskVerdictBadge from "../../components/report/RiskVerdictBadge";
 import { enrichScans } from "../../utils/scanEnrichment";
@@ -761,7 +760,7 @@ const ScannerPage = () => {
                           )}
                         </td>
                         <td>
-                          <RiskVerdictBadge level={scan.risk_level} score={scan.score} decision={resolveScanVerdict(scan)} warnings={resolveRowProvenance(scan).warnings} />
+                          <RiskVerdictBadge level={scan.risk_level} score={scan.score} decision={resolveScanVerdict(scan)} />
                         </td>
                         <td className="signals-cell">
                           <div className="signals-container">

--- a/frontend/src/services/realScanService.js
+++ b/frontend/src/services/realScanService.js
@@ -51,6 +51,18 @@ class RealScanService {
     return { ...this.getUserHeaders(), ...this.getAuthHeaders() };
   }
 
+  // Admin force-rescan token. An admin sets it once via the browser console:
+  //   localStorage.setItem('es_rescan_admin_token', '<RESCAN_ADMIN_TOKEN>')
+  // It is sent only on force rescans and the server still verifies it matches
+  // RESCAN_ADMIN_TOKEN, so possession alone grants nothing without the server env.
+  getAdminRescanToken() {
+    try {
+      return (localStorage.getItem("es_rescan_admin_token") || "").trim();
+    } catch {
+      return "";
+    }
+  }
+
   // Extract extension ID from Chrome Web Store URL
   extractExtensionId(url) {
     const match = url.match(/\/detail\/(?:[^/]+\/)?([a-z]{32})/);
@@ -93,15 +105,21 @@ class RealScanService {
     }
   }
 
-  // Trigger a scan for an extension URL
-  async triggerScan(url) {
+  // Trigger a scan for an extension URL. Pass { force: true } to bypass the cached
+  // fast path and force a fresh deep scan — server-gated: honored only in dev or
+  // when the admin rescan token matches RESCAN_ADMIN_TOKEN, ignored otherwise.
+  async triggerScan(url, { force = false } = {}) {
+    const headers = {
+      "Content-Type": "application/json",
+      ...this.getRequestHeaders(),
+    };
+    const adminToken = force ? this.getAdminRescanToken() : "";
+    if (adminToken) headers["X-Admin-Rescan-Token"] = adminToken;
+
     const { response, body } = await fetchJson(`${this.baseURL}/api/scan/trigger`, {
       method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        ...this.getRequestHeaders(),
-      },
-      body: JSON.stringify({ url }),
+      headers,
+      body: JSON.stringify(force ? { url, force: true } : { url }),
     });
 
     if (response.ok) {


### PR DESCRIPTION
## What
- **Remove the provenance chip** — the "Unverified listing" chip no longer renders in the recent-scans list (`/scan`) or the history list. `RiskVerdictBadge` is unchanged (still supports the chip if ever needed); the list callers just stop passing `warnings`.
- **Admin force re-scan** — a "⟳ Force re-scan" button on the report page bypasses the freshness cache and runs a fresh deep scan.

## How the force re-scan is gated
- The backend already supports it: `ScanRequest.force` + `X-Admin-Rescan-Token`, honored only in dev or when the header matches `RESCAN_ADMIN_TOKEN` (ignored for everyone else). This PR is frontend-only.
- The button only renders when an admin sets the token in the browser: `localStorage.setItem('es_rescan_admin_token', '<RESCAN_ADMIN_TOKEN>')`. The server still verifies the match, so the button is a convenience — the real gate is server-side.
- Hidden for upload/private scans (no Chrome Web Store URL to re-scan).

## Notes
- Frontend-only; no Supabase/schema changes.
- eslint passes; `npm run build` + prerender succeed.