### PR TITLE
Fix verdict-consistent risk labels

### DIFF
--- a/packages/extension/src/background.js
+++ b/packages/extension/src/background.js
@@ -107,7 +107,26 @@ function extractScore(p) {
   return null;
 }
 
+function resolveAuthoritativeRiskLevel(p) {
+  var verdict = null;
+  if (p && p.final_verdict) verdict = p.final_verdict;
+  else if (p && p.governance_verdict) verdict = p.governance_verdict;
+  else if (p && p.governance_bundle && p.governance_bundle.decision && p.governance_bundle.decision.final_verdict) {
+    verdict = p.governance_bundle.decision.final_verdict;
+  } else if (p && p.scoring_v2 && p.scoring_v2.decision) {
+    verdict = p.scoring_v2.decision;
+  }
+
+  var normalized = verdict && String(verdict).toUpperCase();
+  if (normalized === 'BLOCK') return 'HIGH';
+  if (normalized === 'NEEDS_REVIEW') return 'MEDIUM';
+  return null;
+}
+
 function extractRiskLevel(p) {
+  var verdictRisk = resolveAuthoritativeRiskLevel(p);
+  if (verdictRisk) return verdictRisk;
+
   if (p && p.risk_and_signals && typeof p.risk_and_signals.risk === 'number') {
     var s = p.risk_and_signals.risk;
     if (s >= 75) return 'LOW';

--- a/packages/extension/src/popup.js
+++ b/packages/extension/src/popup.js
@@ -387,7 +387,26 @@
     return signals;
   }
 
+  function resolveAuthoritativeRiskLevel(p) {
+    var verdict = null;
+    if (p && p.final_verdict) verdict = p.final_verdict;
+    else if (p && p.governance_verdict) verdict = p.governance_verdict;
+    else if (p && p.governance_bundle && p.governance_bundle.decision && p.governance_bundle.decision.final_verdict) {
+      verdict = p.governance_bundle.decision.final_verdict;
+    } else if (p && p.scoring_v2 && p.scoring_v2.decision) {
+      verdict = p.scoring_v2.decision;
+    }
+
+    var normalized = verdict && String(verdict).toUpperCase();
+    if (normalized === 'BLOCK') return 'HIGH';
+    if (normalized === 'NEEDS_REVIEW') return 'MEDIUM';
+    return null;
+  }
+
   function extractRiskLevel(p) {
+    var verdictRisk = resolveAuthoritativeRiskLevel(p);
+    if (verdictRisk) return verdictRisk;
+
     if (p && p.risk_and_signals && typeof p.risk_and_signals.risk === 'number') {
       return riskLevelFromScore(p.risk_and_signals.risk);
     }

--- a/src/extension_shield/api/main.py
+++ b/src/extension_shield/api/main.py
@@ -46,6 +46,7 @@ from extension_shield.api.database import db, SupabaseDatabase, _is_extension_id
 from extension_shield.api.supabase_auth import get_current_user_id as _get_current_user_id
 from extension_shield.core.config import get_settings
 from extension_shield.utils.mode import require_cloud, get_feature_flags, is_oss_telemetry_allowed, require_cloud_dep
+from extension_shield.utils.verdict_risk import coherent_risk_level_for_payload
 from extension_shield.api.csp_middleware import CSPMiddleware
 from uvicorn.middleware.proxy_headers import ProxyHeadersMiddleware
 from extension_shield.api.payload_helpers import (
@@ -832,6 +833,16 @@ def _hydrate_db_scan_result(results: Dict[str, Any], identifier: str) -> Dict[st
     payload["scoring_v2"] = results.get("scoring_v2") or summary.get("scoring_v2")
     payload["governance_bundle"] = results.get("governance_bundle") or summary.get("governance_bundle")
     return payload
+
+
+def _apply_coherent_overall_risk(payload: Dict[str, Any]) -> None:
+    """Keep served top-level risk labels coherent with the final verdict."""
+    if isinstance(payload, dict):
+        existing_risk = payload.get("overall_risk") or payload.get("risk_level") or "unknown"
+        payload["overall_risk"] = coherent_risk_level_for_payload(
+            payload,
+            existing_risk,
+        )
 
 
 def _refresh_scan_payload_with_store_metadata(
@@ -2901,6 +2912,7 @@ async def get_scan_results(identifier: str, http_request: Request):
             payload = ensure_consumer_insights(payload)
             ensure_description_in_meta(payload)
             ensure_name_in_payload(payload)
+            _apply_coherent_overall_risk(payload)
             # Add risk and signals mapping
             payload["risk_and_signals"] = _extract_risk_and_signals(payload)
             scan_results[extension_id] = payload
@@ -2931,6 +2943,7 @@ async def get_scan_results(identifier: str, http_request: Request):
         payload = ensure_consumer_insights(payload)
         ensure_description_in_meta(payload)
         ensure_name_in_payload(payload)
+        _apply_coherent_overall_risk(payload)
         # Add risk and signals mapping
         payload["risk_and_signals"] = _extract_risk_and_signals(payload)
         scan_results[extension_id] = payload  # Cache in memory
@@ -2979,6 +2992,7 @@ async def get_scan_results(identifier: str, http_request: Request):
             payload = ensure_consumer_insights(payload)
             ensure_description_in_meta(payload)
             ensure_name_in_payload(payload)
+            _apply_coherent_overall_risk(payload)
             # Add risk and signals mapping
             payload["risk_and_signals"] = _extract_risk_and_signals(payload)
             scan_results[extension_id] = payload  # Cache in memory
@@ -3032,12 +3046,14 @@ def _lookup_scan_result(
     if payload is not None:
         if lightweight:
             ensure_name_in_payload(payload)
+            _apply_coherent_overall_risk(payload)
             payload["risk_and_signals"] = _extract_risk_and_signals(payload)
             return payload
         payload = upgrade_legacy_payload(payload, extension_id)
         payload = ensure_consumer_insights(payload)
         ensure_description_in_meta(payload)
         ensure_name_in_payload(payload)
+        _apply_coherent_overall_risk(payload)
         payload["risk_and_signals"] = _extract_risk_and_signals(payload)
         scan_results[extension_id] = payload
         return payload
@@ -3053,6 +3069,7 @@ def _lookup_scan_result(
         formatted = _hydrate_db_scan_result(db_row, extension_id)
         if lightweight:
             ensure_name_in_payload(formatted)
+            _apply_coherent_overall_risk(formatted)
             formatted["risk_and_signals"] = _extract_risk_and_signals(formatted)
             scan_results[resolved_id] = formatted  # warm the memory cache
             return formatted
@@ -3060,6 +3077,7 @@ def _lookup_scan_result(
         payload = ensure_consumer_insights(payload)
         ensure_description_in_meta(payload)
         ensure_name_in_payload(payload)
+        _apply_coherent_overall_risk(payload)
         payload["risk_and_signals"] = _extract_risk_and_signals(payload)
         scan_results[resolved_id] = payload
         return payload
@@ -3074,6 +3092,7 @@ def _lookup_scan_result(
             return None
         if lightweight:
             ensure_name_in_payload(payload)
+            _apply_coherent_overall_risk(payload)
             payload["risk_and_signals"] = _extract_risk_and_signals(payload)
             scan_results[extension_id] = payload
             return payload
@@ -3081,6 +3100,7 @@ def _lookup_scan_result(
         payload = ensure_consumer_insights(payload)
         ensure_description_in_meta(payload)
         ensure_name_in_payload(payload)
+        _apply_coherent_overall_risk(payload)
         payload["risk_and_signals"] = _extract_risk_and_signals(payload)
         scan_results[extension_id] = payload
         return payload
@@ -3594,6 +3614,7 @@ async def get_recent_scans(limit: int = 10, search: str = None):
         for scan in recent:
             try:
                 _refresh_recent_scan_verdict(scan)
+                scan["risk_level"] = coherent_risk_level_for_payload(scan, scan.get("risk_level"))
                 mapping = _extract_risk_and_signals(scan)
                 signals = mapping.get("signals", {})
                 missing_layers = any(k not in signals for k in ("security", "privacy", "gov"))

--- a/src/extension_shield/core/report_generator.py
+++ b/src/extension_shield/core/report_generator.py
@@ -23,6 +23,8 @@ from reportlab.platypus import (
 )
 from reportlab.lib.enums import TA_CENTER
 
+from extension_shield.utils.verdict_risk import coherent_risk_level_for_payload
+
 logger = logging.getLogger(__name__)
 
 
@@ -160,6 +162,7 @@ class ReportGenerator:
             or scan_results.get("risk_level")
             or "unknown"
         )
+        overall_risk = coherent_risk_level_for_payload(scan_results, overall_risk)
         overall_confidence = cls._coerce_float(
             scoring_v2.get("overall_confidence", scan_results.get("overall_confidence"))
         )
@@ -207,7 +210,11 @@ class ReportGenerator:
         """
         bundle = scan_results.get("governance_bundle") or {}
         decision = bundle.get("decision") or {}
-        verdict = decision.get("final_verdict") or scan_results.get("governance_verdict")
+        verdict = (
+            scan_results.get("final_verdict")
+            or scan_results.get("governance_verdict")
+            or decision.get("final_verdict")
+        )
         reasons = decision.get("final_reasons") or []
         authority = decision.get("final_authority")
         return {

--- a/src/extension_shield/utils/verdict_risk.py
+++ b/src/extension_shield/utils/verdict_risk.py
@@ -1,0 +1,53 @@
+"""Helpers for keeping consumer risk labels aligned with verdict authority."""
+
+from typing import Any, Mapping
+
+
+def resolve_authoritative_verdict(payload: Mapping[str, Any] | None) -> str | None:
+    """Return the authoritative verdict from an API/report payload, if present."""
+    if not isinstance(payload, Mapping):
+        return None
+
+    final_verdict = payload.get("final_verdict")
+    if final_verdict:
+        return str(final_verdict).upper()
+
+    governance_verdict = payload.get("governance_verdict")
+    if governance_verdict:
+        return str(governance_verdict).upper()
+
+    governance_bundle = payload.get("governance_bundle")
+    if isinstance(governance_bundle, Mapping):
+        decision = governance_bundle.get("decision")
+        if isinstance(decision, Mapping):
+            bundle_verdict = decision.get("final_verdict")
+            if bundle_verdict:
+                return str(bundle_verdict).upper()
+
+    scoring_v2 = payload.get("scoring_v2")
+    if isinstance(scoring_v2, Mapping):
+        scoring_decision = scoring_v2.get("decision")
+        if scoring_decision:
+            return str(scoring_decision).upper()
+
+    return None
+
+
+def coherent_risk_level(final_verdict: Any, risk_level: Any) -> Any:
+    """Floor safe-looking risk labels when a stronger final verdict exists.
+
+    The helper only changes label bands, never scores or stored analyzer output.
+    """
+    verdict = str(final_verdict or "").upper()
+    normalized_risk = str(risk_level or "").lower()
+
+    if verdict == "BLOCK" and normalized_risk in {"", "low", "none", "unknown"}:
+        return "high"
+    if verdict == "NEEDS_REVIEW" and normalized_risk in {"", "low", "none", "unknown"}:
+        return "medium"
+    return risk_level
+
+
+def coherent_risk_level_for_payload(payload: Mapping[str, Any] | None, risk_level: Any) -> Any:
+    """Resolve verdict from a payload and return the coherent risk label."""
+    return coherent_risk_level(resolve_authoritative_verdict(payload), risk_level)

--- a/tests/api/test_verdict_risk_consistency.py
+++ b/tests/api/test_verdict_risk_consistency.py
@@ -1,0 +1,112 @@
+from typing import Any, Dict
+from unittest.mock import MagicMock, patch
+
+from fastapi.testclient import TestClient
+
+from extension_shield.api.main import app, scan_results
+
+
+def _row(ext_id: str, verdict: str, risk_level: str = "low", score: int = 86) -> Dict[str, Any]:
+    return {
+        "extension_id": ext_id,
+        "extension_name": "Verdict Fixture",
+        "url": f"https://chromewebstore.google.com/detail/verdict-fixture/{ext_id}",
+        "timestamp": "2026-07-08T12:00:00+00:00",
+        "status": "completed",
+        "security_score": score,
+        "risk_level": risk_level,
+        "total_findings": 1,
+        "high_risk_count": 0,
+        "medium_risk_count": 1,
+        "low_risk_count": 0,
+        "metadata": {},
+        "manifest": {
+            "name": "Verdict Fixture",
+            "version": "1.0.0",
+            "manifest_version": 3,
+            "permissions": [],
+            "host_permissions": [],
+        },
+        "permissions_analysis": {},
+        "sast_results": {},
+        "webstore_analysis": {},
+        "summary": {},
+        "impact_analysis": {},
+        "privacy_compliance": {},
+        "extracted_path": None,
+        "extracted_files": [],
+        "scoring_v2": {
+            "scoring_version": "2.1.0",
+            "overall_score": score,
+            "risk_level": risk_level,
+            "decision": "ALLOW",
+        },
+        "governance_bundle": {
+            "decision": {
+                "final_verdict": verdict,
+                "final_authority": "test",
+                "final_reasons": ["fixture"],
+            }
+        },
+        "governance_verdict": verdict,
+        "final_verdict": verdict,
+    }
+
+
+def test_block_result_and_recent_risk_labels_are_not_safe():
+    client = TestClient(app)
+    ext_id = "abcdefghijklmnopabcdefghijklmnop"
+    scan_results.pop(ext_id, None)
+    row = _row(ext_id, "BLOCK", "low", 86)
+
+    with patch("extension_shield.api.main.db") as mock_db:
+        mock_db.get_scan_result = MagicMock(return_value=row)
+        mock_db.get_recent_scans = MagicMock(return_value=[dict(row)])
+
+        result_response = client.get(f"/api/scan/results/{ext_id}")
+        recent_response = client.get("/api/recent?limit=1")
+
+    assert result_response.status_code == 200
+    assert recent_response.status_code == 200
+    assert result_response.json()["overall_risk"] not in {"low", "none"}
+    assert recent_response.json()["recent"][0]["risk_level"] not in {"low", "none"}
+    assert result_response.json()["overall_risk"] == recent_response.json()["recent"][0]["risk_level"]
+
+
+def test_needs_review_result_and_recent_risk_labels_are_at_least_medium():
+    client = TestClient(app)
+    ext_id = "bcdefghijklmnopabcdefghijklmnopa"
+    scan_results.pop(ext_id, None)
+    row = _row(ext_id, "NEEDS_REVIEW", "low", 94)
+
+    with patch("extension_shield.api.main.db") as mock_db:
+        mock_db.get_scan_result = MagicMock(return_value=row)
+        mock_db.get_recent_scans = MagicMock(return_value=[dict(row)])
+
+        result_response = client.get(f"/api/scan/results/{ext_id}")
+        recent_response = client.get("/api/recent?limit=1")
+
+    assert result_response.status_code == 200
+    assert recent_response.status_code == 200
+    assert result_response.json()["overall_risk"] == "medium"
+    assert recent_response.json()["recent"][0]["risk_level"] == "medium"
+
+
+def test_allow_low_risk_label_is_preserved():
+    client = TestClient(app)
+    ext_id = "cdefghijklmnopabcdefghijklmnopab"
+    scan_results.pop(ext_id, None)
+    row = _row(ext_id, "ALLOW", "low", 92)
+    row["scoring_v2"]["decision"] = "ALLOW"
+
+    with patch("extension_shield.api.main.db") as mock_db:
+        mock_db.get_scan_result = MagicMock(return_value=row)
+        mock_db.get_recent_scans = MagicMock(return_value=[dict(row)])
+
+        result_response = client.get(f"/api/scan/results/{ext_id}")
+        recent_response = client.get("/api/recent?limit=1")
+
+    assert result_response.status_code == 200
+    assert recent_response.status_code == 200
+    assert result_response.json()["overall_risk"] == "low"
+    assert recent_response.json()["recent"][0]["risk_level"] == "low"

--- a/tests/extension/test_extension_verdict_risk.js
+++ b/tests/extension/test_extension_verdict_risk.js
@@ -1,0 +1,80 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+const vm = require('node:vm');
+
+const repoRoot = path.resolve(__dirname, '..', '..');
+
+function extractFunction(source, name) {
+  const marker = `function ${name}`;
+  const start = source.indexOf(marker);
+  assert.notEqual(start, -1, `${name} not found`);
+
+  const bodyStart = source.indexOf('{', start);
+  let depth = 0;
+  for (let i = bodyStart; i < source.length; i += 1) {
+    if (source[i] === '{') depth += 1;
+    if (source[i] === '}') depth -= 1;
+    if (depth === 0) return source.slice(start, i + 1);
+  }
+  throw new Error(`${name} function body not closed`);
+}
+
+function loadFunctions(filePath, names) {
+  const source = fs.readFileSync(path.join(repoRoot, filePath), 'utf8');
+  const context = {};
+  vm.createContext(context);
+  vm.runInContext(names.map((name) => extractFunction(source, name)).join('\n'), context);
+  return context;
+}
+
+const popup = loadFunctions('packages/extension/src/popup.js', [
+  'riskLevelFromScore',
+  'riskDisplayLabel',
+  'resolveAuthoritativeRiskLevel',
+  'extractRiskLevel',
+]);
+
+const background = loadFunctions('packages/extension/src/background.js', [
+  'resolveAuthoritativeRiskLevel',
+  'extractRiskLevel',
+]);
+
+test('popup BLOCK verdict wins over high numeric score', () => {
+  const payload = {
+    final_verdict: 'BLOCK',
+    risk_and_signals: { risk: 86 },
+  };
+
+  assert.equal(popup.extractRiskLevel(payload), 'HIGH');
+  assert.equal(popup.riskDisplayLabel(popup.extractRiskLevel(payload)), 'Not safe');
+});
+
+test('popup NEEDS_REVIEW verdict wins over high numeric score', () => {
+  const payload = {
+    final_verdict: 'NEEDS_REVIEW',
+    risk_and_signals: { risk: 94 },
+  };
+
+  assert.equal(popup.extractRiskLevel(payload), 'MEDIUM');
+  assert.equal(popup.riskDisplayLabel(popup.extractRiskLevel(payload)), 'Review');
+});
+
+test('popup falls back to numeric score when verdict is missing', () => {
+  assert.equal(popup.extractRiskLevel({ risk_and_signals: { risk: 86 } }), 'LOW');
+});
+
+test('background BLOCK verdict wins over high numeric score', () => {
+  assert.equal(
+    background.extractRiskLevel({
+      governance_bundle: { decision: { final_verdict: 'BLOCK' } },
+      risk_and_signals: { risk: 86 },
+    }),
+    'HIGH',
+  );
+});
+
+test('background falls back to numeric score when verdict is missing', () => {
+  assert.equal(background.extractRiskLevel({ risk_and_signals: { risk: 86 } }), 'LOW');
+});

--- a/tests/test_pdf_report_verdict.py
+++ b/tests/test_pdf_report_verdict.py
@@ -137,6 +137,32 @@ class TestScoreSection:
         assert "49" in text
         assert "92" in text
 
+    def test_block_score_section_does_not_render_low_overall_risk(self):
+        gen = ReportGenerator()
+        results = _results("BLOCK", ["Policy block"], overall_score=86, risk_level="low")
+        results["scoring_v2"] = {
+            "overall_score": 86,
+            "risk_level": "low",
+        }
+
+        text = _collect_text(gen._create_score_section(gen._extract_scoring_snapshot(results)))
+        assert "Overall Risk" in text
+        assert "HIGH" in text
+        assert "LOW" not in text
+
+    def test_needs_review_score_section_does_not_render_low_overall_risk(self):
+        gen = ReportGenerator()
+        results = _results("NEEDS_REVIEW", ["Needs review"], overall_score=94, risk_level="low")
+        results["scoring_v2"] = {
+            "overall_score": 94,
+            "risk_level": "low",
+        }
+
+        text = _collect_text(gen._create_score_section(gen._extract_scoring_snapshot(results)))
+        assert "Overall Risk" in text
+        assert "MEDIUM" in text
+        assert "LOW" not in text
+
     def test_header_is_extension_risk_report_not_security_only(self):
         gen = ReportGenerator()
         text = _collect_text(gen._create_header("Example", "a" * 32, "2026-06-24T00:00:00Z"))

--- a/tests/test_verdict_risk.py
+++ b/tests/test_verdict_risk.py
@@ -1,0 +1,31 @@
+from extension_shield.utils.verdict_risk import (
+    coherent_risk_level,
+    resolve_authoritative_verdict,
+)
+
+
+def test_coherent_risk_level_truth_table():
+    assert coherent_risk_level("BLOCK", "low") == "high"
+    assert coherent_risk_level("BLOCK", "none") == "high"
+    assert coherent_risk_level("BLOCK", "medium") == "medium"
+    assert coherent_risk_level("BLOCK", "high") == "high"
+
+    assert coherent_risk_level("NEEDS_REVIEW", "low") == "medium"
+    assert coherent_risk_level("NEEDS_REVIEW", "none") == "medium"
+    assert coherent_risk_level("NEEDS_REVIEW", "medium") == "medium"
+    assert coherent_risk_level("NEEDS_REVIEW", "high") == "high"
+
+    assert coherent_risk_level("ALLOW", "low") == "low"
+    assert coherent_risk_level(None, "low") == "low"
+
+
+def test_resolve_authoritative_verdict_order():
+    assert resolve_authoritative_verdict({"final_verdict": "BLOCK"}) == "BLOCK"
+    assert resolve_authoritative_verdict({"governance_verdict": "needs_review"}) == "NEEDS_REVIEW"
+    assert (
+        resolve_authoritative_verdict(
+            {"governance_bundle": {"decision": {"final_verdict": "block"}}}
+        )
+        == "BLOCK"
+    )
+    assert resolve_authoritative_verdict({"scoring_v2": {"decision": "allow"}}) == "ALLOW"


### PR DESCRIPTION
Fixes verdict-consistent risk labels across the API, Chrome extension, and PDF reports.

## What changed
- Floors served risk labels so `BLOCK` never appears as `LOW/Safe`.
- Floors `NEEDS_REVIEW` to at least `MEDIUM/Review`.
- Updates the Chrome extension popup/background to read the authoritative verdict before numeric score.
- Updates PDF Overall Risk display to match the verdict banner.
- Adds backend, extension, and PDF tests for verdict/risk consistency.
