### PR TITLE
Fix report coverage reasons and update-age labeling

### DIFF
--- a/frontend/src/components/report/LayerModal.test.jsx
+++ b/frontend/src/components/report/LayerModal.test.jsx
@@ -38,7 +38,7 @@ describe('LayerModal status mapping', () => {
   });
 
   it('a moderate finding (>=0.4) is an amber "Issue"', () => {
-    const result = humanizeFactor({ name: 'Maintenance', severity: 0.5 });
+    const result = humanizeFactor({ name: 'Obfuscation', severity: 0.5 });
     expect(result.status).toBe('Issue');
     expect(result.statusType).toBe('issues');
     expect(result.tone).toBe('warn');
@@ -49,6 +49,19 @@ describe('LayerModal status mapping', () => {
     expect(result.status).toBe('High severity');
     expect(result.statusType).toBe('issues');
     expect(result.tone).toBe('bad');
+  });
+
+  it('publisher update age (Maintenance) is advisory "Caution", never standalone "High severity"', () => {
+    // Even at a high raw severity (e.g. >365 days old = 0.8) it must not read as
+    // a red "High severity" code-safety finding — it is a trust/caution signal.
+    const stale = humanizeFactor({ name: 'Maintenance', severity: 0.8 });
+    expect(stale.status).toBe('Caution');
+    expect(stale.tone).toBe('warn');
+    expect(stale.label).toBe('Publisher update age');
+
+    const moderate = humanizeFactor({ name: 'Maintenance', severity: 0.5 });
+    expect(moderate.status).toBe('Caution');
+    expect(moderate.tone).toBe('warn');
   });
 
   it('an actual finding wins over the not-analyzed flag', () => {

--- a/frontend/src/components/report/layerFactors.js
+++ b/frontend/src/components/report/layerFactors.js
@@ -9,7 +9,7 @@ const FACTOR_HUMAN = {
   Manifest:             { label: 'Extension Config',      category: 'code',   desc: 'Validates security settings in the extension manifest' },
   ChromeStats:          { label: 'Threat Intel',          category: 'threat', desc: 'Cross-references known threat databases' },
   Webstore:             { label: 'Store Reputation',      category: 'trust',  desc: 'Chrome Web Store ratings and user reviews' },
-  Maintenance:          { label: 'Update Freshness',      category: 'trust',  desc: 'How recently the extension was updated by its developer' },
+  Maintenance:          { label: 'Publisher update age',   category: 'trust',  desc: 'How recently the extension was updated by its developer' },
   PermissionsBaseline:  { label: 'Permission Risk',       category: 'access', desc: 'Evaluates the sensitivity of requested browser permissions' },
   PermissionCombos:     { label: 'Dangerous Combos',      category: 'access', desc: 'Flags risky combinations of permissions that enable data theft' },
   NetworkExfil:         { label: 'Data Sharing',          category: 'data',   desc: 'Detects if data is sent to external servers' },
@@ -45,11 +45,16 @@ export function humanizeFactor(factor) {
     desc: '',
   };
   const severity = factor.severity ?? 0;
+  // Publisher update age is a trust/caution signal, not a code-safety finding.
+  // It must never present as standalone "High severity" — cap it at an advisory
+  // "Caution" (amber) even when its raw severity is high (e.g. >365 days old).
+  const isAdvisoryTrust = factor.name === 'Maintenance';
   let status, statusType, tone;
   if (severity >= 0.4) {
     statusType = 'issues';
-    tone = severity >= 0.7 ? 'bad' : 'warn';
-    status = severity >= 0.7 ? 'High severity' : 'Issue';
+    const isHigh = severity >= 0.7 && !isAdvisoryTrust;
+    tone = isHigh ? 'bad' : 'warn';
+    status = isHigh ? 'High severity' : isAdvisoryTrust ? 'Caution' : 'Issue';
   } else if (isNotAnalyzed(factor)) {
     statusType = 'unknown';
     tone = 'neutral';

--- a/frontend/src/utils/normalizeScanResult.test.ts
+++ b/frontend/src/utils/normalizeScanResult.test.ts
@@ -16,6 +16,7 @@ import {
   createEmptyReportViewModel,
   hasScoring,
   hasScoringV2,
+  coherentRiskLevel,
 } from './normalizeScanResult';
 import type { RawScanResult, ReportViewModel } from './reportTypes';
 
@@ -870,3 +871,174 @@ if (typeof window !== 'undefined') {
   (window as unknown as Record<string, unknown>).__runNormalizerAssertions = runRuntimeAssertions;
 }
 
+
+// =============================================================================
+// NARROW REPORTING/COVERAGE FIX TESTS (audit follow-up)
+// =============================================================================
+
+describe('Publisher update age (Maintenance) presentation', () => {
+  it('publisher age >365 days alone does NOT create a standalone HIGH key finding', () => {
+    const raw: RawScanResult = {
+      extension_id: 'staleonly1234567890abcdefghijklmn',
+      extension_name: 'Old But Clean',
+      scoring_v2: {
+        overall_score: 88,
+        security_score: 84,
+        privacy_score: 100,
+        governance_score: 100,
+        decision: 'NEEDS_REVIEW',
+        risk_level: 'low',
+        hard_gates_triggered: [],
+        security_layer: {
+          layer_name: 'security', score: 84, risk: 0.16, confidence: 0.9,
+          factors: [
+            { name: 'Maintenance', severity: 0.8, confidence: 0.9, weight: 0.1, contribution: 0.072, flags: ['stale_extension'] },
+          ],
+        },
+        privacy_layer: { layer_name: 'privacy', score: 100, risk: 0, confidence: 1, factors: [] },
+        governance_layer: { layer_name: 'governance', score: 100, risk: 0, confidence: 1, factors: [] },
+      },
+    } as unknown as RawScanResult;
+
+    const vm = normalizeScanResult(raw);
+    const maint = vm.keyFindings.find((f) => f.title === 'Publisher update age');
+    expect(maint).toBeDefined();
+    expect(maint!.severity).toBe('medium'); // advisory, NOT high
+    // No HIGH key finding at all (nothing corroborates the staleness).
+    expect(vm.keyFindings.some((f) => f.severity === 'high')).toBe(false);
+    // Renamed label — "Update Freshness" must not appear.
+    expect(vm.keyFindings.some((f) => /Update Freshness/i.test(f.title))).toBe(false);
+  });
+
+  it('publisher age CAN stay high when corroborated by a triggered gate', () => {
+    const raw: RawScanResult = {
+      extension_id: 'stalegate1234567890abcdefghijklmn',
+      scoring_v2: {
+        overall_score: 60, decision: 'BLOCK', risk_level: 'medium',
+        hard_gates_triggered: ['SENSITIVE_EXFIL'],
+        security_layer: { layer_name: 'security', score: 70, risk: 0.3, confidence: 0.9,
+          factors: [{ name: 'Maintenance', severity: 0.8, confidence: 0.9, weight: 0.1, contribution: 0.072 }] },
+        privacy_layer: { layer_name: 'privacy', score: 40, risk: 0.6, confidence: 0.9, factors: [] },
+        governance_layer: { layer_name: 'governance', score: 100, risk: 0, confidence: 1, factors: [] },
+      },
+    } as unknown as RawScanResult;
+    const vm = normalizeScanResult(raw);
+    const maint = vm.keyFindings.find((f) => f.title === 'Publisher update age');
+    expect(maint!.severity).toBe('high'); // corroborated by the SENSITIVE_EXFIL gate
+  });
+});
+
+describe('Coverage-cap reasons are promoted into Key Findings', () => {
+  it('coverage_cap_applied + Maintenance 0.8 surfaces the coverage reason FIRST (no-code)', () => {
+    const raw: RawScanResult = {
+      extension_id: 'nocode1234567890abcdefghijklmnop',
+      scoring_v2: {
+        overall_score: 80, decision: 'NEEDS_REVIEW', risk_level: 'low',
+        coverage_cap_applied: true,
+        coverage_cap_reason: 'SAST coverage missing; score capped at 80',
+        hard_gates_triggered: [],
+        security_layer: { layer_name: 'security', score: 85, risk: 0.15, confidence: 0.9,
+          factors: [{ name: 'Maintenance', severity: 0.8, confidence: 0.9, weight: 0.1, contribution: 0.072 }] },
+        privacy_layer: { layer_name: 'privacy', score: 100, risk: 0, confidence: 1, factors: [] },
+        governance_layer: { layer_name: 'governance', score: 100, risk: 0, confidence: 1, factors: [] },
+      },
+      sast_results: { scan_error: false, files_scanned: 0, sast_findings: {} },
+      virustotal_analysis: { enabled: true, files_found_in_vt: 5 },
+    } as unknown as RawScanResult;
+
+    const vm = normalizeScanResult(raw);
+    // The PRIMARY key finding explains the real reason, not publisher update age.
+    expect(vm.keyFindings[0].title).toBe('No analyzable code scanned');
+    expect(vm.keyFindings[0].severity).toBe('high');
+    // Publisher update age is still present but demoted to advisory.
+    const maint = vm.keyFindings.find((f) => f.title === 'Publisher update age');
+    expect(maint!.severity).toBe('medium');
+  });
+
+  it('VirusTotal unavailable surfaces "Limited malware reputation coverage", not malware', () => {
+    const raw: RawScanResult = {
+      extension_id: 'vtunknown1234567890abcdefghijklmn',
+      scoring_v2: {
+        overall_score: 65, decision: 'NEEDS_REVIEW', risk_level: 'medium',
+        coverage_cap_applied: true,
+        hard_gates_triggered: [],
+        security_layer: { layer_name: 'security', score: 84, risk: 0.16, confidence: 0.9, factors: [] },
+        privacy_layer: { layer_name: 'privacy', score: 100, risk: 0, confidence: 1, factors: [] },
+        governance_layer: { layer_name: 'governance', score: 100, risk: 0, confidence: 1, factors: [] },
+      },
+      sast_results: { scan_error: false, files_scanned: 8, sast_findings: { 'a.js': [{}] } },
+      virustotal_analysis: { enabled: true, files_found_in_vt: 0 },
+    } as unknown as RawScanResult;
+
+    const vm = normalizeScanResult(raw);
+    const cov = vm.keyFindings.find((f) => f.title === 'Limited malware reputation coverage');
+    expect(cov).toBeDefined();
+    expect(/malware reputation could not be confirmed/i.test(cov!.summary)).toBe(true);
+    // Never presented as a confirmed malware finding.
+    expect(vm.keyFindings.some((f) => /flagged by antivirus/i.test(f.title))).toBe(false);
+  });
+});
+
+describe('Microsoft Defender-style regression: coverage cap, not Update Freshness', () => {
+  it('SAST-failure cap surfaces "Limited code coverage" as primary, not "Update Freshness HIGH"', () => {
+    const raw: RawScanResult = {
+      extension_id: 'defenderlike1234567890abcdefghij',
+      extension_name: 'Microsoft Defender-like',
+      metadata: { last_updated: 'February 15, 2025' },
+      scoring_v2: {
+        overall_score: 65, decision: 'NEEDS_REVIEW', risk_level: 'medium',
+        coverage_cap_applied: true,
+        coverage_cap_reason: 'SAST scan failed or was incomplete; cannot clear as safe without code-analysis coverage',
+        hard_gates_triggered: [],
+        security_layer: { layer_name: 'security', score: 84, risk: 0.16, confidence: 0.9,
+          factors: [{ name: 'Maintenance', severity: 0.8, confidence: 0.9, weight: 0.1, contribution: 0.072, flags: ['stale_extension'] }] },
+        privacy_layer: { layer_name: 'privacy', score: 100, risk: 0, confidence: 1, factors: [] },
+        governance_layer: { layer_name: 'governance', score: 100, risk: 0, confidence: 1, factors: [] },
+      },
+      sast_results: { scan_error: true, files_scanned: 0, sast_findings: {} },
+      virustotal_analysis: { enabled: true, files_found_in_vt: 5 },
+    } as unknown as RawScanResult;
+
+    const vm = normalizeScanResult(raw);
+    expect(vm.keyFindings[0].title).toBe('Limited code coverage');
+    // "Update Freshness" wording is gone; publisher update age is NOT the HIGH driver.
+    expect(vm.keyFindings.some((f) => /Update Freshness/i.test(f.title))).toBe(false);
+    const maint = vm.keyFindings.find((f) => f.title === 'Publisher update age');
+    expect(maint!.severity).toBe('medium');
+  });
+});
+
+describe('Verdict / risk-label coherence (coherentRiskLevel)', () => {
+  it('floors low/none risk under BLOCK and NEEDS_REVIEW', () => {
+    expect(coherentRiskLevel('BLOCK', 'low')).toBe('high');
+    expect(coherentRiskLevel('BLOCK', 'none')).toBe('high');
+    expect(coherentRiskLevel('BLOCK', '')).toBe('high');
+    expect(coherentRiskLevel('NEEDS_REVIEW', 'low')).toBe('medium');
+    expect(coherentRiskLevel('WARN', 'none')).toBe('medium');
+  });
+
+  it('does not downgrade an already-severe level, and passes ALLOW/unrated through', () => {
+    expect(coherentRiskLevel('BLOCK', 'high')).toBe('high');
+    expect(coherentRiskLevel('NEEDS_REVIEW', 'medium')).toBe('medium');
+    expect(coherentRiskLevel('ALLOW', 'low')).toBe('low');
+    expect(coherentRiskLevel(null, 'low')).toBe('low');
+  });
+
+  it('a BLOCK with a high score never renders a GOOD overall band', () => {
+    const raw: RawScanResult = {
+      extension_id: 'blockhigh1234567890abcdefghijklmn',
+      scoring_v2: { overall_score: 85, decision: 'BLOCK', risk_level: 'low' },
+    } as unknown as RawScanResult;
+    const vm = normalizeScanResult(raw);
+    expect(vm.scores.overall.band).toBe('BAD');
+  });
+
+  it('a NEEDS_REVIEW with a high score renders a WARN (never GOOD) overall band', () => {
+    const raw: RawScanResult = {
+      extension_id: 'reviewhigh1234567890abcdefghijklm',
+      scoring_v2: { overall_score: 97, decision: 'NEEDS_REVIEW', risk_level: 'none' },
+    } as unknown as RawScanResult;
+    const vm = normalizeScanResult(raw);
+    expect(vm.scores.overall.band).toBe('WARN');
+  });
+});

--- a/frontend/src/utils/normalizeScanResult.ts
+++ b/frontend/src/utils/normalizeScanResult.ts
@@ -411,6 +411,27 @@ function severityToFindingLevel(severity: number): FindingSeverity {
   return 'low';
 }
 
+/**
+ * Floor a displayed/serialized risk level so it can never contradict the
+ * authoritative verdict. A BLOCK must not read as "low"/"none"; a NEEDS_REVIEW
+ * (WARN) must not imply fully safe. ALLOW / unrated pass through unchanged.
+ *
+ * Display/serialization coherence only — it does NOT change any numeric score,
+ * weight, or the stored risk_level; it only prevents the displayed band from
+ * telling a different story than the verdict.
+ */
+export function coherentRiskLevel(
+  decision: string | null | undefined,
+  riskLevel: string | null | undefined
+): string | null | undefined {
+  const verdict = (decision || '').toUpperCase();
+  const level = (riskLevel || '').toLowerCase();
+  const readsSafe = level === 'low' || level === 'none' || level === '';
+  if (verdict === 'BLOCK') return readsSafe ? 'high' : riskLevel;
+  if (verdict === 'WARN' || verdict === 'NEEDS_REVIEW') return readsSafe ? 'medium' : riskLevel;
+  return riskLevel;
+}
+
 const GATE_HUMAN_TITLE: Record<string, string> = {
   CRITICAL_SAST: 'Dangerous code pattern detected',
   SENSITIVE_EXFIL: 'May send your data to external servers',
@@ -431,7 +452,7 @@ const FACTOR_HUMAN_TITLE: Record<string, string> = {
   Manifest: 'Extension Config',
   ChromeStats: 'Threat Intel',
   Webstore: 'Store Reputation',
-  Maintenance: 'Update Freshness',
+  Maintenance: 'Publisher update age',
   PermissionsBaseline: 'Permission Risk',
   PermissionCombos: 'Dangerous Combos',
   NetworkExfil: 'Data Sharing',
@@ -974,6 +995,79 @@ function buildEvidenceIndex(raw: RawScanResult): Record<string, EvidenceItemVM> 
 }
 
 /**
+ * Build "limited coverage" key findings from the coverage-cap / insufficient-data
+ * state. When an analyzer could not clear the extension (SAST failed, no
+ * analyzable code was scanned, or VirusTotal reputation was unavailable), THAT —
+ * not an ordinary factor like publisher update age — is the real reason the
+ * extension needs review. These are surfaced ahead of factor findings so the
+ * headline reason matches the score driver. They are coverage limitations, not
+ * confirmed threats (each summary says so explicitly).
+ */
+function buildCoverageKeyFindings(
+  scoringV2: RawScoringV2 | null,
+  raw: RawScanResult
+): KeyFindingVM[] {
+  const anyV2 = (scoringV2 || {}) as { coverage_cap_applied?: boolean; coverage_cap_reason?: string };
+  const anyRaw = (raw || {}) as {
+    scoring_v2?: { coverage_cap_applied?: boolean };
+    governance_bundle?: { scoring_v2?: { coverage_cap_applied?: boolean; coverage_cap_reason?: string }; signal_pack?: Record<string, any> };
+    sast_results?: { scan_error?: boolean; files_scanned?: number; filesScanned?: number; sast_findings?: Record<string, unknown>; sastFindings?: Record<string, unknown> };
+    virustotal_analysis?: { enabled?: boolean; files_found_in_vt?: number };
+  };
+
+  const capApplied = Boolean(
+    anyV2.coverage_cap_applied ||
+    anyRaw.scoring_v2?.coverage_cap_applied ||
+    anyRaw.governance_bundle?.scoring_v2?.coverage_cap_applied
+  );
+  const insufficient = resolveInsufficientData(raw, scoringV2);
+  if (!capApplied && !insufficient) return [];
+
+  const findings: KeyFindingVM[] = [];
+  const mk = (title: string, summary: string): KeyFindingVM => ({
+    title, severity: 'high', layer: 'security', summary, evidenceIds: [],
+  });
+
+  const sp = (anyRaw.governance_bundle?.signal_pack || {}) as Record<string, any>;
+  const sast = (sp.sast || anyRaw.sast_results || {}) as {
+    scan_error?: boolean; files_scanned?: number; filesScanned?: number;
+    sast_findings?: Record<string, unknown>; sastFindings?: Record<string, unknown>;
+  };
+  const sastFiles = Number(sast.files_scanned ?? sast.filesScanned ?? 0);
+  const sastFindings = sast.sast_findings || sast.sastFindings;
+  const sastFindingsCount = sastFindings && typeof sastFindings === 'object' ? Object.keys(sastFindings).length : 0;
+  const sastRan = sastFiles > 0 || sastFindingsCount > 0;
+
+  if (sast.scan_error) {
+    findings.push(mk('Limited code coverage',
+      'The code analyzer (SAST) did not complete, so the extension’s code could not be checked. This is why it needs review — not a confirmed threat.'));
+  } else if (!sastRan) {
+    findings.push(mk('No analyzable code scanned',
+      'No analyzable code was scanned (often minified or bundled code). The code was not statically analyzed, so it cannot be cleared as safe.'));
+  }
+
+  const vt = (sp.virustotal || {}) as { enabled?: boolean; total_engines?: number; files_found_in_vt?: number };
+  const vtSummary = anyRaw.virustotal_analysis || {};
+  const vtEnabled = vt.enabled ?? vtSummary.enabled;
+  const vtEngines = Number(vt.total_engines ?? 0);
+  const vtFound = Number(vtSummary.files_found_in_vt ?? vt.files_found_in_vt ?? 0);
+  const vtAvailable = vtEnabled !== false && (vtEngines > 0 || vtFound > 0);
+  if (!vtAvailable) {
+    findings.push(mk('Limited malware reputation coverage',
+      'The extension’s files were not found in VirusTotal (or the malware scan was unavailable), so malware reputation could not be confirmed.'));
+  }
+
+  if (findings.length === 0) {
+    const reason = anyV2.coverage_cap_reason || anyRaw.governance_bundle?.scoring_v2?.coverage_cap_reason;
+    findings.push(mk('Limited analysis coverage',
+      typeof reason === 'string' && reason.trim()
+        ? reason
+        : 'Some analyzers did not run at scan time, so this extension could not be fully cleared.'));
+  }
+  return findings;
+}
+
+/**
  * Build key findings from scoring_v2 data
  */
 function buildKeyFindings(
@@ -981,7 +1075,7 @@ function buildKeyFindings(
   raw: RawScanResult
 ): KeyFindingVM[] {
   const findings: KeyFindingVM[] = [];
-  
+
   // 1. Add hard gates as high severity findings with correct layer classification
   const hardGates = scoringV2?.hard_gates_triggered || [];
   hardGates.forEach((gate: string) => {
@@ -994,7 +1088,12 @@ function buildKeyFindings(
       evidenceIds: [],
     });
   });
-  
+
+  // 1b. Promote coverage-cap / insufficient-data reasons ahead of ordinary factor
+  // findings (e.g. publisher update age) so the primary Key Finding explains the
+  // real reason the extension needs review.
+  buildCoverageKeyFindings(scoringV2, raw).forEach((f) => findings.push(f));
+
   // 2. Add top 3 factors by riskContribution where severity >= 0.4
   const allFactors: Array<FactorVM & { layer: 'security' | 'privacy' | 'governance' }> = [];
   
@@ -1049,6 +1148,14 @@ function buildKeyFindings(
     });
   }
   
+  // Publisher update age (Maintenance) is an advisory trust signal, not a
+  // code-safety finding. It must not be the SOLE high-severity key finding on its
+  // own — cap it at "medium" unless corroborated by a triggered gate or another
+  // genuinely high-severity factor.
+  const hasStrongEvidence =
+    hardGates.length > 0 ||
+    allFactors.some((f) => f.name !== 'Maintenance' && (f.severity ?? 0) >= 0.7);
+
   // Sort by contribution (descending) and take top 3
   allFactors
     .sort((a, b) => (b.riskContribution ?? 0) - (a.riskContribution ?? 0))
@@ -1057,12 +1164,18 @@ function buildKeyFindings(
       const humanTitle = humanizeFactorName(factor.name);
       const details = factor.details || {};
       const desc = typeof details === 'object' ? (details as any).description : '';
-      const level = factor.severity >= 0.7 ? 'significant' : factor.severity >= 0.4 ? 'moderate' : 'minor';
+
+      let findingSeverity = severityToFindingLevel(factor.severity);
+      if (factor.name === 'Maintenance' && findingSeverity === 'high' && !hasStrongEvidence) {
+        findingSeverity = 'medium';
+      }
+
+      const level = findingSeverity === 'high' ? 'significant' : findingSeverity === 'medium' ? 'moderate' : 'minor';
       const summary = desc || `${level.charAt(0).toUpperCase() + level.slice(1)} findings in ${humanTitle.toLowerCase()}`;
 
       findings.push({
         title: humanTitle,
-        severity: severityToFindingLevel(factor.severity),
+        severity: findingSeverity,
         layer: factor.layer,
         summary,
         evidenceIds: factor.evidenceIds,
@@ -1278,9 +1391,13 @@ export function normalizeScanResult(raw: RawScanResult): ReportViewModel {
     return bandFromScore(score);
   };
   
-  // Helper: get overall band (prefer overall risk_level, fallback to score thresholds)
+  // Helper: get overall band (prefer overall risk_level, fallback to score thresholds).
+  // The risk_level is floored by the authoritative verdict first, so a BLOCK/
+  // NEEDS_REVIEW can never render a "low"/"none" (green) overall band.
   const getOverallBand = (): ScoreBand => {
-    const riskLevelBand = bandFromRiskLevel(scoringV2?.risk_level);
+    const riskLevelBand = bandFromRiskLevel(
+      coherentRiskLevel(resolveFinalVerdict(raw, scoringV2), scoringV2?.risk_level)
+    );
     if (riskLevelBand !== null) return riskLevelBand;
     return bandFromScore(overallScore);
   };

--- a/frontend/src/utils/reportDisplay.test.js
+++ b/frontend/src/utils/reportDisplay.test.js
@@ -120,6 +120,19 @@ describe('resolveAnalyzerCoverage — honest coverage states', () => {
     expect(at(rows, 'virustotal').state).toBe('partial');
   });
 
+  it('VirusTotal hash-not-found is Limited coverage — never malware, never clean/full', () => {
+    const rows = resolveAnalyzerCoverage({
+      virustotal_analysis: { enabled: true, files_analyzed: 5, files_found_in_vt: 0 },
+    });
+    const vt = at(rows, 'virustotal');
+    expect(vt.state).toBe('limited');
+    expect(vt.statusText).toMatch(/not found in the VirusTotal database/i);
+    // Unknown reputation must not read as a malware detection...
+    expect(vt.statusText).not.toMatch(/flagged|malicious|malware/i);
+    // ...nor as a clean/full pass.
+    expect(vt.state).not.toBe('full');
+  });
+
   it('Chrome Web Store listing with metadata is Full; ChromeStats absent is Not run', () => {
     const rows = resolveAnalyzerCoverage({
       metadata: { user_count: 1000, rating: 4.5, version: '1.0' },


### PR DESCRIPTION
## Summary
- Show analyzer coverage limits as the primary report finding when they affect the verdict
- Rename Update Freshness to Publisher update age
- Prevent publisher update age from appearing as a standalone high-severity issue
- Keep verdict and displayed risk band aligned in report views

## Checks
- Frontend tests passed
- Frontend lint passed
- Frontend build passed