### PR TITLE
fix(report): improve evidence truthfulness and coverage states

### DIFF
--- a/frontend/src/components/report/EvidenceTechnicalDetails.jsx
+++ b/frontend/src/components/report/EvidenceTechnicalDetails.jsx
@@ -1,5 +1,6 @@
 import React, { useMemo, useState } from 'react';
 import {
+  BarChart3,
   CheckCircle2,
   Code2,
   FileJson2,
@@ -8,6 +9,7 @@ import {
   ScrollText,
   ShieldCheck,
   SlidersHorizontal,
+  Store,
 } from 'lucide-react';
 import { toRelativeEvidencePath } from '../../utils/normalizeScanResult';
 import { resolveAnalyzerCoverage } from '../../utils/reportDisplay';
@@ -22,6 +24,13 @@ const TABS = [
   { key: 'governance', label: 'Governance', Icon: ScrollText },
   { key: 'coverage', label: 'Coverage', Icon: SlidersHorizontal },
 ];
+
+const ANALYZER_ICON = {
+  sast: Code2,
+  virustotal: ShieldCheck,
+  listing: Store,
+  chromestats: BarChart3,
+};
 
 const LOCAL_PATH_RE = /(?:\/Users\/|\/home\/|\b[A-Za-z]:\/(?!\/)|extensions_storage\/|extracted_[^/\s]+\/)\S+/g;
 const HIGH_RISK_PERMISSIONS = new Set(['cookies', 'debugger', 'downloads', 'history', 'management', 'nativeMessaging', 'proxy', 'webRequest', 'webRequestBlocking']);
@@ -68,6 +77,13 @@ function EmptyState({ children = 'No evidence was included for this group in the
       <span>{children}</span>
     </div>
   );
+}
+
+function formatDate(iso) {
+  if (!iso) return '—';
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return '—';
+  return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
 }
 
 function permissionExplanation(name, type) {
@@ -502,16 +518,25 @@ function CoveragePanel({ rows }) {
   return (
     <div className="etd-table etd-coverage" role="table" aria-label="Analyzer coverage details">
       <div className="etd-row etd-row-head" role="row">
-        <span role="columnheader">Analyzer</span><span role="columnheader">Coverage</span><span role="columnheader">Status</span><span role="columnheader">Checks</span>
+        <span role="columnheader">Analyzer</span><span role="columnheader">Coverage</span><span role="columnheader">Status</span><span role="columnheader">Last updated</span>
       </div>
-      {rows.map((row) => (
-        <div className="etd-row" role="row" key={row.key}>
-          <span role="cell" className="etd-strong">{row.label}</span>
-          <span role="cell"><Pill tone={row.tone}>{row.coverageLabel}</Pill></span>
-          <span role="cell">{row.statusText}</span>
-          <span role="cell" className="etd-muted">{row.whatItChecks}</span>
-        </div>
-      ))}
+      {rows.map((row) => {
+        const Icon = ANALYZER_ICON[row.key] || Code2;
+        return (
+          <div className="etd-row" role="row" key={row.key}>
+            <span role="cell" className="etd-coverage-analyzer">
+              <Icon size={16} aria-hidden="true" />
+              <span>
+                <span className="etd-strong">{row.label}</span>
+                <span className="etd-coverage-checks">{row.whatItChecks}</span>
+              </span>
+            </span>
+            <span role="cell"><Pill tone={row.tone}>{row.coverageLabel}</Pill></span>
+            <span role="cell" className="etd-coverage-status">{row.statusText}</span>
+            <span role="cell" className="etd-muted">{formatDate(row.lastUpdated)}</span>
+          </div>
+        );
+      })}
     </div>
   );
 }

--- a/frontend/src/components/report/EvidenceTechnicalDetails.jsx
+++ b/frontend/src/components/report/EvidenceTechnicalDetails.jsx
@@ -1,0 +1,519 @@
+import React, { useMemo, useState } from 'react';
+import {
+  CheckCircle2,
+  Code2,
+  FileJson2,
+  Globe2,
+  Network,
+  ScrollText,
+  ShieldCheck,
+  SlidersHorizontal,
+} from 'lucide-react';
+import { toRelativeEvidencePath } from '../../utils/normalizeScanResult';
+import { resolveAnalyzerCoverage } from '../../utils/reportDisplay';
+import './EvidenceTechnicalDetails.scss';
+
+const TABS = [
+  { key: 'permissions', label: 'Permissions', Icon: ShieldCheck },
+  { key: 'manifest', label: 'Manifest', Icon: FileJson2 },
+  { key: 'code', label: 'Code/SAST', Icon: Code2 },
+  { key: 'network', label: 'Network', Icon: Network },
+  { key: 'virustotal', label: 'VirusTotal', Icon: Globe2 },
+  { key: 'governance', label: 'Governance', Icon: ScrollText },
+  { key: 'coverage', label: 'Coverage', Icon: SlidersHorizontal },
+];
+
+const LOCAL_PATH_RE = /(?:\/Users\/|\/home\/|\b[A-Za-z]:\/(?!\/)|extensions_storage\/|extracted_[^/\s]+\/)\S+/g;
+const HIGH_RISK_PERMISSIONS = new Set(['cookies', 'debugger', 'downloads', 'history', 'management', 'nativeMessaging', 'proxy', 'webRequest', 'webRequestBlocking']);
+const MEDIUM_RISK_PERMISSIONS = new Set(['tabs', 'webNavigation', 'activeTab', 'scripting', 'clipboardRead', 'clipboardWrite', 'identity']);
+
+function asArray(value) {
+  if (!value) return [];
+  return Array.isArray(value) ? value : [value];
+}
+
+function cleanText(value) {
+  if (value === null || value === undefined) return '';
+  return String(value).replace(LOCAL_PATH_RE, (match) => toRelativeEvidencePath(match));
+}
+
+function cleanPath(value) {
+  return cleanText(toRelativeEvidencePath(value));
+}
+
+function compactList(items, limit = 3) {
+  const clean = asArray(items).map(cleanText).filter(Boolean);
+  if (!clean.length) return 'Not declared';
+  const head = clean.slice(0, limit).join(', ');
+  const extra = clean.length > limit ? ` +${clean.length - limit} more` : '';
+  return `${head}${extra}`;
+}
+
+function severityTone(value) {
+  const s = String(value || '').toLowerCase();
+  if (['critical', 'error', 'high', 'block', 'blocked', 'fail', 'failed', 'malicious'].includes(s)) return 'bad';
+  if (['medium', 'warning', 'warn', 'review', 'needs_review', 'partial', 'caution', 'suspicious'].includes(s)) return 'warn';
+  if (['low', 'info', 'clean', 'pass', 'passed', 'allow', 'full', 'scanned', 'ok'].includes(s)) return 'good';
+  return 'neutral';
+}
+
+function Pill({ children, tone = 'neutral' }) {
+  return <span className={`etd-pill tone-${tone}`}>{children}</span>;
+}
+
+function EmptyState({ children = 'No evidence was included for this group in the scan payload.' }) {
+  return (
+    <div className="etd-empty">
+      <CheckCircle2 size={16} aria-hidden="true" />
+      <span>{children}</span>
+    </div>
+  );
+}
+
+function permissionExplanation(name, type) {
+  if (type === 'Host') return 'Allows access to pages matching this host pattern.';
+  const lower = String(name).toLowerCase();
+  const explanations = {
+    tabs: 'Read browser tab metadata and interact with tab state.',
+    storage: 'Store and retrieve extension data locally.',
+    cookies: 'Read or modify browser cookies where allowed.',
+    webnavigation: 'Observe browser navigation events.',
+    webrequest: 'Observe or intercept network requests.',
+    webrequestblocking: 'Block or modify network requests.',
+    scripting: 'Inject scripts into allowed pages.',
+    activetab: 'Access the active tab after user interaction.',
+    history: 'Read browsing history.',
+    downloads: 'Manage browser downloads.',
+  };
+  return explanations[lower] || 'Requested browser capability declared by the extension.';
+}
+
+function permissionRisk(name, type, permissionsVm) {
+  const highRisk = new Set([...(permissionsVm?.highRiskPermissions || []), ...(permissionsVm?.unreasonablePermissions || []), ...(permissionsVm?.broadHostPatterns || [])]);
+  if (highRisk.has(name)) return 'High';
+  if (type === 'Host') {
+    return String(name).includes('<all_urls>') || String(name).includes('*://*/*') ? 'High' : 'Medium';
+  }
+  if (HIGH_RISK_PERMISSIONS.has(name)) return 'High';
+  if (MEDIUM_RISK_PERMISSIONS.has(name)) return 'Medium';
+  return 'Low';
+}
+
+function buildPermissionsRows(viewModel) {
+  const permissions = viewModel?.permissions || {};
+  const apiRows = (permissions.apiPermissions || []).map((name) => {
+    const risk = permissionRisk(name, 'API', permissions);
+    return {
+      id: `api:${name}`,
+      name: cleanText(name),
+      type: 'API',
+      risk,
+      why: permissionExplanation(name, 'API'),
+      source: 'manifest.json',
+    };
+  });
+  const hostRows = (permissions.hostPermissions || []).map((name) => {
+    const risk = permissionRisk(name, 'Host', permissions);
+    return {
+      id: `host:${name}`,
+      name: cleanText(name),
+      type: 'Host',
+      risk,
+      why: permissionExplanation(name, 'Host'),
+      source: 'manifest.json',
+    };
+  });
+  return [...apiRows, ...hostRows];
+}
+
+function getManifest(raw) {
+  return raw?.manifest || raw?.governance_bundle?.facts?.manifest || raw?.governance_bundle?.signal_pack?.manifest || {};
+}
+
+function buildManifestRows(raw) {
+  const manifest = getManifest(raw);
+  if (!manifest || !Object.keys(manifest).length) return [];
+  const csp = manifest.content_security_policy;
+  return [
+    { id: 'manifest-version', label: 'Manifest version', value: manifest.manifest_version ? `Manifest V${manifest.manifest_version}` : 'Not declared', status: manifest.manifest_version ? 'Present' : 'Missing' },
+    { id: 'csp', label: 'Content Security Policy', value: csp ? cleanText(typeof csp === 'string' ? csp : JSON.stringify(csp)) : 'Not declared', status: csp ? 'Present' : 'Missing' },
+    { id: 'host-permissions', label: 'Host permissions', value: compactList(manifest.host_permissions), status: `${asArray(manifest.host_permissions).length}` },
+    { id: 'optional-permissions', label: 'Optional permissions', value: compactList(manifest.optional_permissions), status: `${asArray(manifest.optional_permissions).length}` },
+    {
+      id: 'content-scripts',
+      label: 'Content scripts',
+      value: asArray(manifest.content_scripts).length
+        ? asArray(manifest.content_scripts).map((script) => `${compactList(script.matches, 2)} -> ${compactList(script.js, 2)}`).join('; ')
+        : 'Not declared',
+      status: `${asArray(manifest.content_scripts).length}`,
+    },
+    { id: 'web-accessible', label: 'Web accessible resources', value: compactList(manifest.web_accessible_resources?.flatMap?.((r) => r.resources || r.matches || r) || manifest.web_accessible_resources), status: `${asArray(manifest.web_accessible_resources).length}` },
+    { id: 'externally-connectable', label: 'Externally connectable', value: manifest.externally_connectable ? cleanText(JSON.stringify(manifest.externally_connectable)) : 'Not declared', status: manifest.externally_connectable ? 'Present' : 'None' },
+  ];
+}
+
+function extractSastRows(raw, viewModel) {
+  const rows = [];
+  const sast = raw?.sast_results || raw?.governance_bundle?.signal_pack?.sast || {};
+  const findings = sast.sast_findings || sast.sastFindings || {};
+  if (findings && typeof findings === 'object' && !Array.isArray(findings)) {
+    Object.entries(findings).forEach(([filePath, fileFindings]) => {
+      asArray(fileFindings).forEach((finding, index) => {
+        const extra = finding?.extra || {};
+        const path = cleanPath(finding?.path || filePath);
+        rows.push({
+          id: `sast:${filePath}:${index}`,
+          rule: cleanText(finding?.check_id || extra.message || 'SAST finding'),
+          severity: cleanText(extra.severity || finding?.severity || 'Info'),
+          file: path || 'File not provided',
+          line: finding?.start?.line || finding?.line_number || null,
+          endLine: finding?.end?.line || null,
+          snippet: cleanText(extra.lines || finding?.code_snippet || ''),
+        });
+      });
+    });
+  }
+
+  Object.entries(viewModel?.evidenceIndex || {}).forEach(([id, evidence]) => {
+    if (!evidence?.filePath || !String(evidence.toolName || '').toLowerCase().includes('sast')) return;
+    if (rows.some((row) => row.file === cleanPath(evidence.filePath) && row.line === evidence.lineStart)) return;
+    rows.push({
+      id: `evidence:${id}`,
+      rule: cleanText(evidence.toolName || 'SAST evidence'),
+      severity: 'Info',
+      file: cleanPath(evidence.filePath),
+      line: evidence.lineStart || null,
+      endLine: evidence.lineEnd || null,
+      snippet: cleanText(evidence.snippet || ''),
+    });
+  });
+
+  return rows;
+}
+
+function extractNetworkRows(raw, viewModel) {
+  const rows = [];
+  const candidates = [
+    raw?.network_analysis?.domains,
+    raw?.network_analysis?.urls,
+    raw?.network_analysis?.endpoints,
+    raw?.network_analysis?.requests,
+    raw?.network_results?.domains,
+    raw?.network_results?.urls,
+    raw?.network_results?.endpoints,
+    raw?.network_evidence?.domains,
+    raw?.network_evidence?.urls,
+  ].flatMap(asArray);
+
+  candidates.forEach((entry, index) => {
+    const target = typeof entry === 'string' ? entry : (entry?.domain || entry?.url || entry?.endpoint || entry?.host);
+    if (!target) return;
+    rows.push({
+      id: `network:${index}`,
+      target: cleanText(target),
+      kind: cleanText(typeof entry === 'string' ? 'Observed endpoint' : (entry.type || entry.kind || 'Observed endpoint')),
+      status: 'Observed',
+      evidence: cleanText(typeof entry === 'string' ? '' : (entry.reason || entry.source || entry.sink || entry.file || '')),
+    });
+  });
+
+  if (!rows.length) {
+    const hosts = viewModel?.permissions?.hostPermissions || [];
+    hosts.slice(0, 8).forEach((host, index) => {
+      rows.push({
+        id: `network-capability:${index}`,
+        target: cleanText(host),
+        kind: 'Capability',
+        status: 'Declared access',
+        evidence: 'Host permission; not proof of network exfiltration.',
+      });
+    });
+  }
+
+  return rows;
+}
+
+function extractVirusTotalRows(raw) {
+  const vt = raw?.virustotal_analysis || {};
+  const fileRows = asArray(vt.file_results).map((file, index) => {
+    const stats = file?.virustotal?.detection_stats || {};
+    const malicious = stats.malicious ?? 0;
+    const suspicious = stats.suspicious ?? 0;
+    const total = stats.total_engines ?? (
+      typeof stats.harmless === 'number' || typeof stats.undetected === 'number'
+        ? (stats.harmless || 0) + (stats.undetected || 0) + malicious + suspicious
+        : null
+    );
+    return {
+      id: `vt:${index}`,
+      file: cleanPath(file.file_path || file.file_name) || 'File not provided',
+      hash: cleanText(file.hashes?.sha256 || file.virustotal?.sha256 || file.hash || ''),
+      status: file.virustotal?.found === false ? 'Not in VirusTotal' : (malicious > 0 ? 'Detected' : 'No detections'),
+      malicious,
+      suspicious,
+      total,
+    };
+  });
+  return {
+    summary: {
+      enabled: vt.enabled,
+      filesAnalyzed: vt.files_analyzed,
+      filesFound: vt.files_found_in_vt,
+      filesWithDetections: vt.files_with_detections,
+      malicious: vt.total_malicious,
+      suspicious: vt.total_suspicious,
+      threat: vt.summary?.threat_level,
+    },
+    rows: fileRows,
+  };
+}
+
+function extractGovernanceRows(raw) {
+  const bundle = raw?.governance_bundle || {};
+  const ruleResults = [
+    ...asArray(bundle.rule_results?.rule_results),
+    ...asArray(bundle.report?.rule_results),
+    ...asArray(raw?.rule_results?.rule_results),
+    ...asArray(raw?.rule_results),
+  ];
+  const rows = ruleResults
+    .filter((rule) => rule && typeof rule === 'object')
+    .map((rule, index) => ({
+      id: `gov:${rule.rulepack || 'rule'}:${rule.rule_id || index}`,
+      rulepack: cleanText(rule.rulepack || 'Governance'),
+      ruleId: cleanText(rule.rule_id || rule.id || 'Rule'),
+      verdict: cleanText(rule.verdict || 'Review'),
+      reason: cleanText(rule.explanation || rule.reason || ''),
+      action: cleanText(rule.recommended_action || rule.action_required || ''),
+    }));
+
+  const decision = bundle.decision || bundle.report?.decision || raw?.decision;
+  if (!rows.length && decision) {
+    rows.push({
+      id: 'gov:decision',
+      rulepack: cleanText(decision.final_authority || 'Decision'),
+      ruleId: cleanText(decision.final_verdict || decision.verdict || 'Final verdict'),
+      verdict: cleanText(decision.final_verdict || decision.verdict || 'Review'),
+      reason: cleanText(asArray(decision.final_reasons)[0] || decision.rationale || ''),
+      action: cleanText(decision.action_required || ''),
+    });
+  }
+  return rows;
+}
+
+function buildCounts(data) {
+  return {
+    permissions: data.permissions.length,
+    manifest: data.manifest.filter((row) => row.value && row.value !== 'Not declared').length,
+    code: data.code.length,
+    network: data.network.length,
+    virustotal: data.virustotal.rows.length || (data.virustotal.summary.enabled !== undefined ? 1 : 0),
+    governance: data.governance.length,
+    coverage: data.coverage.length,
+  };
+}
+
+function EvidenceTechnicalDetails({ rawScanResult, viewModel }) {
+  const [activeTab, setActiveTab] = useState('permissions');
+  const data = useMemo(() => {
+    const raw = rawScanResult || {};
+    const vm = viewModel || {};
+    return {
+      permissions: buildPermissionsRows(vm),
+      manifest: buildManifestRows(raw),
+      code: extractSastRows(raw, vm),
+      network: extractNetworkRows(raw, vm),
+      virustotal: extractVirusTotalRows(raw),
+      governance: extractGovernanceRows(raw),
+      coverage: resolveAnalyzerCoverage(raw),
+    };
+  }, [rawScanResult, viewModel]);
+  const counts = buildCounts(data);
+
+  return (
+    <section className="evidence-technical-details" id="evidence-technical-details" aria-labelledby="evidence-technical-details-heading">
+      <div className="etd-head">
+        <div>
+          <h2 id="evidence-technical-details-heading" className="etd-title">Evidence &amp; Technical Details</h2>
+          <p className="etd-sub">Scan inputs and analyzer outputs used to support the report.</p>
+        </div>
+      </div>
+
+      <div className="etd-tabs" role="tablist" aria-label="Evidence detail groups">
+        {TABS.map(({ key, label, Icon }) => (
+          <button
+            type="button"
+            key={key}
+            className={`etd-tab${activeTab === key ? ' is-active' : ''}`}
+            role="tab"
+            aria-selected={activeTab === key}
+            aria-controls={`etd-panel-${key}`}
+            id={`etd-tab-${key}`}
+            onClick={() => setActiveTab(key)}
+          >
+            <Icon size={14} aria-hidden="true" />
+            <span>{label}</span>
+            <span className="etd-tab-count">{counts[key]}</span>
+          </button>
+        ))}
+      </div>
+
+      <div className="etd-panel" id={`etd-panel-${activeTab}`} role="tabpanel" aria-labelledby={`etd-tab-${activeTab}`}>
+        {activeTab === 'permissions' && <PermissionsPanel rows={data.permissions} />}
+        {activeTab === 'manifest' && <ManifestPanel rows={data.manifest} />}
+        {activeTab === 'code' && <CodePanel rows={data.code} />}
+        {activeTab === 'network' && <NetworkPanel rows={data.network} />}
+        {activeTab === 'virustotal' && <VirusTotalPanel summary={data.virustotal.summary} rows={data.virustotal.rows} />}
+        {activeTab === 'governance' && <GovernancePanel rows={data.governance} />}
+        {activeTab === 'coverage' && <CoveragePanel rows={data.coverage} />}
+      </div>
+    </section>
+  );
+}
+
+function PermissionsPanel({ rows }) {
+  if (!rows.length) return <EmptyState>No permissions were included in the normalized report.</EmptyState>;
+  return (
+    <div className="etd-table etd-permissions" role="table" aria-label="Declared permissions">
+      <div className="etd-row etd-row-head" role="row">
+        <span role="columnheader">Permission</span><span role="columnheader">Type</span><span role="columnheader">Risk</span><span role="columnheader">Why it matters</span><span role="columnheader">Source</span>
+      </div>
+      {rows.map((row) => (
+        <div className="etd-row" role="row" key={row.id}>
+          <span role="cell" className="etd-strong">{row.name}</span>
+          <span role="cell">{row.type}</span>
+          <span role="cell"><Pill tone={severityTone(row.risk)}>{row.risk}</Pill></span>
+          <span role="cell">{row.why}</span>
+          <span role="cell" className="etd-muted">{row.source}</span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function ManifestPanel({ rows }) {
+  if (!rows.length) return <EmptyState>No manifest details were included in the scan payload.</EmptyState>;
+  return (
+    <div className="etd-key-list">
+      {rows.map((row) => (
+        <div className="etd-key-row" key={row.id}>
+          <span className="etd-key">{row.label}</span>
+          <span className="etd-value">{row.value}</span>
+          <Pill tone={severityTone(row.status === 'Missing' ? 'warn' : 'good')}>{row.status}</Pill>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function CodePanel({ rows }) {
+  if (!rows.length) return <EmptyState>No SAST findings or code evidence were included in the scan payload.</EmptyState>;
+  return (
+    <div className="etd-list">
+      {rows.map((row) => (
+        <article className="etd-code-item" key={row.id}>
+          <div className="etd-item-head">
+            <span className="etd-strong">{row.rule}</span>
+            <Pill tone={severityTone(row.severity)}>{row.severity}</Pill>
+          </div>
+          <div className="etd-meta-line">
+            <span>{row.file}</span>
+            {row.line && <span>Line {row.line}{row.endLine && row.endLine > row.line ? `-${row.endLine}` : ''}</span>}
+          </div>
+          {row.snippet && <pre className="etd-snippet">{row.snippet}</pre>}
+        </article>
+      ))}
+    </div>
+  );
+}
+
+function NetworkPanel({ rows }) {
+  if (!rows.length) return <EmptyState>No network domains, URLs, or host-permission capabilities were included.</EmptyState>;
+  return (
+    <div className="etd-table etd-network" role="table" aria-label="Network evidence">
+      <div className="etd-row etd-row-head" role="row">
+        <span role="columnheader">Target</span><span role="columnheader">Type</span><span role="columnheader">Status</span><span role="columnheader">Evidence</span>
+      </div>
+      {rows.map((row) => (
+        <div className="etd-row" role="row" key={row.id}>
+          <span role="cell" className="etd-strong">{row.target}</span>
+          <span role="cell">{row.kind}</span>
+          <span role="cell"><Pill tone={row.status === 'Observed' ? 'warn' : 'neutral'}>{row.status}</Pill></span>
+          <span role="cell" className="etd-muted">{row.evidence || 'No detail provided'}</span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function VirusTotalPanel({ summary, rows }) {
+  const hasSummary = Object.values(summary || {}).some((value) => value !== undefined && value !== null && value !== '');
+  if (!hasSummary && !rows.length) return <EmptyState>No VirusTotal result data was included in the scan payload.</EmptyState>;
+  return (
+    <div className="etd-list">
+      {hasSummary && (
+        <div className="etd-summary-grid">
+          <div><span className="etd-key">Coverage</span><span>{summary.enabled === false ? 'Not run' : 'Available'}</span></div>
+          <div><span className="etd-key">Files analyzed</span><span>{summary.filesAnalyzed ?? '—'}</span></div>
+          <div><span className="etd-key">Found in VT</span><span>{summary.filesFound ?? '—'}</span></div>
+          <div><span className="etd-key">Malicious</span><span>{summary.malicious ?? 0}</span></div>
+          <div><span className="etd-key">Suspicious</span><span>{summary.suspicious ?? 0}</span></div>
+          <div><span className="etd-key">Threat level</span><span>{summary.threat || 'Not reported'}</span></div>
+        </div>
+      )}
+      {rows.map((row) => (
+        <article className="etd-code-item" key={row.id}>
+          <div className="etd-item-head">
+            <span className="etd-strong">{row.file}</span>
+            <Pill tone={row.malicious > 0 || row.suspicious > 0 ? 'bad' : 'good'}>{row.status}</Pill>
+          </div>
+          <div className="etd-meta-line">
+            <span>{row.malicious} malicious</span>
+            <span>{row.suspicious} suspicious</span>
+            {row.total && <span>{row.total} engines</span>}
+            {row.hash && <span>SHA-256 {row.hash}</span>}
+          </div>
+        </article>
+      ))}
+    </div>
+  );
+}
+
+function GovernancePanel({ rows }) {
+  if (!rows.length) return <EmptyState>No governance rule results were included in the scan payload.</EmptyState>;
+  return (
+    <div className="etd-list">
+      {rows.map((row) => (
+        <article className="etd-code-item" key={row.id}>
+          <div className="etd-item-head">
+            <span className="etd-strong">{row.rulepack} · {row.ruleId}</span>
+            <Pill tone={severityTone(row.verdict)}>{row.verdict}</Pill>
+          </div>
+          {row.reason && <p className="etd-row-copy">{row.reason}</p>}
+          {row.action && <div className="etd-meta-line"><span>Action</span><span>{row.action}</span></div>}
+        </article>
+      ))}
+    </div>
+  );
+}
+
+function CoveragePanel({ rows }) {
+  if (!rows.length) return <EmptyState>No analyzer coverage rows were available.</EmptyState>;
+  return (
+    <div className="etd-table etd-coverage" role="table" aria-label="Analyzer coverage details">
+      <div className="etd-row etd-row-head" role="row">
+        <span role="columnheader">Analyzer</span><span role="columnheader">Coverage</span><span role="columnheader">Status</span><span role="columnheader">Checks</span>
+      </div>
+      {rows.map((row) => (
+        <div className="etd-row" role="row" key={row.key}>
+          <span role="cell" className="etd-strong">{row.label}</span>
+          <span role="cell"><Pill tone={row.tone}>{row.coverageLabel}</Pill></span>
+          <span role="cell">{row.statusText}</span>
+          <span role="cell" className="etd-muted">{row.whatItChecks}</span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export default EvidenceTechnicalDetails;

--- a/frontend/src/components/report/EvidenceTechnicalDetails.scss
+++ b/frontend/src/components/report/EvidenceTechnicalDetails.scss
@@ -1,0 +1,346 @@
+.evidence-technical-details {
+  background: var(--extensionshield-bg-card);
+  border: 1px solid var(--extensionshield-border);
+  border-radius: 14px;
+  padding: 20px 22px;
+}
+
+.etd-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 14px;
+}
+
+.etd-title {
+  font-size: 1.05rem;
+  font-weight: 700;
+  margin: 0;
+  color: var(--extensionshield-text-primary);
+}
+
+.etd-sub {
+  margin: 2px 0 0;
+  font-size: 0.85rem;
+  color: var(--extensionshield-text-muted);
+}
+
+.etd-tabs {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding-bottom: 10px;
+  border-bottom: 1px solid var(--extensionshield-border);
+  overflow-x: auto;
+  scrollbar-width: thin;
+}
+
+.etd-tab {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-height: 34px;
+  padding: 7px 10px;
+  border: 1px solid transparent;
+  border-radius: 999px;
+  background: transparent;
+  color: var(--extensionshield-text-muted);
+  font-size: 0.82rem;
+  font-weight: 600;
+  white-space: nowrap;
+  cursor: pointer;
+  transition: color 140ms ease, background 140ms ease, border-color 140ms ease;
+
+  &:hover {
+    color: var(--extensionshield-text-primary);
+    background: rgba(22, 163, 74, 0.06);
+  }
+
+  &:focus-visible {
+    outline: 2px solid rgba(22, 163, 74, 0.35);
+    outline-offset: 2px;
+  }
+
+  &.is-active {
+    color: var(--extensionshield-accent, #15803d);
+    background: rgba(22, 163, 74, 0.1);
+    border-color: rgba(22, 163, 74, 0.24);
+  }
+}
+
+.etd-tab-count {
+  display: inline-grid;
+  place-items: center;
+  min-width: 18px;
+  height: 18px;
+  padding: 0 5px;
+  border-radius: 999px;
+  font-size: 0.7rem;
+  background: rgba(15, 23, 42, 0.06);
+  color: var(--extensionshield-text-muted);
+}
+
+.etd-tab.is-active .etd-tab-count {
+  color: var(--extensionshield-accent, #15803d);
+  background: rgba(22, 163, 74, 0.14);
+}
+
+.etd-panel {
+  padding-top: 14px;
+}
+
+.etd-table,
+.etd-list,
+.etd-key-list {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+}
+
+.etd-row {
+  display: grid;
+  gap: 12px;
+  align-items: center;
+  padding: 12px 4px;
+  border-top: 1px solid var(--extensionshield-border);
+  color: var(--extensionshield-text-secondary);
+  font-size: 0.86rem;
+
+  &:first-child {
+    border-top: 0;
+  }
+}
+
+.etd-row-head {
+  padding-top: 2px;
+  padding-bottom: 8px;
+  color: var(--extensionshield-text-muted);
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.etd-permissions .etd-row {
+  grid-template-columns: minmax(120px, 1.2fr) 0.6fr 0.65fr minmax(220px, 2fr) 0.8fr;
+}
+
+.etd-network .etd-row {
+  grid-template-columns: minmax(150px, 1.3fr) 0.75fr 0.9fr minmax(220px, 1.8fr);
+}
+
+.etd-coverage .etd-row {
+  grid-template-columns: 1fr 0.9fr 1.6fr 1.8fr;
+}
+
+.etd-key-row {
+  display: grid;
+  grid-template-columns: minmax(160px, 0.8fr) minmax(220px, 2fr) auto;
+  gap: 12px;
+  align-items: center;
+  padding: 12px 4px;
+  border-top: 1px solid var(--extensionshield-border);
+  font-size: 0.86rem;
+
+  &:first-child {
+    border-top: 0;
+  }
+}
+
+.etd-key {
+  display: block;
+  color: var(--extensionshield-text-muted);
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.etd-value {
+  min-width: 0;
+  color: var(--extensionshield-text-secondary);
+  overflow-wrap: anywhere;
+}
+
+.etd-strong {
+  min-width: 0;
+  color: var(--extensionshield-text-primary);
+  font-weight: 700;
+  overflow-wrap: anywhere;
+}
+
+.etd-muted {
+  min-width: 0;
+  color: var(--extensionshield-text-muted);
+  overflow-wrap: anywhere;
+}
+
+.etd-pill {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: max-content;
+  max-width: 100%;
+  padding: 3px 9px;
+  border: 1px solid transparent;
+  border-radius: 999px;
+  font-size: 0.72rem;
+  font-weight: 700;
+  line-height: 1.2;
+  white-space: nowrap;
+}
+
+.etd-pill.tone-good {
+  color: var(--risk-good);
+  background: var(--risk-good-bg);
+  border-color: var(--risk-good-border);
+}
+
+.etd-pill.tone-warn {
+  color: var(--risk-warn);
+  background: var(--risk-warn-bg);
+  border-color: var(--risk-warn-border);
+}
+
+.etd-pill.tone-bad {
+  color: var(--risk-bad);
+  background: var(--risk-bad-bg);
+  border-color: var(--risk-bad-border);
+}
+
+.etd-pill.tone-info {
+  color: #2563eb;
+  background: rgba(37, 99, 235, 0.12);
+  border-color: rgba(37, 99, 235, 0.32);
+}
+
+.etd-pill.tone-neutral {
+  color: var(--extensionshield-text-muted);
+  background: rgba(148, 163, 184, 0.14);
+  border-color: rgba(148, 163, 184, 0.3);
+}
+
+.etd-code-item {
+  padding: 12px 4px;
+  border-top: 1px solid var(--extensionshield-border);
+
+  &:first-child {
+    border-top: 0;
+    padding-top: 2px;
+  }
+}
+
+.etd-item-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.etd-meta-line {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px 14px;
+  margin-top: 6px;
+  color: var(--extensionshield-text-muted);
+  font-size: 0.82rem;
+}
+
+.etd-row-copy {
+  margin: 7px 0 0;
+  color: var(--extensionshield-text-secondary);
+  font-size: 0.86rem;
+  line-height: 1.45;
+}
+
+.etd-snippet {
+  margin: 10px 0 0;
+  padding: 10px 12px;
+  max-height: 160px;
+  overflow: auto;
+  border: 1px solid var(--extensionshield-border);
+  border-radius: 10px;
+  background: rgba(15, 23, 42, 0.035);
+  color: var(--extensionshield-text-primary);
+  font-size: 0.78rem;
+  line-height: 1.45;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+.etd-summary-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 10px;
+  margin-bottom: 8px;
+
+  > div {
+    min-width: 0;
+    padding: 10px 12px;
+    border: 1px solid var(--extensionshield-border);
+    border-radius: 10px;
+    background: rgba(15, 23, 42, 0.025);
+  }
+
+  span:last-child {
+    display: block;
+    margin-top: 4px;
+    color: var(--extensionshield-text-primary);
+    font-size: 0.9rem;
+    font-weight: 700;
+    overflow-wrap: anywhere;
+  }
+}
+
+.etd-empty {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  padding: 12px;
+  border: 1px dashed var(--extensionshield-border);
+  border-radius: 10px;
+  color: var(--extensionshield-text-muted);
+  background: rgba(15, 23, 42, 0.025);
+  font-size: 0.86rem;
+
+  svg {
+    flex: 0 0 auto;
+    margin-top: 1px;
+    color: var(--risk-good);
+  }
+}
+
+@media (max-width: 900px) {
+  .etd-permissions .etd-row,
+  .etd-network .etd-row,
+  .etd-coverage .etd-row,
+  .etd-key-row {
+    grid-template-columns: 1fr;
+    gap: 6px;
+  }
+
+  .etd-row-head {
+    display: none;
+  }
+
+  .etd-summary-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 560px) {
+  .evidence-technical-details {
+    padding: 18px 16px;
+  }
+
+  .etd-summary-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .etd-item-head {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+}

--- a/frontend/src/components/report/EvidenceTechnicalDetails.scss
+++ b/frontend/src/components/report/EvidenceTechnicalDetails.scss
@@ -30,10 +30,29 @@
   display: flex;
   align-items: center;
   gap: 6px;
-  padding-bottom: 10px;
+  padding-bottom: 8px;
   border-bottom: 1px solid var(--extensionshield-border);
   overflow-x: auto;
+  scrollbar-color: rgba(100, 116, 139, 0.58) rgba(148, 163, 184, 0.12);
   scrollbar-width: thin;
+
+  &::-webkit-scrollbar {
+    height: 5px;
+  }
+
+  &::-webkit-scrollbar-track {
+    border-radius: 999px;
+    background: rgba(148, 163, 184, 0.12);
+  }
+
+  &::-webkit-scrollbar-thumb {
+    border-radius: 999px;
+    background: rgba(100, 116, 139, 0.58);
+  }
+
+  &::-webkit-scrollbar-thumb:hover {
+    background: rgba(71, 85, 105, 0.68);
+  }
 }
 
 .etd-tab {
@@ -131,7 +150,7 @@
 }
 
 .etd-coverage .etd-row {
-  grid-template-columns: 1fr 0.9fr 1.6fr 1.8fr;
+  grid-template-columns: minmax(190px, 1.5fr) minmax(130px, 0.85fr) minmax(220px, 1.4fr) minmax(110px, 0.7fr);
 }
 
 .etd-key-row {
@@ -174,6 +193,33 @@
   min-width: 0;
   color: var(--extensionshield-text-muted);
   overflow-wrap: anywhere;
+}
+
+.etd-coverage-analyzer {
+  display: flex;
+  align-items: flex-start;
+  gap: 9px;
+  min-width: 0;
+
+  svg {
+    flex: 0 0 auto;
+    margin-top: 1px;
+    color: var(--extensionshield-text-muted);
+  }
+}
+
+.etd-coverage-checks {
+  display: block;
+  margin-top: 3px;
+  color: var(--extensionshield-text-muted);
+  font-size: 0.8rem;
+  font-weight: 400;
+  line-height: 1.35;
+}
+
+.etd-coverage-status {
+  color: var(--extensionshield-text-secondary);
+  line-height: 1.42;
 }
 
 .etd-pill {

--- a/frontend/src/components/report/EvidenceTechnicalDetails.test.jsx
+++ b/frontend/src/components/report/EvidenceTechnicalDetails.test.jsx
@@ -4,7 +4,7 @@ import { fireEvent, render, screen, within } from '@testing-library/react';
 import EvidenceTechnicalDetails from './EvidenceTechnicalDetails';
 
 const rawScanResult = {
-  timestamp: '2026-07-08T00:00:00Z',
+  timestamp: '2026-07-08T12:00:00Z',
   manifest: {
     manifest_version: 3,
     permissions: ['tabs', 'storage'],
@@ -154,7 +154,10 @@ describe('EvidenceTechnicalDetails', () => {
     const panel = screen.getByRole('tabpanel');
     expect(within(panel).getByText('SAST')).toBeInTheDocument();
     expect(within(panel).getByText('VirusTotal')).toBeInTheDocument();
+    expect(within(panel).getByText(/Code patterns, security anti-patterns, risky functions/)).toBeInTheDocument();
+    expect(within(panel).getByText(/Known malicious files, URLs, and domains/)).toBeInTheDocument();
     expect(within(panel).getByText(/Completed on scanned files/)).toBeInTheDocument();
+    expect(within(panel).getAllByText('Jul 8, 2026').length).toBeGreaterThan(0);
   });
 
   it('renders a safe empty state when data is missing', () => {

--- a/frontend/src/components/report/EvidenceTechnicalDetails.test.jsx
+++ b/frontend/src/components/report/EvidenceTechnicalDetails.test.jsx
@@ -1,0 +1,166 @@
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { fireEvent, render, screen, within } from '@testing-library/react';
+import EvidenceTechnicalDetails from './EvidenceTechnicalDetails';
+
+const rawScanResult = {
+  timestamp: '2026-07-08T00:00:00Z',
+  manifest: {
+    manifest_version: 3,
+    permissions: ['tabs', 'storage'],
+    host_permissions: ['https://example.com/*'],
+    optional_permissions: ['downloads'],
+    content_security_policy: { extension_pages: "script-src 'self'; object-src 'self'" },
+    content_scripts: [{ matches: ['https://example.com/*'], js: ['content.js'] }],
+    web_accessible_resources: [{ resources: ['images/icon.png'], matches: ['https://example.com/*'] }],
+    externally_connectable: { matches: ['https://partner.example/*'] },
+  },
+  sast_results: {
+    files_scanned: 2,
+    sast_findings: {
+      '/Users/dev/ExtensionShield/extensions_storage/extracted_abc/js/background.js': [
+        {
+          check_id: 'dangerous.eval',
+          path: '/Users/dev/ExtensionShield/extensions_storage/extracted_abc/js/background.js',
+          start: { line: 42 },
+          end: { line: 43 },
+          extra: {
+            severity: 'ERROR',
+            message: 'Avoid eval',
+            lines: 'eval(userInput);',
+          },
+        },
+      ],
+    },
+  },
+  virustotal_analysis: {
+    enabled: true,
+    files_analyzed: 2,
+    files_found_in_vt: 1,
+    files_with_detections: 1,
+    total_malicious: 1,
+    total_suspicious: 0,
+    summary: { threat_level: 'malicious' },
+    file_results: [
+      {
+        file_name: 'background.js',
+        file_path: '/Users/dev/ExtensionShield/extensions_storage/extracted_abc/js/background.js',
+        hashes: { sha256: 'abc123def456' },
+        virustotal: {
+          found: true,
+          detection_stats: { malicious: 1, suspicious: 0, harmless: 20, undetected: 4, total_engines: 25 },
+        },
+      },
+    ],
+  },
+  governance_bundle: {
+    rule_results: {
+      rule_results: [
+        {
+          rulepack: 'CWS_LIMITED_USE',
+          rule_id: 'R5',
+          verdict: 'REVIEW',
+          explanation: 'Sensitive permission requires disclosure.',
+          recommended_action: 'Verify privacy disclosure.',
+        },
+      ],
+    },
+    signal_pack: {
+      sast: { files_scanned: 2 },
+      virustotal: { enabled: true, files_analyzed: 2, malicious_count: 1 },
+    },
+  },
+  metadata: { user_count: 1000, rating: 4.5, version: '1.0.0' },
+};
+
+const viewModel = {
+  permissions: {
+    apiPermissions: ['tabs', 'storage'],
+    hostPermissions: ['https://example.com/*'],
+    highRiskPermissions: ['tabs'],
+    unreasonablePermissions: [],
+    broadHostPatterns: [],
+  },
+  evidenceIndex: {},
+};
+
+function renderDetails(raw = rawScanResult, vm = viewModel) {
+  return render(<EvidenceTechnicalDetails rawScanResult={raw} viewModel={vm} />);
+}
+
+function clickTab(name) {
+  fireEvent.click(screen.getByRole('tab', { name }));
+}
+
+describe('EvidenceTechnicalDetails', () => {
+  it('renders the section with available normalized data', () => {
+    renderDetails();
+    expect(screen.getByRole('heading', { name: 'Evidence & Technical Details' })).toBeInTheDocument();
+    expect(screen.getByText('tabs')).toBeInTheDocument();
+    expect(screen.getByText('https://example.com/*')).toBeInTheDocument();
+  });
+
+  it('renders permissions and host permissions in the Permissions tab', () => {
+    renderDetails();
+    const panel = screen.getByRole('tabpanel');
+    expect(within(panel).getByText('tabs')).toBeInTheDocument();
+    expect(within(panel).getAllByText('API').length).toBeGreaterThan(0);
+    expect(within(panel).getByText('https://example.com/*')).toBeInTheDocument();
+    expect(within(panel).getByText('Host')).toBeInTheDocument();
+  });
+
+  it('renders manifest, CSP, host, and content script fields', () => {
+    renderDetails();
+    clickTab(/Manifest/);
+    expect(screen.getByText('Manifest V3')).toBeInTheDocument();
+    expect(screen.getByText(/script-src 'self'/)).toBeInTheDocument();
+    expect(screen.getAllByText(/https:\/\/example\.com\/\*/).length).toBeGreaterThan(0);
+    expect(screen.getByText(/content\.js/)).toBeInTheDocument();
+  });
+
+  it('renders Code/SAST file, line, and snippet without local absolute paths', () => {
+    const { container } = renderDetails();
+    clickTab(/Code\/SAST/);
+    expect(screen.getByText('dangerous.eval')).toBeInTheDocument();
+    expect(screen.getByText('js/background.js')).toBeInTheDocument();
+    expect(screen.getByText('Line 42-43')).toBeInTheDocument();
+    expect(screen.getByText('eval(userInput);')).toBeInTheDocument();
+    expect(container.textContent).not.toContain('/Users/');
+    expect(container.textContent).not.toContain('extensions_storage');
+  });
+
+  it('renders VirusTotal coverage, counts, hash, and file details', () => {
+    renderDetails();
+    clickTab(/VirusTotal/);
+    expect(screen.getByText('Files analyzed')).toBeInTheDocument();
+    expect(screen.getByText('Malicious')).toBeInTheDocument();
+    expect(screen.getByText('js/background.js')).toBeInTheDocument();
+    expect(screen.getByText(/abc123def456/)).toBeInTheDocument();
+    expect(screen.getByText('1 malicious')).toBeInTheDocument();
+  });
+
+  it('renders governance rulepack, rule, reason, and action', () => {
+    renderDetails();
+    clickTab(/Governance/);
+    expect(screen.getByText(/CWS_LIMITED_USE/)).toBeInTheDocument();
+    expect(screen.getByText(/R5/)).toBeInTheDocument();
+    expect(screen.getByText('Sensitive permission requires disclosure.')).toBeInTheDocument();
+    expect(screen.getByText('Verify privacy disclosure.')).toBeInTheDocument();
+  });
+
+  it('renders analyzer coverage status and reason', () => {
+    renderDetails();
+    clickTab(/Coverage/);
+    const panel = screen.getByRole('tabpanel');
+    expect(within(panel).getByText('SAST')).toBeInTheDocument();
+    expect(within(panel).getByText('VirusTotal')).toBeInTheDocument();
+    expect(within(panel).getByText(/Completed on scanned files/)).toBeInTheDocument();
+  });
+
+  it('renders a safe empty state when data is missing', () => {
+    renderDetails({}, { permissions: {}, evidenceIndex: {} });
+    expect(screen.getByText('No permissions were included in the normalized report.')).toBeInTheDocument();
+    clickTab(/Manifest/);
+    expect(screen.getByText('No manifest details were included in the scan payload.')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/report/LayerModal.jsx
+++ b/frontend/src/components/report/LayerModal.jsx
@@ -3,11 +3,12 @@ import { createPortal } from 'react-dom';
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogHeader,
   DialogTitle,
 } from '../ui/dialog';
-import { AlertTriangle, Check, HelpCircle, Info } from 'lucide-react';
-import { triageFactors } from './layerFactors';
+import { AlertTriangle, Check, ChevronDown, HelpCircle, Info, Landmark, Lock, Shield } from 'lucide-react';
+import { buildLayerModalModel } from './layerFactors';
 import './LayerModal.scss';
 
 // Short, sentence-case tags used as a secondary caption on flagged/uncovered rows.
@@ -21,9 +22,9 @@ const CATEGORY_TAG = {
 };
 
 const LAYER_CONFIG = {
-  security:   { title: 'Security',   icon: '🛡️' },
-  privacy:    { title: 'Privacy',    icon: '🔒' },
-  governance: { title: 'Governance', icon: '📋' },
+  security:   { title: 'Security',   Icon: Shield },
+  privacy:    { title: 'Privacy',    Icon: Lock },
+  governance: { title: 'Governance', Icon: Landmark },
 };
 
 function bandLabel(band) {
@@ -109,127 +110,251 @@ const InfoTooltip = ({ text }) => {
   );
 };
 
+function pluralize(count, singular, plural = `${singular}s`) {
+  return `${count} ${count === 1 ? singular : plural}`;
+}
+
+const EvidenceRows = ({ rows }) => {
+  if (!rows || rows.length === 0) {
+    return (
+      <div className="lm-evidence-empty">
+        No structured evidence is available for this item.
+      </div>
+    );
+  }
+
+  return (
+    <div className="lm-evidence-panel">
+      {rows.map((row, index) => (
+        <div className={`lm-evidence-row${row.kind === 'snippet' ? ' lm-evidence-row--snippet' : ''}`} key={`${row.key}-${index}`}>
+          <span className="lm-evidence-row-key">{row.key}</span>
+          {row.kind === 'snippet' ? (
+            <pre className="lm-evidence-snippet">{row.value}</pre>
+          ) : (
+            <span className="lm-evidence-row-value">{row.value}</span>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+};
+
 /** Prominent row for a flagged or uncovered check (issues + not-analyzed tiers). */
-const PrimaryCheckRow = ({ item, index }) => (
+const PrimaryCheckRow = ({ item, index, expanded, onToggle }) => {
+  const hasEvidence = Boolean(item.evidence || (item.evidenceRows && item.evidenceRows.length));
+  const glyph = item.statusType === 'issues'
+    ? <AlertTriangle size={15} strokeWidth={2.25} />
+    : <HelpCircle size={15} strokeWidth={2.25} />;
+  return (
   <div
     className={`lm-check lm-check--${item.statusType} lm-tone-${item.tone}`}
     style={{ animationDelay: `${index * 30}ms` }}
     role="listitem"
   >
     <span className="lm-check-rail" aria-hidden />
-    <span className="lm-check-glyph" aria-hidden>
-      {item.statusType === 'issues'
-        ? <AlertTriangle size={15} strokeWidth={2.25} />
-        : <HelpCircle size={15} strokeWidth={2.25} />}
-    </span>
-    <span className="lm-check-main">
-      <span className="lm-check-name">
-        {item.label}
-        {item.desc && <InfoTooltip text={item.desc} />}
-      </span>
-      {CATEGORY_TAG[item.category] && (
-        <span className="lm-check-tag">{CATEGORY_TAG[item.category]}</span>
-      )}
+    <span className="lm-check-glyph" aria-hidden>{glyph}</span>
+    <div className="lm-check-main">
+      <div className="lm-check-title-row">
+        <span className="lm-check-name">
+          {item.title || item.label}
+          {item.description && <InfoTooltip text={item.description} />}
+        </span>
+        {CATEGORY_TAG[item.category] ? (
+          <span className="lm-check-tag">{CATEGORY_TAG[item.category]}</span>
+        ) : item.source ? (
+          <span className="lm-check-tag">{item.source}</span>
+        ) : null}
+      </div>
       {item.evidence && (
         <span className="lm-check-evidence" title={item.evidence}>
           <span className="lm-check-evidence-key">Evidence</span>
           {item.evidence}
         </span>
       )}
-    </span>
-    <span className={`lm-check-status lm-status-${item.statusType}`}>{item.status}</span>
+    </div>
+    <div className="lm-check-actions">
+      <span className={`lm-check-status lm-status-${item.statusType} lm-tone-pill-${item.tone}`}>{item.status}</span>
+      <button
+        type="button"
+        className={`lm-evidence-toggle${expanded ? ' is-open' : ''}`}
+        aria-expanded={expanded}
+        aria-label={`Toggle evidence for ${item.title || item.label}`}
+        onClick={onToggle}
+      >
+        <ChevronDown size={15} aria-hidden />
+      </button>
+    </div>
+    {expanded && (
+      <div className="lm-check-detail">
+        {hasEvidence && item.evidence && (
+          <p className="lm-check-detail-summary">{item.evidence}</p>
+        )}
+        <EvidenceRows rows={item.evidenceRows} />
+      </div>
+    )}
   </div>
+  );
+};
+
+const ClearedRow = ({ item, index }) => (
+  <div className="lm-clear-row" key={`c-${index}`} role="listitem">
+    <Check className="lm-clear-tick" size={13} strokeWidth={2.5} aria-hidden />
+    <span className="lm-clear-name">{item.label}</span>
+    {item.desc && <InfoTooltip text={item.desc} />}
+  </div>
+);
+
+const EmptyState = ({ children }) => (
+  <p className="lm-empty">{children}</p>
 );
 
 const LayerModal = ({
   open,
   onClose,
   layer,
-  // eslint-disable-next-line no-unused-vars
   score = null,
   band = 'NA',
   factors = [],
-  // eslint-disable-next-line no-unused-vars
   keyFindings = [],
-  // eslint-disable-next-line no-unused-vars
   gateResults = [],
-  // eslint-disable-next-line no-unused-vars
   layerReasons = [],
-  // eslint-disable-next-line no-unused-vars
-  layerDetails = null,
-  // eslint-disable-next-line no-unused-vars
-  onViewEvidence = null,
 }) => {
   const config = LAYER_CONFIG[layer] || LAYER_CONFIG.security;
+  const Icon = config.Icon;
 
-  // Severity-first triage: what's wrong, then what couldn't be checked, then what's fine.
-  const { all, issues, notAnalyzed, cleared } = triageFactors(factors);
+  // Severity-first modal model from real normalized factors/findings only.
+  const { all, issues, notAnalyzed, cleared, about } = React.useMemo(
+    () => buildLayerModalModel({ factors, keyFindings, gateResults, layerReasons }),
+    [factors, keyFindings, gateResults, layerReasons]
+  );
   const hasChecks = all.length > 0;
+  const tabs = [
+    { key: 'issues', label: 'Open Issues', count: issues.length },
+    { key: 'cleared', label: 'Cleared', count: cleared.length },
+    { key: 'unknown', label: 'Not Analyzed', count: notAnalyzed.length },
+    { key: 'about', label: 'About', count: about.length },
+  ];
+  const initialTab = issues.length > 0 ? 'issues' : cleared.length > 0 ? 'cleared' : notAnalyzed.length > 0 ? 'unknown' : 'about';
+  const firstIssueId = issues[0]?.id || null;
+  const firstUnknownId = notAnalyzed[0]?.id || null;
+  const [activeTab, setActiveTab] = React.useState(initialTab);
+  const [expandedRow, setExpandedRow] = React.useState(firstIssueId);
+
+  React.useEffect(() => {
+    const nextTab = issues.length > 0 ? 'issues' : cleared.length > 0 ? 'cleared' : notAnalyzed.length > 0 ? 'unknown' : 'about';
+    setActiveTab(nextTab);
+    setExpandedRow(firstIssueId || firstUnknownId);
+  }, [layer, firstIssueId, firstUnknownId, issues.length, cleared.length, notAnalyzed.length]);
+
+  const toggleRow = (id) => setExpandedRow((current) => current === id ? null : id);
 
   return (
-    <Dialog open={open} onOpenChange={onClose}>
+    <Dialog open={open} onOpenChange={(nextOpen) => { if (!nextOpen) onClose(); }}>
       <DialogContent className="lm-content lm-dialog-smooth" aria-describedby="lm-checks" aria-label={`${config.title} details`} data-layer={layer} data-band={band}>
         <DialogHeader className="lm-header-wrap">
           <DialogTitle className="lm-header">
             <div className="lm-header-inner">
               <div className="lm-header-left">
-                <span className="lm-icon" aria-hidden>{config.icon}</span>
-                <span className="lm-title">{config.title}</span>
+                <span className="lm-icon" aria-hidden><Icon size={18} strokeWidth={2.2} /></span>
+                <div className="lm-title-block">
+                  <span className="lm-title">{config.title}</span>
+                  <span className="lm-summary">
+                    {pluralize(issues.length, 'open issue')} · {pluralize(cleared.length, 'cleared')} · {pluralize(notAnalyzed.length, 'not analyzed')}
+                  </span>
+                </div>
               </div>
-              <span className={`lm-verdict-pill ${bandToneClass(band)}`}>{bandLabel(band)}</span>
+              <div className="lm-header-score">
+                <span className="lm-score">{score ?? '—'}<span>/100</span></span>
+                <span className={`lm-verdict-pill ${bandToneClass(band)}`}>{bandLabel(band)}</span>
+              </div>
             </div>
           </DialogTitle>
+          <DialogDescription className="lm-visually-hidden">
+            {config.title} layer details including open issues, cleared checks, not analyzed checks, and supporting evidence.
+          </DialogDescription>
         </DialogHeader>
 
         <div className="lm-body" id="lm-checks">
           {!hasChecks && (
-            <p className="lm-empty">No checks are available for this layer.</p>
+            <EmptyState>No checks are available for this layer.</EmptyState>
           )}
 
-          {issues.length > 0 && (
-            <section className="lm-tier lm-tier--issues" aria-label="Issues found">
-              <header className="lm-tier-head">
-                <span className="lm-tier-title">Issues found</span>
-                <span className="lm-tier-count lm-tier-count--issues">{issues.length}</span>
-              </header>
+          <div className="lm-tabs" role="tablist" aria-label={`${config.title} detail sections`}>
+            {tabs.map((tab) => (
+              <button
+                type="button"
+                role="tab"
+                key={tab.key}
+                className={`lm-tab${activeTab === tab.key ? ' is-active' : ''}`}
+                aria-selected={activeTab === tab.key}
+                aria-controls={`lm-panel-${tab.key}`}
+                onClick={() => setActiveTab(tab.key)}
+              >
+                {tab.label}
+                <span>{tab.count}</span>
+              </button>
+            ))}
+          </div>
+
+          {activeTab === 'issues' && (
+            <section className="lm-tier lm-tier--issues" id="lm-panel-issues" role="tabpanel" aria-label="Open issues">
+              {issues.length === 0 && <EmptyState>No open issues were reported for this layer.</EmptyState>}
               <div className="lm-rows" role="list">
                 {issues.map((item, idx) => (
-                  <PrimaryCheckRow key={`i-${idx}`} item={item} index={idx} />
+                  <PrimaryCheckRow
+                    key={item.id}
+                    item={item}
+                    index={idx}
+                    expanded={expandedRow === item.id}
+                    onToggle={() => toggleRow(item.id)}
+                  />
                 ))}
               </div>
             </section>
           )}
 
-          {notAnalyzed.length > 0 && (
-            <section className="lm-tier lm-tier--unknown" aria-label="Not analyzed">
-              <header className="lm-tier-head">
-                <span className="lm-tier-title">Not analyzed</span>
-                <span className="lm-tier-count">{notAnalyzed.length}</span>
-              </header>
-              <div className="lm-rows" role="list">
-                {notAnalyzed.map((item, idx) => (
-                  <PrimaryCheckRow key={`u-${idx}`} item={item} index={idx} />
-                ))}
-              </div>
-              <p className="lm-tier-note">Coverage unavailable — treat as unknown, not safe.</p>
-            </section>
-          )}
-
-          {cleared.length > 0 && (
-            <section className="lm-tier lm-tier--clear" aria-label="Checks that passed">
-              <header className="lm-tier-head">
-                <span className="lm-tier-title">Cleared</span>
-                <span className="lm-tier-count">{cleared.length}</span>
-              </header>
+          {activeTab === 'cleared' && (
+            <section className="lm-tier lm-tier--clear" id="lm-panel-cleared" role="tabpanel" aria-label="Cleared checks">
+              {cleared.length === 0 && <EmptyState>No cleared checks are available for this layer.</EmptyState>}
               <div className="lm-clear-grid" role="list">
                 {cleared.map((item, idx) => (
-                  <div className="lm-clear-row" key={`c-${idx}`} role="listitem">
-                    <Check className="lm-clear-tick" size={13} strokeWidth={2.5} aria-hidden />
-                    <span className="lm-clear-name">{item.label}</span>
-                    {item.desc && <InfoTooltip text={item.desc} />}
-                  </div>
+                  <ClearedRow item={item} index={idx} key={`c-${idx}`} />
                 ))}
               </div>
+            </section>
+          )}
+
+          {activeTab === 'unknown' && (
+            <section className="lm-tier lm-tier--unknown" id="lm-panel-unknown" role="tabpanel" aria-label="Not analyzed">
+              {notAnalyzed.length === 0 && <EmptyState>No checks are marked not analyzed for this layer.</EmptyState>}
+              <div className="lm-rows" role="list">
+                {notAnalyzed.map((item, idx) => (
+                  <PrimaryCheckRow
+                    key={item.id}
+                    item={item}
+                    index={idx}
+                    expanded={expandedRow === item.id}
+                    onToggle={() => toggleRow(item.id)}
+                  />
+                ))}
+              </div>
+              {notAnalyzed.length > 0 && <p className="lm-tier-note">Coverage unavailable - treat as unknown, not safe.</p>}
+            </section>
+          )}
+
+          {activeTab === 'about' && (
+            <section className="lm-tier lm-tier--about" id="lm-panel-about" role="tabpanel" aria-label="Layer details">
+              <div className="lm-about-card">
+                <span className="lm-about-label">Layer status</span>
+                <p>{bandLabel(band)} based on {hasChecks ? pluralize(all.length, 'check') : 'available report data'}.</p>
+              </div>
+              {about.length === 0 ? (
+                <EmptyState>No additional layer details are available in this scan.</EmptyState>
+              ) : (
+                <ul className="lm-about-list">
+                  {about.map((reason) => <li key={reason.id}>{reason.text}</li>)}
+                </ul>
+              )}
             </section>
           )}
         </div>

--- a/frontend/src/components/report/LayerModal.jsx
+++ b/frontend/src/components/report/LayerModal.jsx
@@ -130,6 +130,12 @@ const PrimaryCheckRow = ({ item, index }) => (
       {CATEGORY_TAG[item.category] && (
         <span className="lm-check-tag">{CATEGORY_TAG[item.category]}</span>
       )}
+      {item.evidence && (
+        <span className="lm-check-evidence" title={item.evidence}>
+          <span className="lm-check-evidence-key">Evidence</span>
+          {item.evidence}
+        </span>
+      )}
     </span>
     <span className={`lm-check-status lm-status-${item.statusType}`}>{item.status}</span>
   </div>

--- a/frontend/src/components/report/LayerModal.jsx
+++ b/frontend/src/components/report/LayerModal.jsx
@@ -259,7 +259,7 @@ const LayerModal = ({
                 <div className="lm-title-block">
                   <span className="lm-title">{config.title}</span>
                   <span className="lm-summary">
-                    {pluralize(issues.length, 'open issue')} · {pluralize(cleared.length, 'cleared')} · {pluralize(notAnalyzed.length, 'not analyzed')}
+                    {pluralize(issues.length, 'open issue')} · {pluralize(cleared.length, 'cleared', 'cleared')} · {pluralize(notAnalyzed.length, 'not analyzed', 'not analyzed')}
                   </span>
                 </div>
               </div>

--- a/frontend/src/components/report/LayerModal.scss
+++ b/frontend/src/components/report/LayerModal.scss
@@ -7,10 +7,22 @@
   --lm-ease: cubic-bezier(0.32, 0.72, 0, 1);
 }
 
+.dialog-overlay {
+  position: fixed !important;
+  inset: 0 !important;
+  z-index: 9999 !important;
+}
+
 .lm-dialog-smooth {
+  position: fixed !important;
+  inset: 50% auto auto 50% !important;
   top: 50% !important;
+  right: auto !important;
+  bottom: auto !important;
   left: 50% !important;
+  margin: 0 !important;
   transform: translate(-50%, -50%) !important;
+  z-index: 10000 !important;
 
   &[data-state="open"],
   &[data-state="closed"] {
@@ -61,7 +73,7 @@
 }
 
 @keyframes lmDrawerIn {
-  from { opacity: 0; transform: translate(-50%, -48%) scale(0.99); }
+  from { opacity: 0; transform: translate(-50%, calc(-50% + 10px)) scale(0.99); }
   to   { opacity: 1; transform: translate(-50%, -50%) scale(1); }
 }
 
@@ -659,9 +671,13 @@
 
 @media (max-width: 700px) {
   .lm-dialog-smooth {
+    position: fixed !important;
+    inset: 50% auto auto 50% !important;
     top: 50% !important;
-    left: 50% !important;
     right: auto !important;
+    bottom: auto !important;
+    left: 50% !important;
+    margin: 0 !important;
     transform: translate(-50%, -50%) !important;
   }
 

--- a/frontend/src/components/report/LayerModal.scss
+++ b/frontend/src/components/report/LayerModal.scss
@@ -1,242 +1,300 @@
 // ===========================================================================
-// LayerModal — severity-triaged layer detail dialog
-// Issues first (loud) → Not analyzed (neutral) → Cleared (quiet).
+// LayerModal - tabbed layer detail drawer
 // ===========================================================================
 
 :root {
-  --lm-transition-duration: 280ms;
+  --lm-transition-duration: 220ms;
   --lm-ease: cubic-bezier(0.32, 0.72, 0, 1);
 }
 
 .lm-dialog-smooth {
+  left: auto !important;
+  right: clamp(12px, 3vw, 28px) !important;
+  top: 50% !important;
+  transform: translateY(-50%) !important;
+
   &[data-state="open"],
   &[data-state="closed"] {
     animation: none;
   }
 
   > button {
+    top: 18px;
+    right: 18px;
     color: var(--theme-text-muted);
     opacity: 1;
+    border-radius: 8px;
+
     &:hover {
       color: var(--theme-text-primary);
       background: var(--theme-hover-bg);
     }
+
+    &:focus-visible {
+      outline: 2px solid var(--color-ring, var(--theme-accent));
+      outline-offset: 2px;
+    }
   }
 }
 
-// ---------------------------------------------------------------------------
-// Container — accent rail reflects the authoritative verdict, not the layer.
-// ---------------------------------------------------------------------------
 .lm-content {
   --lm-accent: var(--risk-neutral);
 
   font-family: var(--report-font, var(--font-sans));
-  background: var(--theme-bg-card);
-  border: 1px solid var(--theme-border);
-  border-top: 3px solid var(--lm-accent);
-  color: var(--theme-text-primary);
-  max-width: 460px;
-  width: 92vw;
-  max-height: 82vh;
-  overflow-y: auto;
-  overflow-x: hidden;
-  scrollbar-width: thin;
-  scrollbar-color: var(--theme-border-subtle) transparent;
-  box-shadow: var(--theme-shadow-dropdown);
-  border-radius: 14px;
-  padding: 0;
-  animation: lmSlideIn var(--lm-transition-duration) var(--lm-ease) both;
   display: flex;
   flex-direction: column;
   gap: 0;
+  width: min(94vw, 520px);
+  max-width: 520px;
+  max-height: min(82vh, 760px);
+  padding: 0;
+  overflow: hidden;
+  color: var(--theme-text-primary);
+  background: var(--theme-bg-card);
+  border: 1px solid var(--theme-border);
+  border-radius: 14px;
+  box-shadow: var(--theme-shadow-dropdown);
+  animation: lmDrawerIn var(--lm-transition-duration) var(--lm-ease) both;
 
   &[data-band="GOOD"] { --lm-accent: var(--risk-good); }
   &[data-band="WARN"] { --lm-accent: var(--risk-warn); }
   &[data-band="BAD"]  { --lm-accent: var(--risk-bad); }
 }
 
-@keyframes lmSlideIn {
-  from { opacity: 0; transform: translate(-50%, -48%) scale(0.985); }
-  to   { opacity: 1; transform: translate(-50%, -50%) scale(1); }
+@keyframes lmDrawerIn {
+  from { opacity: 0; transform: translateY(-50%) translateX(18px) scale(0.99); }
+  to   { opacity: 1; transform: translateY(-50%) translateX(0) scale(1); }
 }
 
-// ---------------------------------------------------------------------------
-// Header — identity left, verdict right
-// ---------------------------------------------------------------------------
-.lm-header-wrap {
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  justify-content: center;
-  text-align: left;
-  gap: 0;
-  margin: 0;
-  padding: 0;
-  border: none;
-}
-
+.lm-header-wrap,
 .lm-header {
   width: 100%;
   margin: 0;
   padding: 0;
   border: none;
-  font: inherit;
-  letter-spacing: inherit;
+  text-align: left;
+}
+
+.lm-visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 
 .lm-header-inner {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   justify-content: space-between;
-  width: 100%;
-  padding: 18px 20px 16px;
-  padding-right: 48px;
+  gap: 16px;
+  padding: 18px 56px 15px 20px;
   border-bottom: 1px solid var(--theme-border-subtle);
-  gap: 12px;
 }
 
 .lm-header-left {
   display: flex;
-  align-items: center;
-  gap: 10px;
+  align-items: flex-start;
+  gap: 11px;
   min-width: 0;
 }
 
-.lm-header-inner .lm-icon {
-  font-size: 19px;
-  line-height: 1;
+.lm-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  flex: 0 0 auto;
+  color: var(--lm-accent);
+  background: color-mix(in srgb, var(--lm-accent) 12%, transparent);
+  border: 1px solid color-mix(in srgb, var(--lm-accent) 25%, transparent);
+  border-radius: 9px;
 }
 
-.lm-header-inner .lm-title {
-  font-size: 1.0625rem;
-  font-weight: 650;
+.lm-title-block {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 0;
+}
+
+.lm-title {
+  font-size: 1.05rem;
+  font-weight: 750;
+  line-height: 1.2;
   color: var(--theme-text-primary);
-  letter-spacing: -0.01em;
 }
 
-// Verdict pill — the layer's authoritative status, restated in the modal.
-.lm-verdict-pill {
-  flex-shrink: 0;
-  font-size: 0.6875rem;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-  padding: 5px 11px;
-  border-radius: var(--radius-full, 9999px);
-  white-space: nowrap;
-  border: 1px solid transparent;
+.lm-summary {
+  font-size: 0.76rem;
+  font-weight: 500;
+  line-height: 1.35;
+  color: var(--theme-text-muted);
 }
+
+.lm-header-score {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 7px;
+  flex: 0 0 auto;
+}
+
+.lm-score {
+  color: var(--lm-accent);
+  font-size: 1.05rem;
+  font-weight: 800;
+  line-height: 1;
+
+  span {
+    margin-left: 1px;
+    color: var(--theme-text-muted);
+    font-size: 0.65rem;
+    font-weight: 650;
+  }
+}
+
+.lm-verdict-pill {
+  display: inline-flex;
+  align-items: center;
+  min-height: 24px;
+  padding: 4px 10px;
+  border: 1px solid transparent;
+  border-radius: var(--radius-full, 9999px);
+  font-size: 0.64rem;
+  font-weight: 800;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
 .lm-verdict-good { color: var(--risk-good); background: var(--risk-good-bg); border-color: var(--risk-good-border); }
 .lm-verdict-warn { color: var(--risk-warn); background: var(--risk-warn-bg); border-color: var(--risk-warn-border); }
 .lm-verdict-bad  { color: var(--risk-bad);  background: var(--risk-bad-bg);  border-color: var(--risk-bad-border); }
 .lm-verdict-na   { color: var(--theme-text-muted); background: var(--theme-bg-secondary); border-color: var(--theme-border); }
 
-// ---------------------------------------------------------------------------
-// Body — tiers stacked by severity
-// ---------------------------------------------------------------------------
 .lm-body {
   display: flex;
+  min-height: 0;
+  flex: 1 1 auto;
   flex-direction: column;
-  gap: 18px;
-  padding: 16px 20px 20px;
+  overflow: hidden;
+}
+
+.lm-tabs {
+  display: flex;
+  align-items: flex-end;
+  gap: 4px;
+  padding: 0 18px;
+  border-bottom: 1px solid var(--theme-border-subtle);
+  overflow-x: auto;
+  scrollbar-width: none;
+
+  &::-webkit-scrollbar { display: none; }
+}
+
+.lm-tab {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-height: 42px;
+  padding: 0 10px;
+  border: none;
+  background: transparent;
+  color: var(--theme-text-secondary);
+  cursor: pointer;
+  font-size: 0.78rem;
+  font-weight: 650;
+  white-space: nowrap;
+
+  span {
+    color: var(--theme-text-muted);
+    font-size: 0.68rem;
+    font-weight: 800;
+  }
+
+  &::after {
+    content: "";
+    position: absolute;
+    right: 10px;
+    bottom: 0;
+    left: 10px;
+    height: 2px;
+    background: transparent;
+    border-radius: 999px 999px 0 0;
+  }
+
+  &:hover {
+    color: var(--theme-text-primary);
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--color-ring, var(--theme-accent));
+    outline-offset: -4px;
+    border-radius: 8px;
+  }
+
+  &.is-active {
+    color: var(--theme-text-primary);
+
+    &::after { background: var(--lm-accent); }
+  }
+}
+
+.lm-tier {
+  flex: 1 1 auto;
+  min-height: 0;
+  padding: 16px 18px 18px;
+  overflow-y: auto;
+  scrollbar-width: thin;
+  scrollbar-color: var(--theme-border-subtle) transparent;
 }
 
 .lm-empty {
   margin: 0;
-  padding: 8px 0;
-  font-size: 0.8125rem;
+  padding: 12px 2px;
   color: var(--theme-text-muted);
-}
-
-.lm-tier {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-}
-
-.lm-tier-head {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-}
-
-.lm-tier-title {
-  font-size: 0.6875rem;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.09em;
-  color: var(--theme-text-muted);
-}
-
-.lm-tier--issues .lm-tier-title {
-  color: var(--risk-bad);
-}
-
-.lm-tier-count {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-width: 18px;
-  height: 18px;
-  padding: 0 5px;
-  font-size: 0.6875rem;
-  font-weight: 700;
-  font-variant-numeric: tabular-nums;
-  color: var(--theme-text-secondary);
-  background: var(--theme-bg-tertiary);
-  border-radius: var(--radius-full, 9999px);
-
-  // Accent text on a tint (AA-safe), matching the verdict-pill treatment.
-  &--issues {
-    color: var(--risk-bad);
-    background: var(--risk-bad-bg);
-    border: 1px solid var(--risk-bad-border);
-  }
-}
-
-.lm-tier-note {
-  margin: 2px 0 0;
-  font-size: 0.75rem;
-  line-height: 1.4;
-  color: var(--theme-text-subtle);
+  font-size: 0.84rem;
+  line-height: 1.45;
 }
 
 .lm-rows {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 10px;
 }
 
-// ---------------------------------------------------------------------------
-// Primary row — issues + not analyzed
-// ---------------------------------------------------------------------------
 .lm-check {
   --row-accent: var(--risk-neutral);
   --row-tint: var(--theme-bg-secondary);
 
   position: relative;
   display: grid;
-  grid-template-columns: auto 1fr auto;
-  align-items: center;
+  grid-template-columns: auto minmax(0, 1fr) auto;
   gap: 10px;
+  align-items: start;
   width: 100%;
-  padding: 11px 13px 11px 15px;
-  border-radius: var(--radius, 10px);
+  padding: 12px 12px 12px 15px;
+  overflow: hidden;
   background: var(--row-tint);
   border: 1px solid var(--theme-border-subtle);
-  overflow: hidden;
-  animation: lmFadeUp 0.28s var(--lm-ease) both;
+  border-radius: 10px;
+  animation: lmFadeUp 0.24s var(--lm-ease) both;
 
   &.lm-tone-bad     { --row-accent: var(--risk-bad);  --row-tint: var(--risk-bad-bg); border-color: var(--risk-bad-border); }
   &.lm-tone-warn    { --row-accent: var(--risk-warn); --row-tint: var(--risk-warn-bg); border-color: var(--risk-warn-border); }
-  &.lm-tone-neutral { --row-accent: var(--risk-neutral); --row-tint: var(--theme-bg-secondary); border-style: dashed; border-color: var(--theme-border); }
+  &.lm-tone-neutral { --row-accent: var(--risk-neutral); --row-tint: var(--theme-bg-secondary); border-color: var(--theme-border); }
 }
 
 .lm-check-rail {
   position: absolute;
-  left: 0;
-  top: 0;
-  bottom: 0;
+  inset: 0 auto 0 0;
   width: 3px;
   background: var(--row-accent);
 }
@@ -245,13 +303,23 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  width: 20px;
+  height: 20px;
+  margin-top: 1px;
   color: var(--row-accent);
 }
 
 .lm-check-main {
   display: flex;
-  align-items: center;
+  flex-direction: column;
+  gap: 6px;
+  min-width: 0;
+}
+
+.lm-check-title-row {
+  display: flex;
   flex-wrap: wrap;
+  align-items: center;
   gap: 6px 8px;
   min-width: 0;
 }
@@ -260,116 +328,277 @@
   display: inline-flex;
   align-items: center;
   gap: 5px;
-  font-size: 0.875rem;
-  font-weight: 600;
+  min-width: 0;
   color: var(--theme-text-primary);
+  font-size: 0.87rem;
+  font-weight: 700;
   line-height: 1.25;
 }
 
 .lm-check-tag {
-  font-size: 0.625rem;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-  color: var(--theme-text-muted);
+  display: inline-flex;
+  align-items: center;
+  min-height: 18px;
   padding: 2px 6px;
-  border-radius: 4px;
+  color: var(--theme-text-muted);
   background: var(--theme-bg-tertiary);
+  border-radius: 4px;
+  font-size: 0.58rem;
+  font-weight: 800;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
 }
 
-/* Truthful, path-safe evidence caption for a flagged / not-analyzed row.
-   Wraps to its own line under the check name (flex-basis: 100%). */
 .lm-check-evidence {
-  flex: 1 0 100%;
-  display: inline-flex;
-  align-items: baseline;
-  gap: 6px;
+  display: block;
   min-width: 0;
+  max-width: 100%;
+  overflow: hidden;
+  color: var(--theme-text-secondary);
   font-size: 0.75rem;
   line-height: 1.35;
-  color: var(--theme-text-secondary);
-  overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
+
 .lm-check-evidence-key {
-  flex-shrink: 0;
-  font-size: 0.5625rem;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
+  margin-right: 6px;
   color: var(--theme-text-muted);
+  font-size: 0.56rem;
+  font-weight: 800;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.lm-check-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  flex: 0 0 auto;
 }
 
 .lm-check-status {
-  flex-shrink: 0;
-  font-size: 0.625rem;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
+  display: inline-flex;
+  align-items: center;
+  min-height: 24px;
   padding: 4px 9px;
-  border-radius: var(--radius-full, 9999px);
-  white-space: nowrap;
   border: 1px solid transparent;
+  border-radius: var(--radius-full, 9999px);
+  font-size: 0.59rem;
+  font-weight: 850;
+  letter-spacing: 0.045em;
+  line-height: 1;
+  text-transform: uppercase;
+  white-space: nowrap;
 }
-// Dark ink on a solid accent: loud, and AA-contrast on both amber and red in
-// either theme (white-on-amber failed WCAG).
+
 .lm-status-issues {
   color: #1c1a17;
   background: var(--row-accent);
-  font-weight: 800;
 }
+
 .lm-status-unknown {
   color: var(--theme-text-secondary);
   background: var(--theme-bg-tertiary);
   border-color: var(--theme-border);
 }
 
-// ---------------------------------------------------------------------------
-// Cleared tier — quiet, dense, low-contrast (no green pill noise)
-// ---------------------------------------------------------------------------
+.lm-tone-pill-neutral {
+  color: var(--theme-text-secondary);
+  background: var(--theme-bg-tertiary);
+  border-color: var(--theme-border);
+}
+
+.lm-evidence-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  padding: 0;
+  color: var(--theme-text-muted);
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 7px;
+  cursor: pointer;
+
+  svg { transition: transform 0.16s ease; }
+  &.is-open svg { transform: rotate(180deg); }
+
+  &:hover {
+    color: var(--theme-text-primary);
+    background: var(--theme-bg-tertiary);
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--color-ring, var(--theme-accent));
+    outline-offset: 1px;
+  }
+}
+
+.lm-check-detail {
+  grid-column: 2 / -1;
+  display: flex;
+  flex-direction: column;
+  gap: 9px;
+  margin-top: 2px;
+}
+
+.lm-check-detail-summary {
+  margin: 0;
+  padding: 9px 10px;
+  color: var(--theme-text-secondary);
+  background: color-mix(in srgb, var(--row-accent) 9%, transparent);
+  border: 1px solid color-mix(in srgb, var(--row-accent) 24%, transparent);
+  border-radius: 8px;
+  font-size: 0.78rem;
+  line-height: 1.42;
+}
+
+.lm-evidence-panel,
+.lm-evidence-empty {
+  padding: 9px 10px;
+  background: var(--theme-bg-card);
+  border: 1px solid var(--theme-border-subtle);
+  border-radius: 8px;
+}
+
+.lm-evidence-empty {
+  color: var(--theme-text-muted);
+  font-size: 0.78rem;
+  line-height: 1.42;
+}
+
+.lm-evidence-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 7px;
+}
+
+.lm-evidence-row {
+  display: grid;
+  grid-template-columns: 92px minmax(0, 1fr);
+  gap: 8px;
+  align-items: baseline;
+  min-width: 0;
+}
+
+.lm-evidence-row-key {
+  color: var(--theme-text-muted);
+  font-size: 0.64rem;
+  font-weight: 800;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.lm-evidence-row-value {
+  min-width: 0;
+  color: var(--theme-text-primary);
+  font-size: 0.77rem;
+  line-height: 1.35;
+  overflow-wrap: anywhere;
+}
+
+.lm-evidence-row--snippet {
+  grid-template-columns: 1fr;
+  gap: 5px;
+}
+
+.lm-evidence-snippet {
+  margin: 0;
+  padding: 8px 9px;
+  max-height: 120px;
+  overflow: auto;
+  color: var(--theme-text-primary);
+  background: var(--extensionshield-code-bg, rgba(0, 0, 0, 0.06));
+  border-radius: 6px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.72rem;
+  line-height: 1.45;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+.lm-tier-note {
+  margin: 10px 0 0;
+  color: var(--theme-text-subtle);
+  font-size: 0.75rem;
+  line-height: 1.4;
+}
+
 .lm-clear-grid {
   display: grid;
   grid-template-columns: 1fr 1fr;
-  gap: 4px 16px;
+  gap: 7px 16px;
 }
 
 .lm-clear-row {
   display: flex;
   align-items: center;
   gap: 7px;
-  padding: 5px 2px;
   min-width: 0;
+  padding: 5px 2px;
 }
 
 .lm-clear-tick {
+  flex: 0 0 auto;
   color: var(--risk-good);
-  opacity: 0.85;
-  flex-shrink: 0;
 }
 
 .lm-clear-name {
-  font-size: 0.8125rem;
-  font-weight: 500;
+  min-width: 0;
+  color: var(--theme-text-secondary);
+  font-size: 0.82rem;
+  font-weight: 550;
   line-height: 1.3;
-  color: var(--theme-text-muted);
 }
 
-// ---------------------------------------------------------------------------
-// Info tooltip (i icon)
-// ---------------------------------------------------------------------------
+.lm-about-card {
+  margin-bottom: 12px;
+  padding: 12px 13px;
+  background: var(--theme-bg-secondary);
+  border: 1px solid var(--theme-border-subtle);
+  border-radius: 10px;
+
+  p {
+    margin: 4px 0 0;
+    color: var(--theme-text-secondary);
+    font-size: 0.84rem;
+    line-height: 1.45;
+  }
+}
+
+.lm-about-label {
+  color: var(--theme-text-muted);
+  font-size: 0.64rem;
+  font-weight: 850;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.lm-about-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin: 0;
+  padding: 0 0 0 18px;
+  color: var(--theme-text-secondary);
+  font-size: 0.84rem;
+  line-height: 1.45;
+}
+
 .lm-info-trigger {
   position: relative;
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  flex-shrink: 0;
   color: var(--theme-text-muted);
   cursor: help;
-  flex-shrink: 0;
-  opacity: 0.55;
-  transition: opacity 0.15s ease, color 0.15s ease;
+  opacity: 0.58;
   outline: none;
   border-radius: 50%;
+  transition: opacity 0.15s ease, color 0.15s ease;
 
   &:hover,
   &:focus-visible {
@@ -382,46 +611,33 @@
   position: absolute;
   bottom: calc(100% + 8px);
   left: 50%;
-  transform: translateX(-50%);
+  width: max-content;
+  max-width: 220px;
   padding: 8px 12px;
-  font-size: 0.75rem;
-  font-weight: 400;
-  line-height: 1.45;
   color: var(--theme-text-primary);
   background: var(--theme-bg-card);
   border: 1px solid var(--theme-border);
   border-radius: 8px;
   box-shadow: 0 8px 24px rgba(0, 0, 0, 0.25);
-  white-space: normal;
-  width: max-content;
-  max-width: 220px;
-  z-index: 50;
-  pointer-events: none;
+  font-size: 0.75rem;
+  font-weight: 400;
+  line-height: 1.45;
   opacity: 0;
+  pointer-events: none;
+  transform: translateX(-50%);
   visibility: hidden;
-  transition: opacity 0.15s ease, visibility 0.15s ease, transform 0.15s ease;
+  white-space: normal;
+  z-index: 50;
 }
 
 .lm-info-tooltip--portal {
   position: fixed;
   bottom: auto;
-  transform: translate(-50%, -100%);
   z-index: 10000;
   opacity: 1;
+  transform: translate(-50%, -100%);
   visibility: visible;
   animation: lmTooltipPortalIn 0.15s ease both;
-}
-
-.lm-info-trigger:hover .lm-info-tooltip,
-.lm-info-trigger:focus-visible .lm-info-tooltip {
-  opacity: 1;
-  visibility: visible;
-  animation: lmTooltipIn 0.15s ease both;
-}
-
-@keyframes lmTooltipIn {
-  from { opacity: 0; transform: translateX(-50%) translateY(4px); }
-  to   { opacity: 1; transform: translateX(-50%) translateY(0); }
 }
 
 @keyframes lmTooltipPortalIn {
@@ -434,72 +650,61 @@
   to   { opacity: 1; transform: translateY(0); }
 }
 
-// ---------------------------------------------------------------------------
-// Responsive
-// ---------------------------------------------------------------------------
-@media (max-width: 480px) {
-  .lm-content {
-    max-width: 100%;
-    border-radius: var(--radius, 12px);
-  }
-  .lm-header-inner {
-    flex-wrap: wrap;
-    justify-content: flex-start;
-    gap: 8px;
-    padding-right: 48px;
-  }
-  .lm-verdict-pill {
-    align-self: flex-start;
-  }
-  .lm-clear-grid {
-    grid-template-columns: 1fr;
-    gap: 2px;
-  }
-}
-
-.lm-content button:focus-visible {
-  outline: 2px solid var(--color-ring, var(--theme-accent));
-  outline-offset: 2px;
-  border-radius: 6px;
-}
-
-// ---------------------------------------------------------------------------
-// Light theme overrides
-// ---------------------------------------------------------------------------
-.light .lm-dialog-smooth > button {
-  color: var(--extensionshield-text-muted);
-  &:hover {
-    color: var(--extensionshield-text-primary);
-    background: var(--theme-hover-bg);
-  }
-}
-
-.light .lm-content {
-  background: var(--theme-bg-card);
-  border-color: var(--theme-border);
-  color: var(--theme-text-primary);
-  box-shadow: var(--theme-shadow-dropdown);
-}
-
-.light .lm-header-inner {
-  border-bottom-color: var(--theme-border-subtle);
-}
-
-.light .lm-check {
-  background: var(--row-tint, var(--theme-bg-secondary));
-}
-
-.light .lm-check.lm-tone-neutral {
-  background: var(--theme-bg-secondary);
-}
-
 .light .lm-status-issues {
   color: #fff;
 }
 
 .light .lm-info-tooltip {
-  background: var(--theme-bg-card);
-  border-color: var(--theme-border);
-  color: var(--theme-text-primary);
   box-shadow: 0 8px 24px rgba(0, 0, 0, 0.1);
+}
+
+@media (max-width: 700px) {
+  .lm-dialog-smooth {
+    inset: auto 10px 10px 10px !important;
+    top: auto !important;
+    right: 10px !important;
+    left: 10px !important;
+    transform: none !important;
+  }
+
+  .lm-content {
+    width: auto;
+    max-width: none;
+    max-height: calc(100vh - 20px);
+  }
+
+  .lm-header-inner {
+    padding: 16px 52px 14px 16px;
+  }
+
+  .lm-header-score {
+    align-items: flex-start;
+  }
+
+  .lm-tier {
+    padding: 14px 14px 16px;
+  }
+
+  .lm-check {
+    grid-template-columns: auto minmax(0, 1fr);
+  }
+
+  .lm-check-actions {
+    grid-column: 2;
+    justify-content: space-between;
+    width: 100%;
+  }
+
+  .lm-check-detail {
+    grid-column: 1 / -1;
+  }
+
+  .lm-clear-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .lm-evidence-row {
+    grid-template-columns: 1fr;
+    gap: 3px;
+  }
 }

--- a/frontend/src/components/report/LayerModal.scss
+++ b/frontend/src/components/report/LayerModal.scss
@@ -21,7 +21,8 @@
   bottom: auto !important;
   left: 50dvw !important;
   margin: 0 !important;
-  transform: translate3d(-50%, -50%, 0) !important;
+  translate: -50% -50% !important;
+  transform: none !important;
   z-index: 10000 !important;
 
   &[data-state="open"],
@@ -678,7 +679,8 @@
     bottom: auto !important;
     left: 50dvw !important;
     margin: 0 !important;
-    transform: translate3d(-50%, -50%, 0) !important;
+    translate: -50% -50% !important;
+    transform: none !important;
   }
 
   .lm-content {

--- a/frontend/src/components/report/LayerModal.scss
+++ b/frontend/src/components/report/LayerModal.scss
@@ -15,13 +15,13 @@
 
 .lm-dialog-smooth {
   position: fixed !important;
-  inset: 50% auto auto 50% !important;
-  top: 50% !important;
+  inset: 50dvh auto auto 50dvw !important;
+  top: 50dvh !important;
   right: auto !important;
   bottom: auto !important;
-  left: 50% !important;
+  left: 50dvw !important;
   margin: 0 !important;
-  transform: translate(-50%, -50%) !important;
+  transform: translate3d(-50%, -50%, 0) !important;
   z-index: 10000 !important;
 
   &[data-state="open"],
@@ -73,8 +73,8 @@
 }
 
 @keyframes lmDrawerIn {
-  from { opacity: 0; transform: translate(-50%, calc(-50% + 10px)) scale(0.99); }
-  to   { opacity: 1; transform: translate(-50%, -50%) scale(1); }
+  from { opacity: 0; }
+  to   { opacity: 1; }
 }
 
 .lm-header-wrap,
@@ -672,13 +672,13 @@
 @media (max-width: 700px) {
   .lm-dialog-smooth {
     position: fixed !important;
-    inset: 50% auto auto 50% !important;
-    top: 50% !important;
+    inset: 50dvh auto auto 50dvw !important;
+    top: 50dvh !important;
     right: auto !important;
     bottom: auto !important;
-    left: 50% !important;
+    left: 50dvw !important;
     margin: 0 !important;
-    transform: translate(-50%, -50%) !important;
+    transform: translate3d(-50%, -50%, 0) !important;
   }
 
   .lm-content {

--- a/frontend/src/components/report/LayerModal.scss
+++ b/frontend/src/components/report/LayerModal.scss
@@ -277,6 +277,30 @@
   background: var(--theme-bg-tertiary);
 }
 
+/* Truthful, path-safe evidence caption for a flagged / not-analyzed row.
+   Wraps to its own line under the check name (flex-basis: 100%). */
+.lm-check-evidence {
+  flex: 1 0 100%;
+  display: inline-flex;
+  align-items: baseline;
+  gap: 6px;
+  min-width: 0;
+  font-size: 0.75rem;
+  line-height: 1.35;
+  color: var(--theme-text-secondary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.lm-check-evidence-key {
+  flex-shrink: 0;
+  font-size: 0.5625rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--theme-text-muted);
+}
+
 .lm-check-status {
   flex-shrink: 0;
   font-size: 0.625rem;

--- a/frontend/src/components/report/LayerModal.scss
+++ b/frontend/src/components/report/LayerModal.scss
@@ -8,10 +8,9 @@
 }
 
 .lm-dialog-smooth {
-  left: auto !important;
-  right: clamp(12px, 3vw, 28px) !important;
   top: 50% !important;
-  transform: translateY(-50%) !important;
+  left: 50% !important;
+  transform: translate(-50%, -50%) !important;
 
   &[data-state="open"],
   &[data-state="closed"] {
@@ -62,8 +61,8 @@
 }
 
 @keyframes lmDrawerIn {
-  from { opacity: 0; transform: translateY(-50%) translateX(18px) scale(0.99); }
-  to   { opacity: 1; transform: translateY(-50%) translateX(0) scale(1); }
+  from { opacity: 0; transform: translate(-50%, -48%) scale(0.99); }
+  to   { opacity: 1; transform: translate(-50%, -50%) scale(1); }
 }
 
 .lm-header-wrap,
@@ -660,16 +659,15 @@
 
 @media (max-width: 700px) {
   .lm-dialog-smooth {
-    inset: auto 10px 10px 10px !important;
-    top: auto !important;
-    right: 10px !important;
-    left: 10px !important;
-    transform: none !important;
+    top: 50% !important;
+    left: 50% !important;
+    right: auto !important;
+    transform: translate(-50%, -50%) !important;
   }
 
   .lm-content {
-    width: auto;
-    max-width: none;
+    width: calc(100vw - 20px);
+    max-width: 520px;
     max-height: calc(100vh - 20px);
   }
 

--- a/frontend/src/components/report/LayerModal.test.jsx
+++ b/frontend/src/components/report/LayerModal.test.jsx
@@ -9,8 +9,17 @@
  *
  * Pure logic only — no rendering required.
  */
-import { describe, it, expect } from 'vitest';
-import { factorEvidenceCaption, humanizeFactor, isNotAnalyzed, triageFactors } from './layerFactors';
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { fireEvent, render, screen, within } from '@testing-library/react';
+import LayerModal from './LayerModal';
+import {
+  buildLayerModalModel,
+  factorEvidenceCaption,
+  humanizeFactor,
+  isNotAnalyzed,
+  triageFactors,
+} from './layerFactors';
 
 describe('LayerModal status mapping', () => {
   it('Data Sharing with no network coverage is "Not analyzed", not "Clear"', () => {
@@ -149,5 +158,171 @@ describe('factorEvidenceCaption', () => {
   it('is attached to humanized factors', () => {
     const h = humanizeFactor({ name: 'Maintenance', severity: 0.8, details: { days_since_update: 400 } });
     expect(h.evidence).toBe('Last updated 400 days ago');
+  });
+});
+
+describe('buildLayerModalModel', () => {
+  it('builds open, cleared, and not-analyzed sections from real layer factors/findings', () => {
+    const model = buildLayerModalModel({
+      factors: [
+        { name: 'Manifest', severity: 0.6, details: { description: 'missing CSP in manifest' } },
+        { name: 'SAST', severity: 0.1 },
+        { name: 'NetworkExfil', severity: 0, details: { network_analysis_enabled: false } },
+      ],
+      keyFindings: [
+        {
+          title: 'Extension Config missing CSP',
+          severity: 'medium',
+          layer: 'security',
+          summary: 'missing CSP in manifest',
+          evidence: { available: true, kind: 'manifest', manifestField: 'content_security_policy', label: 'missing CSP in manifest' },
+        },
+      ],
+    });
+
+    expect(model.issues.map((row) => row.title)).toContain('Extension Config missing CSP');
+    expect(model.cleared.map((row) => row.label)).toContain('Code Safety');
+    expect(model.notAnalyzed.map((row) => row.title)).toContain('Data Sharing');
+  });
+
+  it('renders relative evidence details without local absolute paths', () => {
+    const model = buildLayerModalModel({
+      keyFindings: [{
+        title: 'Static analysis finding',
+        severity: 'high',
+        layer: 'security',
+        evidence: {
+          available: true,
+          kind: 'sast',
+          filePath: '/Users/stanzin/ExtensionShield/extensions_storage/extracted_a/js/background.js',
+          lineStart: 9,
+          snippet: 'chrome.tabs.query({})',
+          label: '/Users/stanzin/ExtensionShield/extensions_storage/extracted_a/js/background.js:9',
+        },
+      }],
+    });
+
+    const text = JSON.stringify(model);
+    expect(text).toContain('js/background.js:9');
+    expect(text).not.toMatch(/\/Users|\/home|extensions_storage|extracted_/);
+  });
+});
+
+describe('LayerModal rendering', () => {
+  const renderModal = (props = {}) => render(
+    <LayerModal
+      open
+      onClose={vi.fn()}
+      layer="security"
+      score={90}
+      band="WARN"
+      factors={[
+        { name: 'Manifest', severity: 0.6, details: { description: 'missing CSP in manifest', manifest_field: 'content_security_policy' } },
+        { name: 'SAST', severity: 0.1 },
+        { name: 'VirusTotal', severity: 0.1 },
+        { name: 'NetworkExfil', severity: 0, details: { network_analysis_enabled: false, reason: 'Rate limited' } },
+      ]}
+      keyFindings={[
+        {
+          title: 'Extension Config missing CSP',
+          severity: 'medium',
+          layer: 'security',
+          summary: 'missing CSP in manifest',
+          evidence: { available: true, kind: 'manifest', manifestField: 'content_security_policy', label: 'missing CSP in manifest' },
+        },
+      ]}
+      layerReasons={['Security layer reason from scoring']}
+      {...props}
+    />
+  );
+
+  it('opens a Security modal with open, cleared, and not-analyzed tabs', () => {
+    renderModal();
+
+    expect(screen.getByText('Security')).toBeInTheDocument();
+    expect(screen.getByText('90')).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: /Open Issues/i })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: /Cleared/i })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: /Not Analyzed/i })).toBeInTheDocument();
+    expect(screen.getByText('Extension Config missing CSP')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('tab', { name: /Cleared/i }));
+    expect(screen.getByText('Code Safety')).toBeInTheDocument();
+    expect(screen.getByText('Malware Scan')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('tab', { name: /Not Analyzed/i }));
+    expect(screen.getByText('Data Sharing')).toBeInTheDocument();
+  });
+
+  it('opens Privacy and Governance modals with the same section structure', () => {
+    renderModal({
+      layer: 'privacy',
+      score: 58,
+      factors: [
+        { name: 'PermissionsBaseline', severity: 0.8, details: { permission: 'tabs' } },
+        { name: 'NetworkExfil', severity: 0, details: { network_analysis_enabled: false } },
+      ],
+      keyFindings: [],
+    });
+    expect(screen.getByText('Privacy')).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: /Open Issues/i })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: /Cleared/i })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: /Not Analyzed/i })).toBeInTheDocument();
+
+    renderModal({
+      layer: 'governance',
+      score: 100,
+      band: 'GOOD',
+      factors: [
+        { name: 'ToSViolations', severity: 0.1 },
+        { name: 'DisclosureAlignment', severity: 0.1 },
+      ],
+      keyFindings: [],
+    });
+    expect(screen.getByText('Governance')).toBeInTheDocument();
+    expect(screen.getAllByRole('tab', { name: /Open Issues/i }).length).toBeGreaterThan(0);
+    expect(screen.getAllByRole('tab', { name: /Cleared/i }).length).toBeGreaterThan(0);
+    expect(screen.getAllByRole('tab', { name: /Not Analyzed/i }).length).toBeGreaterThan(0);
+  });
+
+  it('renders expandable evidence detail when data exists', () => {
+    renderModal();
+
+    const issue = screen.getByText('Extension Config missing CSP').closest('.lm-check');
+    expect(within(issue).getByText('Evidence')).toBeInTheDocument();
+    fireEvent.click(within(issue).getByRole('button', { name: /Toggle evidence/i }));
+    expect(within(issue).getByText('Manifest')).toBeInTheDocument();
+    expect(within(issue).getByText('content_security_policy')).toBeInTheDocument();
+  });
+
+  it('shows a safe empty state when an issue has no structured evidence', () => {
+    renderModal({
+      factors: [{ name: 'Obfuscation', severity: 0.7 }],
+      keyFindings: [],
+    });
+
+    expect(screen.getByText('Hidden Code')).toBeInTheDocument();
+    expect(screen.getByText('No structured evidence is available for this item.')).toBeInTheDocument();
+  });
+
+  it('does not render local absolute paths in modal text', () => {
+    renderModal({
+      factors: [],
+      keyFindings: [{
+        title: 'Code path finding',
+        severity: 'high',
+        layer: 'security',
+        evidence: {
+          available: true,
+          kind: 'sast',
+          filePath: '/Users/stanzin/ExtensionShield/extensions_storage/extracted_a/background.js',
+          lineStart: 12,
+          label: '/Users/stanzin/ExtensionShield/extensions_storage/extracted_a/background.js:12',
+        },
+      }],
+    });
+
+    expect(document.body.textContent).toContain('background.js:12');
+    expect(document.body.textContent).not.toMatch(/\/Users|\/home|extensions_storage|extracted_/);
   });
 });

--- a/frontend/src/components/report/LayerModal.test.jsx
+++ b/frontend/src/components/report/LayerModal.test.jsx
@@ -10,7 +10,7 @@
  * Pure logic only — no rendering required.
  */
 import { describe, it, expect } from 'vitest';
-import { humanizeFactor, isNotAnalyzed, triageFactors } from './layerFactors';
+import { factorEvidenceCaption, humanizeFactor, isNotAnalyzed, triageFactors } from './layerFactors';
 
 describe('LayerModal status mapping', () => {
   it('Data Sharing with no network coverage is "Not analyzed", not "Clear"', () => {
@@ -109,5 +109,45 @@ describe('LayerModal triage ordering', () => {
     expect(issues).toEqual([]);
     expect(notAnalyzed).toEqual([]);
     expect(cleared).toEqual([]);
+  });
+});
+
+describe('factorEvidenceCaption', () => {
+  it('prefers an explicit analyzer description', () => {
+    expect(factorEvidenceCaption({ name: 'SAST', details: { description: 'Reads document.cookie' } }))
+      .toBe('Reads document.cookie');
+  });
+
+  it('renders publisher update age from days_since_update', () => {
+    expect(factorEvidenceCaption({ name: 'Maintenance', details: { days_since_update: 508 } }))
+      .toBe('Last updated 508 days ago');
+    expect(factorEvidenceCaption({ name: 'Maintenance', details: { days_since_update: 1 } }))
+      .toBe('Last updated 1 day ago');
+  });
+
+  it('renders a relative file:line reference and never a local absolute path', () => {
+    const cap = factorEvidenceCaption({
+      name: 'SAST',
+      details: { file: '/Users/x/ExtensionShield/extensions_storage/extracted_a/js/background.js', line: 42 },
+    });
+    expect(cap).toBe('js/background.js:42');
+    expect(cap).not.toMatch(/\/Users|\/home|extensions_storage|extracted_/);
+  });
+
+  it('drops a free-text caption that would leak a local path', () => {
+    expect(factorEvidenceCaption({ name: 'SAST', details: { description: 'see /Users/stanzin/secret/app.js' } }))
+      .toBe('see app.js');
+  });
+
+  it('falls back to reason, then to empty string when no evidence exists', () => {
+    expect(factorEvidenceCaption({ name: 'X', details: { reason: 'Rate limited' } })).toBe('Rate limited');
+    expect(factorEvidenceCaption({ name: 'X', details: {} })).toBe('');
+    expect(factorEvidenceCaption({ name: 'X' })).toBe('');
+    expect(factorEvidenceCaption(null)).toBe('');
+  });
+
+  it('is attached to humanized factors', () => {
+    const h = humanizeFactor({ name: 'Maintenance', severity: 0.8, details: { days_since_update: 400 } });
+    expect(h.evidence).toBe('Last updated 400 days ago');
   });
 });

--- a/frontend/src/components/report/LayerModal.test.jsx
+++ b/frontend/src/components/report/LayerModal.test.jsx
@@ -73,6 +73,20 @@ describe('LayerModal status mapping', () => {
     expect(moderate.tone).toBe('warn');
   });
 
+  it('advisory publisher update age below 0.6 is NOT counted as an open issue', () => {
+    // Under the key-finding threshold (0.6, ~180 days) it is routine context,
+    // so the modal must not count it among "Open Issues" (matches the card /
+    // Issue Overview / Key Findings, which all exclude it). At >= 0.6 it stays a
+    // visible caution in the issues tier.
+    const routine = humanizeFactor({ name: 'Maintenance', severity: 0.4 });
+    expect(routine.statusType).not.toBe('issues');
+    expect(routine.status).toBe('Caution');
+
+    const olderThan180d = humanizeFactor({ name: 'Maintenance', severity: 0.6 });
+    expect(olderThan180d.statusType).toBe('issues');
+    expect(olderThan180d.status).toBe('Caution');
+  });
+
   it('an actual finding wins over the not-analyzed flag', () => {
     const result = humanizeFactor({
       name: 'NetworkExfil',
@@ -82,9 +96,19 @@ describe('LayerModal status mapping', () => {
     expect(result.statusType).toBe('issues');
   });
 
-  it('isNotAnalyzed only fires on the explicit coverage flag', () => {
+  it('isNotAnalyzed fires on real did-not-run signals, not on clean scans', () => {
+    // Network/exfil analyzer coverage flag.
     expect(isNotAnalyzed({ details: { network_analysis_enabled: false } })).toBe(true);
     expect(isNotAnalyzed({ details: { network_analysis_enabled: true } })).toBe(false);
+    // VirusTotal with zero engines = no coverage (hash not in DB / rate-limited).
+    expect(isNotAnalyzed({ name: 'VirusTotal', details: { total_engines: 0 } })).toBe(true);
+    // A real clean VT scan reports dozens of engines -> genuinely "Clear".
+    expect(isNotAnalyzed({ name: 'VirusTotal', details: { total_engines: 75 } })).toBe(false);
+    // SAST that scanned no code (minified-only / download failed).
+    expect(isNotAnalyzed({ name: 'SAST', details: { files_scanned: 0, deduped_findings: 0 } })).toBe(true);
+    // SAST that actually scanned files with no findings -> genuinely "Clear".
+    expect(isNotAnalyzed({ name: 'SAST', details: { files_scanned: 8, deduped_findings: 0 } })).toBe(false);
+    // No details / unrelated factor -> not flagged.
     expect(isNotAnalyzed({ details: {} })).toBe(false);
     expect(isNotAnalyzed({})).toBe(false);
   });

--- a/frontend/src/components/report/SummaryPanel.jsx
+++ b/frontend/src/components/report/SummaryPanel.jsx
@@ -52,6 +52,7 @@ const SummaryPanel = ({
       summary: finding.summary || finding.title || '',
       severity: typeof finding.severity === 'string' ? finding.severity : 'medium',
       evidenceIds: Array.isArray(finding.evidenceIds) ? finding.evidenceIds : [],
+      evidence: finding.evidence || null,
     }));
 
   const fallbackFindings = (keyFindings || [])
@@ -64,6 +65,7 @@ const SummaryPanel = ({
       summary: finding.summary || finding.title || '',
       severity: finding.severity || 'medium',
       evidenceIds: Array.isArray(finding.evidenceIds) ? finding.evidenceIds : [],
+      evidence: finding.evidence || null,
     }));
 
   const findingsToShow = (normalizedTopFindings.length > 0 ? normalizedTopFindings : fallbackFindings)
@@ -343,6 +345,14 @@ const SummaryPanel = ({
                 </span>
               </div>
               <p className="summary-finding-summary">{finding.summary}</p>
+              {finding.evidence && finding.evidence.available && finding.evidence.label && (
+                <p className="summary-finding-evidence-ref" title={finding.evidence.snippet || finding.evidence.reason || finding.evidence.finalReason || ''}>
+                  <span className="summary-finding-evidence-ref__label">Evidence:</span> {finding.evidence.label}
+                </p>
+              )}
+              {finding.evidence && finding.evidence.available === false && (
+                <p className="summary-finding-evidence-ref summary-finding-evidence-ref--none">Evidence: summary only</p>
+              )}
               {typeof onViewEvidence === 'function' && finding.evidenceIds.length > 0 && (
                 <button
                   type="button"

--- a/frontend/src/components/report/SummaryPanel.scss
+++ b/frontend/src/components/report/SummaryPanel.scss
@@ -463,6 +463,24 @@
     }
   }
 
+  .summary-finding-evidence-ref {
+    margin: 0;
+    font-size: 0.8125rem;
+    line-height: 1.4;
+    color: var(--theme-text-muted);
+    overflow-wrap: anywhere;
+
+    &__label {
+      font-weight: 600;
+      color: var(--theme-text-secondary);
+    }
+
+    &--none {
+      font-style: italic;
+      opacity: 0.85;
+    }
+  }
+
   .top-findings-title {
     font-size: 0.6875rem;
     font-weight: 700;

--- a/frontend/src/components/report/index.js
+++ b/frontend/src/components/report/index.js
@@ -14,4 +14,5 @@ export { default as SafetyLabelCard } from './SafetyLabelCard';
 export { default as ScenarioGrid } from './ScenarioGrid';
 export { default as ResultFeedback } from './ResultFeedback';
 export { default as AnalyzerCoverage } from './AnalyzerCoverage';
+export { default as EvidenceTechnicalDetails } from './EvidenceTechnicalDetails';
 export { default as SimilarExtensions } from './SimilarExtensions';

--- a/frontend/src/components/report/layerFactors.js
+++ b/frontend/src/components/report/layerFactors.js
@@ -2,6 +2,63 @@
 // module (no React components) so they stay unit-testable and don't trip
 // react-refresh/only-export-components in the LayerModal component file.
 
+import { toRelativeEvidencePath } from '../../utils/normalizeScanResult';
+
+// Local-filesystem fragments that must never reach the UI (matches the audited
+// LEAK_FRAGMENTS guard). Used to scrub free-text captions before display.
+const LOCAL_PATH_RE = /\/Users\/|\/home\/|extensions_storage|extracted_|[A-Za-z]:[\\/]/;
+
+/**
+ * Scrub a free-text caption so it can never render a local absolute path.
+ * Path-like tokens are rewritten to their extension-relative form; if anything
+ * still looks local afterward, the caption is dropped entirely (returns '').
+ */
+function scrubLocalPaths(text) {
+  const s = String(text || '').trim();
+  if (!s) return '';
+  if (!LOCAL_PATH_RE.test(s)) return s;
+  const cleaned = s.replace(/\S+/g, (tok) => (LOCAL_PATH_RE.test(tok) ? toRelativeEvidencePath(tok) : tok));
+  return LOCAL_PATH_RE.test(cleaned) ? '' : cleaned;
+}
+
+/**
+ * Build a short, truthful evidence caption for a single factor from real
+ * analyzer output only — never invents text. Preference order:
+ *   1. an explicit human `description` from the analyzer,
+ *   2. publisher update age (`days_since_update`),
+ *   3. a file[:line] reference (path always made extension-relative),
+ *   4. a `reason` string.
+ * Returns '' when the factor carries no presentable evidence. Any path is run
+ * through the leak guard so `/Users`, `/home`, `extensions_storage`, and
+ * `extracted_` fragments can never render.
+ */
+export function factorEvidenceCaption(factor) {
+  const details = (factor && typeof factor.details === 'object' && factor.details) || {};
+
+  if (typeof details.description === 'string' && details.description.trim()) {
+    return scrubLocalPaths(details.description);
+  }
+
+  const days = details.days_since_update;
+  if (typeof days === 'number' && Number.isFinite(days) && days >= 0) {
+    return `Last updated ${days} day${days === 1 ? '' : 's'} ago`;
+  }
+
+  const file = details.file ?? details.path ?? details.file_path;
+  if (typeof file === 'string' && file.trim()) {
+    const rel = toRelativeEvidencePath(file);
+    const lineRaw = details.line ?? details.line_number;
+    const line = Number(lineRaw);
+    return Number.isFinite(line) && line > 0 ? `${rel}:${line}` : rel;
+  }
+
+  if (typeof details.reason === 'string' && details.reason.trim()) {
+    return scrubLocalPaths(details.reason);
+  }
+
+  return '';
+}
+
 const FACTOR_HUMAN = {
   SAST:                 { label: 'Code Safety',           category: 'code',   desc: 'Scans source code for known vulnerability patterns' },
   VirusTotal:           { label: 'Malware Scan',          category: 'threat', desc: 'Checks against 70+ antivirus engines for malicious code' },
@@ -64,7 +121,7 @@ export function humanizeFactor(factor) {
     tone = 'good';
     status = 'Clear';
   }
-  return { ...info, status, statusType, tone, severity, raw: factor };
+  return { ...info, status, statusType, tone, severity, evidence: factorEvidenceCaption(factor), raw: factor };
 }
 
 /**

--- a/frontend/src/components/report/layerFactors.js
+++ b/frontend/src/components/report/layerFactors.js
@@ -325,7 +325,15 @@ const FACTOR_HUMAN = {
 export function isNotAnalyzed(factor) {
   const details = factor?.details;
   if (!details || typeof details !== 'object') return false;
+  // Network/exfil analyzer explicitly reports it did not run.
   if (details.network_analysis_enabled === false) return true;
+  // VirusTotal returned no coverage (hash not in DB / unavailable / rate-limited):
+  // zero engines scanned. A real clean scan reports dozens of engines, so a
+  // severity-0 VT factor with 0 engines is "did not run", not "clean".
+  if (factor?.name === 'VirusTotal' && Number(details.total_engines) === 0) return true;
+  // SAST analyzed no code (minified/bundled-only, or the download failed):
+  // 0 files scanned and nothing deduped means it could not clear code safety.
+  if (factor?.name === 'SAST' && Number(details.files_scanned) === 0 && !details.deduped_findings) return true;
   return false;
 }
 
@@ -349,10 +357,15 @@ export function humanizeFactor(factor) {
   const isAdvisoryTrust = factor.name === 'Maintenance';
   let status, statusType, tone;
   if (severity >= 0.4) {
-    statusType = 'issues';
     const isHigh = severity >= 0.7 && !isAdvisoryTrust;
     tone = isHigh ? 'bad' : 'warn';
     status = isHigh ? 'High severity' : isAdvisoryTrust ? 'Caution' : 'Issue';
+    // Publisher update age below the key-finding threshold (0.6, matching
+    // buildKeyFindings in normalizeScanResult) is routine context, not an open
+    // issue. Keep the "Caution" label but do not count it among issues, so the
+    // modal agrees with the card / Issue Overview / Key Findings, which all
+    // exclude it. At >= 0.6 (>180 days) it remains a visible caution.
+    statusType = (isAdvisoryTrust && severity < 0.6) ? 'clear' : 'issues';
   } else if (isNotAnalyzed(factor)) {
     statusType = 'unknown';
     tone = 'neutral';

--- a/frontend/src/components/report/layerFactors.js
+++ b/frontend/src/components/report/layerFactors.js
@@ -59,6 +59,247 @@ export function factorEvidenceCaption(factor) {
   return '';
 }
 
+function pushEvidenceRow(rows, key, value, kind = 'text') {
+  const safeValue = scrubLocalPaths(value);
+  if (!safeValue) return;
+  rows.push({ key, value: safeValue, kind });
+}
+
+function fileLineValue(file, lineRaw, lineEndRaw) {
+  if (typeof file !== 'string' || !file.trim()) return '';
+  const rel = toRelativeEvidencePath(file);
+  const line = Number(lineRaw);
+  const lineEnd = Number(lineEndRaw);
+  if (!Number.isFinite(line) || line <= 0) return rel;
+  return Number.isFinite(lineEnd) && lineEnd > line ? `${rel}:${line}-${lineEnd}` : `${rel}:${line}`;
+}
+
+function severityRank(statusType, severity) {
+  if (statusType !== 'issues') return 0;
+  if (severity >= 0.7) return 3;
+  if (severity >= 0.4) return 2;
+  return 1;
+}
+
+function normalizeTitle(title) {
+  return String(title || '').trim().toLowerCase();
+}
+
+function findingLevel(finding) {
+  const severity = finding?.severity;
+  if (typeof severity === 'number') {
+    if (severity >= 0.66) return 'high';
+    if (severity >= 0.4) return 'medium';
+    if (severity > 0) return 'low';
+    return 'info';
+  }
+  const s = String(severity || '').toLowerCase();
+  if (s === 'critical' || s === 'high') return 'high';
+  if (s === 'moderate' || s === 'medium') return 'medium';
+  if (s === 'low') return 'low';
+  return 'info';
+}
+
+function statusForFinding(finding) {
+  const level = findingLevel(finding);
+  if (level === 'high') return { status: 'High severity', tone: 'bad', severity: 0.8 };
+  if (level === 'medium') return { status: 'Issue', tone: 'warn', severity: 0.5 };
+  if (level === 'low') return { status: 'Low', tone: 'neutral', severity: 0.2 };
+  return { status: 'Info', tone: 'neutral', severity: 0 };
+}
+
+export function factorEvidenceDetails(factor) {
+  const details = (factor && typeof factor.details === 'object' && factor.details) || {};
+  const rows = [];
+
+  const permission = details.permission ?? details.permission_name ?? details.host_permission;
+  pushEvidenceRow(rows, permission === details.host_permission ? 'Host permission' : 'Permission', permission);
+
+  const hostPermission = details.hostPermission ?? details.host_permissions ?? details.host;
+  if (hostPermission !== permission) pushEvidenceRow(rows, 'Host access', hostPermission);
+
+  const manifestField = details.manifest_field ?? details.manifestField ?? details.field;
+  pushEvidenceRow(rows, 'Manifest', manifestField);
+
+  const ruleId = details.rule_id ?? details.ruleId;
+  const rulepack = details.rulepack ?? details.rule_pack;
+  if (rulepack || ruleId) {
+    pushEvidenceRow(rows, 'Rule', rulepack ? `${rulepack}${ruleId ? `::${ruleId}` : ''}` : ruleId);
+  }
+
+  const file = details.file ?? details.path ?? details.file_path;
+  const fileValue = fileLineValue(file, details.line ?? details.line_number, details.line_end ?? details.end_line);
+  pushEvidenceRow(rows, 'File', fileValue);
+
+  const snippet = details.snippet ?? details.code_snippet ?? details.sample_match;
+  pushEvidenceRow(rows, 'Snippet', snippet, 'snippet');
+
+  const malicious = details.malicious ?? details.total_malicious;
+  const suspicious = details.suspicious ?? details.total_suspicious;
+  const hash = details.hash ?? details.sha256;
+  if (malicious != null || suspicious != null || hash) {
+    const parts = [];
+    if (malicious != null) parts.push(`${Number(malicious) || 0} malicious`);
+    if (suspicious != null) parts.push(`${Number(suspicious) || 0} suspicious`);
+    if (hash) parts.push(String(hash).slice(0, 16));
+    pushEvidenceRow(rows, 'VirusTotal', parts.join(' · '));
+  }
+
+  const analyzer = details.analyzer ?? details.coverage_analyzer;
+  const coverageReason = details.coverage_reason ?? details.reason;
+  if (analyzer || details.network_analysis_enabled === false) {
+    pushEvidenceRow(
+      rows,
+      'Coverage',
+      `${analyzer || 'Analyzer'}${coverageReason ? ` - ${coverageReason}` : details.network_analysis_enabled === false ? ' - network analysis was not available' : ''}`
+    );
+  } else if (coverageReason && rows.length === 0) {
+    pushEvidenceRow(rows, 'Reason', coverageReason);
+  }
+
+  return rows;
+}
+
+export function findingEvidenceDetails(finding) {
+  const evidence = finding?.evidence || {};
+  const rows = [];
+
+  const fileValue = fileLineValue(
+    evidence.filePath,
+    evidence.lineStart ?? evidence.line,
+    evidence.lineEnd
+  );
+  pushEvidenceRow(rows, 'File', fileValue);
+  pushEvidenceRow(rows, 'Snippet', evidence.snippet, 'snippet');
+  pushEvidenceRow(rows, 'Permission', evidence.permission);
+  pushEvidenceRow(rows, 'Host access', evidence.hostPermission);
+  pushEvidenceRow(rows, 'Manifest', evidence.manifestField);
+
+  if (evidence.rulepack || evidence.ruleId) {
+    pushEvidenceRow(rows, 'Rule', evidence.rulepack ? `${evidence.rulepack}${evidence.ruleId ? `::${evidence.ruleId}` : ''}` : evidence.ruleId);
+  }
+  pushEvidenceRow(rows, 'Reason', evidence.finalReason ?? evidence.reason ?? evidence.explanation);
+  pushEvidenceRow(rows, 'Action', evidence.actionRequired);
+
+  if (evidence.malicious != null || evidence.suspicious != null || evidence.hash || evidence.coverageState) {
+    const parts = [];
+    if (evidence.malicious != null) parts.push(`${Number(evidence.malicious) || 0} malicious`);
+    if (evidence.suspicious != null) parts.push(`${Number(evidence.suspicious) || 0} suspicious`);
+    if (evidence.coverageState) parts.push(evidence.coverageState);
+    if (evidence.hash) parts.push(String(evidence.hash).slice(0, 16));
+    pushEvidenceRow(rows, 'VirusTotal', parts.join(' · '));
+  }
+
+  if (evidence.analyzer || evidence.kind === 'coverage') {
+    pushEvidenceRow(rows, 'Coverage', `${evidence.analyzer || 'Analyzer'}${evidence.reason ? ` - ${evidence.reason}` : ''}`);
+  }
+
+  return rows;
+}
+
+function factorIssueRow(item, index) {
+  return {
+    id: `factor-${normalizeTitle(item.label) || index}`,
+    title: item.label,
+    category: item.category,
+    source: item.category,
+    status: item.status,
+    statusType: item.statusType,
+    tone: item.tone,
+    severity: item.severity,
+    evidence: item.evidence,
+    evidenceRows: factorEvidenceDetails(item.raw),
+    description: item.desc,
+    sortRank: severityRank(item.statusType, item.severity),
+  };
+}
+
+function findingIssueRow(finding, index) {
+  const status = statusForFinding(finding);
+  const evidence = finding?.evidence || {};
+  const evidenceCaption = scrubLocalPaths(evidence.label || finding?.summary || '');
+  return {
+    id: `finding-${normalizeTitle(finding?.title) || index}`,
+    title: finding?.displayTitle || finding?.title || 'Issue',
+    category: finding?.category || finding?.layer || 'issue',
+    source: finding?.category || evidence.kind || finding?.layer || 'Finding',
+    status: status.status,
+    statusType: 'issues',
+    tone: status.tone,
+    severity: status.severity,
+    evidence: evidenceCaption,
+    evidenceRows: findingEvidenceDetails(finding),
+    description: scrubLocalPaths(finding?.summary || ''),
+    sortRank: severityRank('issues', status.severity),
+  };
+}
+
+function gateIssueRow(gate, index) {
+  const reasons = Array.isArray(gate?.reasons) ? gate.reasons : [];
+  const rows = [];
+  pushEvidenceRow(rows, 'Rule', gate?.gate_id);
+  reasons.forEach((reason, idx) => pushEvidenceRow(rows, idx === 0 ? 'Reason' : 'Reason', reason));
+  return {
+    id: `gate-${gate?.gate_id || index}`,
+    title: gate?.gate_id ? String(gate.gate_id).replace(/_/g, ' ') : 'Triggered gate',
+    category: 'gate',
+    source: 'Gate',
+    status: gate?.decision || 'Issue',
+    statusType: 'issues',
+    tone: 'bad',
+    severity: 0.8,
+    evidence: scrubLocalPaths(reasons[0] || ''),
+    evidenceRows: rows,
+    sortRank: 3,
+  };
+}
+
+export function buildLayerModalModel({ factors = [], keyFindings = [], gateResults = [], layerReasons = [] } = {}) {
+  const { all, issues, notAnalyzed, cleared } = triageFactors(factors);
+  const issueRows = [];
+  const seen = new Set();
+
+  (Array.isArray(keyFindings) ? keyFindings : [])
+    .filter((finding) => finding && finding.title)
+    .forEach((finding, index) => {
+      const row = findingIssueRow(finding, index);
+      const key = normalizeTitle(row.title);
+      if (seen.has(key)) return;
+      seen.add(key);
+      issueRows.push(row);
+    });
+
+  issues.forEach((item, index) => {
+    const row = factorIssueRow(item, index);
+    const key = normalizeTitle(row.title);
+    if (seen.has(key)) return;
+    seen.add(key);
+    issueRows.push(row);
+  });
+
+  (Array.isArray(gateResults) ? gateResults : [])
+    .filter((gate) => gate && gate.triggered)
+    .forEach((gate, index) => {
+      const row = gateIssueRow(gate, index);
+      const key = normalizeTitle(row.title);
+      if (seen.has(key)) return;
+      seen.add(key);
+      issueRows.push(row);
+    });
+
+  issueRows.sort((a, b) => (b.sortRank - a.sortRank) || (b.severity - a.severity));
+
+  return {
+    all,
+    issues: issueRows,
+    notAnalyzed: notAnalyzed.map(factorIssueRow),
+    cleared,
+    about: (Array.isArray(layerReasons) ? layerReasons : [])
+      .map((reason, index) => ({ id: `reason-${index}`, text: scrubLocalPaths(reason) }))
+      .filter((reason) => reason.text),
+  };
+}
+
 const FACTOR_HUMAN = {
   SAST:                 { label: 'Code Safety',           category: 'code',   desc: 'Scans source code for known vulnerability patterns' },
   VirusTotal:           { label: 'Malware Scan',          category: 'threat', desc: 'Checks against 70+ antivirus engines for malicious code' },

--- a/frontend/src/pages/scanner/ScanResultsPageV2.constants.js
+++ b/frontend/src/pages/scanner/ScanResultsPageV2.constants.js
@@ -1,0 +1,6 @@
+export const REPORT_QUICK_NAV_ITEMS = [
+  { id: "overview", label: "Overview" },
+  { id: "layers", label: "Security · Privacy · Governance" },
+  { id: "key-findings", label: "Key Findings" },
+  { id: "evidence-technical-details", label: "Evidence & Technical Details / Coverage" },
+];

--- a/frontend/src/pages/scanner/ScanResultsPageV2.jsx
+++ b/frontend/src/pages/scanner/ScanResultsPageV2.jsx
@@ -6,7 +6,6 @@ import {
   EvidenceDrawer,
   LayerModal,
   ResultFeedback,
-  AnalyzerCoverage,
   EvidenceTechnicalDetails,
   SimilarExtensions,
 } from "../../components/report";
@@ -42,6 +41,7 @@ import { normalizeScanResultSafe, validateEvidenceIntegrity, gateIdToLayer, extr
 import { getExtensionIconUrl, EXTENSION_ICON_PLACEHOLDER } from "../../utils/constants";
 import { isUUID } from "../../utils/extensionId";
 import { doesScanResultMatchIdentifier } from "../../utils/scanResultIdentity";
+import { REPORT_QUICK_NAV_ITEMS } from "./ScanResultsPageV2.constants";
 import "./ScanResultsPageV2.scss";
 
 /** True if text is an unresolved Chrome i18n placeholder (e.g. __MSG_appDesc__). */
@@ -654,12 +654,7 @@ const ScanResultsPageV2 = () => {
     ? scanResults.metadata.similar_extensions
     : [];
 
-  const quickNavItems = [
-    { id: "overview", label: "Overview" },
-    { id: "layers", label: "Security · Privacy · Governance" },
-    { id: "key-findings", label: "Key Findings" },
-    { id: "analyzer-coverage", label: "Analyzer Coverage" },
-  ];
+  const quickNavItems = REPORT_QUICK_NAV_ITEMS;
 
   const formatScanDate = (ts) =>
     ts ? new Date(ts).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" }) : "—";
@@ -996,9 +991,6 @@ const ScanResultsPageV2 = () => {
                 </ul>
               )}
             </section>
-
-            {/* Analyzer Coverage — honest, always-visible coverage states */}
-            <AnalyzerCoverage rawScanResult={scanResults} />
 
             <EvidenceTechnicalDetails rawScanResult={scanResults} viewModel={viewModel} />
           </div>

--- a/frontend/src/pages/scanner/ScanResultsPageV2.jsx
+++ b/frontend/src/pages/scanner/ScanResultsPageV2.jsx
@@ -106,6 +106,37 @@ function getDisplayDescription(scanResults) {
   return null;
 }
 
+export const LayerCards = ({ layerCards, onOpenLayer }) => (
+  <section className="report-layers" id="layers" aria-label="Security, privacy, and governance breakdown">
+    {layerCards.map(({ key, label, Icon, score, band, count, explain }) => (
+      <button
+        type="button"
+        key={key}
+        className={`layer-card band-${String(band).toLowerCase()}`}
+        onClick={() => onOpenLayer(key)}
+        aria-label={`${label} details: ${count > 0 ? `${count} ${count === 1 ? "issue" : "issues"}` : "no issues"}`}
+      >
+        <div className="layer-card-head">
+          <span className="layer-card-name"><Icon size={16} aria-hidden="true" /> {label}</span>
+          <span className="layer-card-score">
+            {score ?? "—"}<span className="layer-card-score-max">/100</span>
+          </span>
+        </div>
+        {count > 0 ? (
+          <span className="layer-card-issues">{count} {count === 1 ? "issue" : "issues"}</span>
+        ) : (
+          <span className="layer-card-issues layer-card-issues--none">No issues</span>
+        )}
+        <div className="layer-card-bar" aria-hidden="true">
+          <span className="layer-card-bar-fill" style={{ width: `${Math.max(0, Math.min(100, score ?? 0))}%` }} />
+        </div>
+        <p className="layer-card-explain">{explain}</p>
+        <span className="layer-card-link">View details <ChevronRight size={14} aria-hidden="true" /></span>
+      </button>
+    ))}
+  </section>
+);
+
 /**
  * ScanResultsPageV2 - Redesigned results dashboard
  * Uses ReportViewModel from normalizeScanResultSafe() - NO fake data
@@ -879,33 +910,7 @@ const ScanResultsPageV2 = () => {
 
           <div className="report-main">
             {/* Layer cards: Security / Privacy / Governance */}
-            <section className="report-layers" id="layers" aria-label="Security, privacy, and governance breakdown">
-              {layerCards.map(({ key, label, Icon, score, band, count, explain }) => (
-                <button
-                  type="button"
-                  key={key}
-                  className={`layer-card band-${String(band).toLowerCase()}`}
-                  onClick={() => openLayerModal(key)}
-                >
-                  <div className="layer-card-head">
-                    <span className="layer-card-name"><Icon size={16} aria-hidden="true" /> {label}</span>
-                    <span className="layer-card-score">
-                      {score ?? "—"}<span className="layer-card-score-max">/100</span>
-                    </span>
-                  </div>
-                  {count > 0 ? (
-                    <span className="layer-card-issues">{count} {count === 1 ? "issue" : "issues"}</span>
-                  ) : (
-                    <span className="layer-card-issues layer-card-issues--none">No issues</span>
-                  )}
-                  <div className="layer-card-bar">
-                    <span className="layer-card-bar-fill" style={{ width: `${Math.max(0, Math.min(100, score ?? 0))}%` }} />
-                  </div>
-                  <p className="layer-card-explain">{explain}</p>
-                  <span className="layer-card-link">View details <ChevronRight size={14} aria-hidden="true" /></span>
-                </button>
-              ))}
-            </section>
+            <LayerCards layerCards={layerCards} onOpenLayer={openLayerModal} />
 
             {/* Key Findings */}
             <section className="report-findings" id="key-findings">

--- a/frontend/src/pages/scanner/ScanResultsPageV2.jsx
+++ b/frontend/src/pages/scanner/ScanResultsPageV2.jsx
@@ -938,6 +938,23 @@ const ScanResultsPageV2 = () => {
                           <div className="finding-text">
                             <span className="finding-title">{f.displayTitle}</span>
                             {f.summary && open && <span className="finding-summary">{f.summary}</span>}
+                            {open && ev && ev.available && (
+                              <div className="finding-evidence-details">
+                                {ev.filePath && (
+                                  <div className="fed-row"><span className="fed-key">File</span>
+                                    <span className="fed-val">{ev.filePath}{typeof ev.lineStart === "number" && ev.lineStart > 0 ? `:${ev.lineStart}${typeof ev.lineEnd === "number" && ev.lineEnd > ev.lineStart ? `–${ev.lineEnd}` : ""}` : ""}</span></div>
+                                )}
+                                {ev.snippet && <pre className="fed-snippet">{ev.snippet}</pre>}
+                                {ev.permission && (<div className="fed-row"><span className="fed-key">Permission</span><span className="fed-val">{ev.permission}</span></div>)}
+                                {ev.hostPermission && (<div className="fed-row"><span className="fed-key">Host access</span><span className="fed-val">{ev.hostPermission}</span></div>)}
+                                {ev.kind === "manifest" && ev.manifestField && !ev.permission && (<div className="fed-row"><span className="fed-key">Manifest</span><span className="fed-val">{ev.manifestField}</span></div>)}
+                                {(ev.rulepack || ev.ruleId) && (<div className="fed-row"><span className="fed-key">Rule</span><span className="fed-val">{ev.rulepack ? `${ev.rulepack}${ev.ruleId ? `::${ev.ruleId}` : ""}` : ev.ruleId}</span></div>)}
+                                {ev.finalReason && (<div className="fed-row"><span className="fed-key">Reason</span><span className="fed-val">{ev.finalReason}</span></div>)}
+                                {ev.actionRequired && ev.actionRequired !== ev.finalReason && (<div className="fed-row"><span className="fed-key">Action</span><span className="fed-val">{ev.actionRequired}</span></div>)}
+                                {typeof ev.malicious === "number" && (<div className="fed-row"><span className="fed-key">VirusTotal</span><span className="fed-val">{ev.malicious} malicious · {ev.suspicious || 0} suspicious{ev.hash ? ` · ${String(ev.hash).slice(0, 12)}…` : ""}</span></div>)}
+                                {ev.analyzer && (<div className="fed-row"><span className="fed-key">Coverage</span><span className="fed-val">{ev.analyzer}{ev.reason ? ` — ${ev.reason}` : ""}</span></div>)}
+                              </div>
+                            )}
                           </div>
                         </div>
                         <span className={`finding-severity tone-${tone}`} title={severityLabel(f.level)}>
@@ -955,7 +972,7 @@ const ScanResultsPageV2 = () => {
                               View evidence <ExternalLink size={13} aria-hidden="true" />
                             </button>
                           )}
-                          {f.summary && (
+                          {(f.summary || (ev && ev.available)) && (
                             <button
                               type="button"
                               className={`finding-expand${open ? " is-open" : ""}`}

--- a/frontend/src/pages/scanner/ScanResultsPageV2.jsx
+++ b/frontend/src/pages/scanner/ScanResultsPageV2.jsx
@@ -28,7 +28,7 @@ import {
   severityTone,
   findingCategory,
   preciseFindingTitle,
-  evidenceCountLabel,
+  resolveFindingEvidenceLabel,
 } from "../../utils/reportDisplay";
 import FileViewerModal from "../../components/FileViewerModal";
 import StatusMessage from "../../components/StatusMessage";
@@ -921,6 +921,16 @@ const ScanResultsPageV2 = () => {
                     const tone = severityTone(f.level);
                     const open = expandedFinding === i;
                     const evCount = f.evidenceCount || 0;
+                    // Evidence label (display only — helper selects the existing
+                    // finding.evidence.label, never generates one). Resolvable IDs keep
+                    // the openable count + "View evidence"; otherwise fall back to the
+                    // structured evidence reference; "Evidence not linked" only when
+                    // neither IDs nor structured evidence exist.
+                    const ev = f.evidence;
+                    const evidenceText = resolveFindingEvidenceLabel(f, evCount);
+                    const evidenceTitle = ev && ev.available
+                      ? (ev.snippet || ev.reason || ev.finalReason || '')
+                      : '';
                     return (
                       <li className="finding-row" key={`${f.displayTitle}-${i}`}>
                         <div className="finding-main">
@@ -934,7 +944,7 @@ const ScanResultsPageV2 = () => {
                           {severityBadge(f.level)}
                         </span>
                         <span className="finding-category">{f.category}</span>
-                        <span className="finding-evidence">{evidenceCountLabel(evCount)}</span>
+                        <span className="finding-evidence" title={evidenceTitle}>{evidenceText}</span>
                         <div className="finding-actions">
                           {evCount > 0 && (
                             <button

--- a/frontend/src/pages/scanner/ScanResultsPageV2.jsx
+++ b/frontend/src/pages/scanner/ScanResultsPageV2.jsx
@@ -7,6 +7,7 @@ import {
   LayerModal,
   ResultFeedback,
   AnalyzerCoverage,
+  EvidenceTechnicalDetails,
   SimilarExtensions,
 } from "../../components/report";
 import {
@@ -998,6 +999,8 @@ const ScanResultsPageV2 = () => {
 
             {/* Analyzer Coverage — honest, always-visible coverage states */}
             <AnalyzerCoverage rawScanResult={scanResults} />
+
+            <EvidenceTechnicalDetails rawScanResult={scanResults} viewModel={viewModel} />
           </div>
 
           {/* Right sidebar: Issue Overview, Quick Navigation, Similar Extensions */}

--- a/frontend/src/pages/scanner/ScanResultsPageV2.scss
+++ b/frontend/src/pages/scanner/ScanResultsPageV2.scss
@@ -1010,6 +1010,10 @@
   font-size: 0.82rem;
   color: var(--extensionshield-text-muted);
   white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  min-width: 0;
+  max-width: 28ch;
 }
 .finding-actions { display: flex; align-items: center; gap: 6px; }
 .finding-view-evidence {

--- a/frontend/src/pages/scanner/ScanResultsPageV2.scss
+++ b/frontend/src/pages/scanner/ScanResultsPageV2.scss
@@ -828,6 +828,16 @@
     border-color: var(--band-color);
     box-shadow: 0 6px 20px rgba(0, 0, 0, 0.18);
   }
+  &:focus-visible {
+    outline: none;
+    border-color: var(--band-color);
+    box-shadow: 0 0 0 3px color-mix(in srgb, var(--band-color) 35%, transparent);
+  }
+  &:active { transform: translateY(0); }
+  &:hover .layer-card-link svg,
+  &:focus-visible .layer-card-link svg {
+    transform: translateX(2px);
+  }
   &.band-good { --band-color: var(--risk-good); }
   &.band-warn { --band-color: var(--risk-warn); }
   &.band-bad  { --band-color: var(--risk-bad); }
@@ -893,6 +903,7 @@
     font-size: 0.8rem;
     font-weight: 600;
     color: var(--extensionshield-accent);
+    svg { transition: transform 0.18s ease; }
   }
 }
 

--- a/frontend/src/pages/scanner/ScanResultsPageV2.scss
+++ b/frontend/src/pages/scanner/ScanResultsPageV2.scss
@@ -962,6 +962,36 @@
   line-height: 1.45;
   color: var(--extensionshield-text-secondary);
 }
+.finding-evidence-details {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  margin-top: 4px;
+  padding: 8px 10px;
+  border-radius: 8px;
+  background: var(--extensionshield-surface-muted, rgba(0, 0, 0, 0.03));
+  font-size: 0.8rem;
+  line-height: 1.4;
+
+  .fed-row { display: flex; gap: 6px; min-width: 0; }
+  .fed-key {
+    flex: 0 0 auto;
+    min-width: 84px;
+    font-weight: 600;
+    color: var(--extensionshield-text-secondary);
+  }
+  .fed-val { min-width: 0; overflow-wrap: anywhere; color: var(--extensionshield-text-primary); }
+  .fed-snippet {
+    margin: 2px 0 0;
+    padding: 6px 8px;
+    border-radius: 6px;
+    background: var(--extensionshield-code-bg, rgba(0, 0, 0, 0.06));
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 0.75rem;
+    white-space: pre-wrap;
+    overflow-wrap: anywhere;
+  }
+}
 .finding-severity {
   font-size: 0.7rem;
   font-weight: 700;

--- a/frontend/src/pages/scanner/ScanResultsPageV2.test.jsx
+++ b/frontend/src/pages/scanner/ScanResultsPageV2.test.jsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { Landmark, Lock, Shield } from 'lucide-react';
+import { LayerCards } from './ScanResultsPageV2';
+
+describe('LayerCards', () => {
+  it('renders real score, status count, summary, progress affordance, and CTA', () => {
+    const onOpenLayer = vi.fn();
+    render(
+      <LayerCards
+        onOpenLayer={onOpenLayer}
+        layerCards={[
+          {
+            key: 'security',
+            label: 'Security',
+            Icon: Shield,
+            score: 90,
+            band: 'WARN',
+            count: 2,
+            explain: 'Low security risk with minimal concerns.',
+          },
+          {
+            key: 'privacy',
+            label: 'Privacy',
+            Icon: Lock,
+            score: 58,
+            band: 'WARN',
+            count: 2,
+            explain: 'Moderate privacy risk: signals that sensitive data could be sent out.',
+          },
+          {
+            key: 'governance',
+            label: 'Governance',
+            Icon: Landmark,
+            score: 100,
+            band: 'GOOD',
+            count: 0,
+            explain: 'Low governance risk with good policy compliance.',
+          },
+        ]}
+      />
+    );
+
+    expect(screen.getByText('90')).toBeInTheDocument();
+    expect(screen.getByText('58')).toBeInTheDocument();
+    expect(screen.getByText('100')).toBeInTheDocument();
+    expect(screen.getAllByText('2 issues')).toHaveLength(2);
+    expect(screen.getByText('No issues')).toBeInTheDocument();
+    expect(screen.getByText('Low security risk with minimal concerns.')).toBeInTheDocument();
+    expect(screen.getAllByText(/View details/i)).toHaveLength(3);
+
+    fireEvent.click(screen.getByRole('button', { name: /Security details: 2 issues/i }));
+    expect(onOpenLayer).toHaveBeenCalledWith('security');
+  });
+});

--- a/frontend/src/pages/scanner/ScanResultsPageV2.test.jsx
+++ b/frontend/src/pages/scanner/ScanResultsPageV2.test.jsx
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { Landmark, Lock, Shield } from 'lucide-react';
 import { LayerCards } from './ScanResultsPageV2';
+import { REPORT_QUICK_NAV_ITEMS } from './ScanResultsPageV2.constants';
 
 describe('LayerCards', () => {
   it('renders real score, status count, summary, progress affordance, and CTA', () => {
@@ -52,5 +53,15 @@ describe('LayerCards', () => {
 
     fireEvent.click(screen.getByRole('button', { name: /Security details: 2 issues/i }));
     expect(onOpenLayer).toHaveBeenCalledWith('security');
+  });
+});
+
+describe('ScanResultsPageV2 report flow', () => {
+  it('links quick navigation to Evidence & Technical Details instead of the removed Analyzer Coverage section', () => {
+    expect(REPORT_QUICK_NAV_ITEMS).not.toContainEqual(expect.objectContaining({ id: 'analyzer-coverage' }));
+    expect(REPORT_QUICK_NAV_ITEMS).toContainEqual({
+      id: 'evidence-technical-details',
+      label: 'Evidence & Technical Details / Coverage',
+    });
   });
 });

--- a/frontend/src/utils/normalizeScanResult.test.ts
+++ b/frontend/src/utils/normalizeScanResult.test.ts
@@ -546,9 +546,11 @@ describe('normalizeScanResult', () => {
         },
       });
       
-      const sensitiveExfilFinding = result.keyFindings.find(f => f.title === 'May send your data to external servers');
+      const sensitiveExfilFinding = result.keyFindings.find(f => f.title === 'Requests permissions that could send data externally');
       expect(sensitiveExfilFinding).toBeDefined();
       expect(sensitiveExfilFinding?.layer).toBe('privacy');
+      // Capability wording must not imply confirmed exfiltration.
+      expect(result.keyFindings.some(f => /may send your data to external servers/i.test(f.title))).toBe(false);
     });
 
     it('should apply gate-based band override to layer tiles (CRITICAL_SAST -> Security tile becomes BAD)', () => {
@@ -1553,5 +1555,22 @@ describe('Key Findings evidence display uses relative paths (no local leak)', ()
       .map((k) => `${k.title} ${k.evidence?.label || ''} ${k.evidence?.filePath || ''}`)
       .join(' | ');
     for (const frag of LEAK_FRAGMENTS) expect(displayText.includes(frag)).toBe(false);
+  });
+});
+
+describe('Encoded-data wording — pattern, not confirmed exfiltration', () => {
+  it('base64 encoded-data SAST finding uses pattern wording + destination clarification', () => {
+    const raw = {
+      extension_id: 'enc12345678901234abcdefghijklmno',
+      sast_results: { sast_findings: { 'sw.js': [
+        { check_id: 'src.extension_shield.config.c2.exfiltration.base64_encoded_data',
+          start: { line: 58 }, path: 'sw.js',
+          extra: { severity: 'WARNING', message: 'Base64 encoding with network transmission', lines: 'btoa(x)' } },
+      ] } },
+    } as unknown as RawScanResult;
+    const enc = extractFindingsByLayer(raw).security.find((f) => f.title === 'Encoded data pattern detected');
+    expect(enc).toBeDefined();
+    expect(enc!.title === 'Sends encoded data').toBe(false);
+    expect(/no confirmed external destination shown/i.test(enc!.summary)).toBe(true);
   });
 });

--- a/frontend/src/utils/normalizeScanResult.test.ts
+++ b/frontend/src/utils/normalizeScanResult.test.ts
@@ -17,6 +17,7 @@ import {
   hasScoring,
   hasScoringV2,
   coherentRiskLevel,
+  extractFindingsByLayer,
 } from './normalizeScanResult';
 import type { RawScanResult, ReportViewModel } from './reportTypes';
 
@@ -1327,5 +1328,130 @@ describe('Key Findings evidence links', () => {
     } as unknown as RawScanResult;
     const vm = normalizeScanResult(raw);
     expect(vm.keyFindings.some((k) => k.title === 'Publisher update age')).toBe(false);
+  });
+});
+
+// =============================================================================
+// EVIDENCE-LINKED KEY FINDINGS — synthetic-id resolution (audit follow-up)
+// =============================================================================
+
+describe('Key Findings synthetic evidence resolution', () => {
+  it('SAST-extracted finding (Google Docs style) maps to file + line + snippet', () => {
+    const raw = {
+      extension_id: 'gdocsev1234567890abcdefghijklmno',
+      sast_results: { sast_findings: { 'service_worker_bin_prod.js': [
+        { check_id: 'src.extension_shield.config.c2.exfiltration.base64_encoded_data',
+          start: { line: 58 }, path: 'service_worker_bin_prod.js',
+          extra: { severity: 'WARNING', message: 'Sends encoded data', lines: 'btoa(payload)' } },
+      ] } },
+      governance_bundle: { signal_pack: { evidence: [
+        { evidence_id: 'tool:sast:26605a6f', tool_name: 'sast', file_path: 'service_worker_bin_prod.js', line_start: 58 },
+      ] } },
+    } as unknown as RawScanResult;
+    const findings = extractFindingsByLayer(raw).security;
+    const coded = findings.find((f) => f.evidence && f.evidence.filePath === 'service_worker_bin_prod.js');
+    expect(coded).toBeDefined();
+    expect(coded!.evidence!.available).toBe(true);
+    expect(coded!.evidence!.lineStart).toBe(58);
+    expect(coded!.evidence!.snippet).toBe('btoa(payload)');
+    // no longer "Evidence not linked": there is structured, available evidence
+    expect(coded!.evidence!.kind).toBe('sast');
+  });
+
+  it('entropy/hidden-code factor (uBlock Lite style) maps to file path via signal_pack', () => {
+    const raw = {
+      extension_id: 'ublockev1234567890abcdefghijklmn',
+      final_verdict: 'ALLOW',
+      scoring_v2: {
+        overall_score: 86, decision: 'ALLOW', risk_level: 'low', hard_gates_triggered: [],
+        security_layer: { layer_name: 'security', score: 82, risk: 0.18, confidence: 0.9, factors: [
+          { name: 'Obfuscation', severity: 0.99, confidence: 0.9, weight: 0.1, contribution: 0.2,
+            evidence_ids: ['entropy:file:js/jsonpath.js', 'entropy:file:rulesets/x.js'] },
+        ] },
+      },
+      governance_bundle: { signal_pack: { evidence: [
+        { evidence_id: 'tool:entropy:6572', tool_name: 'entropy', file_path: 'js/jsonpath.js' },
+      ] } },
+    } as unknown as RawScanResult;
+    const vm = normalizeScanResult(raw);
+    const hidden = vm.keyFindings.find((k) => k.title === 'Hidden Code');
+    expect(hidden).toBeDefined();
+    expect(hidden!.evidence!.available).toBe(true);
+    expect(hidden!.evidence!.filePath).toBe('js/jsonpath.js');
+  });
+
+  it('permission factor surfaces the specific permission from the synthetic id', () => {
+    const raw = {
+      extension_id: 'permev12345678901abcdefghijklmno',
+      final_verdict: 'ALLOW',
+      manifest: { permissions: ['storage', 'cookies'], host_permissions: ['<all_urls>'] },
+      scoring_v2: {
+        overall_score: 70, decision: 'ALLOW', risk_level: 'low', hard_gates_triggered: [],
+        privacy_layer: { layer_name: 'privacy', score: 60, risk: 0.4, confidence: 0.9, factors: [
+          { name: 'PermissionsBaseline', severity: 0.67, confidence: 0.9, weight: 0.4, contribution: 0.2,
+            evidence_ids: ['perm:high_risk:desktopCapture', 'perm:high_risk:cookies'] },
+        ] },
+      },
+    } as unknown as RawScanResult;
+    const vm = normalizeScanResult(raw);
+    const perm = vm.keyFindings.find((k) => k.evidence && k.evidence.kind === 'manifest');
+    expect(perm).toBeDefined();
+    expect(perm!.evidence!.permission).toBe('desktopCapture');
+  });
+
+  it('manifest factor surfaces the specific manifest issue from the synthetic id', () => {
+    const raw = {
+      extension_id: 'maniev123456789012abcdefghijklmn',
+      final_verdict: 'ALLOW',
+      manifest: { permissions: ['storage'], host_permissions: ['<all_urls>'] },
+      scoring_v2: {
+        overall_score: 80, decision: 'ALLOW', risk_level: 'low', hard_gates_triggered: [],
+        security_layer: { layer_name: 'security', score: 78, risk: 0.22, confidence: 0.9, factors: [
+          { name: 'Manifest', severity: 0.6, confidence: 0.9, weight: 0.2, contribution: 0.12,
+            evidence_ids: ['manifest:issue:missing_csp', 'manifest:issue:broad_host_access'] },
+        ] },
+      },
+    } as unknown as RawScanResult;
+    const vm = normalizeScanResult(raw);
+    const mani = vm.keyFindings.find((k) => k.evidence && k.evidence.kind === 'manifest');
+    expect(mani).toBeDefined();
+    expect(mani!.evidence!.manifestField).toBe('missing_csp');
+  });
+
+  it('a factor whose synthetic evidence has no matching signal_pack file stays summary-only', () => {
+    const raw = {
+      extension_id: 'noevmatch123456789abcdefghijklmn',
+      final_verdict: 'ALLOW',
+      scoring_v2: {
+        overall_score: 80, decision: 'ALLOW', risk_level: 'low', hard_gates_triggered: [],
+        security_layer: { layer_name: 'security', score: 80, risk: 0.2, confidence: 0.9, factors: [
+          { name: 'Obfuscation', severity: 0.8, confidence: 0.9, weight: 0.1, contribution: 0.1,
+            evidence_ids: ['entropy:file:js/absent.js'] },
+        ] },
+      },
+      governance_bundle: { signal_pack: { evidence: [] } },
+    } as unknown as RawScanResult;
+    const vm = normalizeScanResult(raw);
+    const hidden = vm.keyFindings.find((k) => k.title === 'Hidden Code');
+    expect(hidden).toBeDefined();
+    expect(hidden!.evidence!.available).toBe(false);
+  });
+
+  it('coverage-cap ordering is preserved (coverage first) with evidence attached', () => {
+    const raw = {
+      extension_id: 'ordev1234567890123abcdefghijklmn',
+      final_verdict: 'NEEDS_REVIEW',
+      scoring_v2: {
+        overall_score: 65, decision: 'NEEDS_REVIEW', risk_level: 'medium', hard_gates_triggered: [], coverage_cap_applied: true,
+        security_layer: { layer_name: 'security', score: 65, risk: 0.35, confidence: 0.9, factors: [
+          { name: 'Obfuscation', severity: 0.8, confidence: 0.9, weight: 0.1, contribution: 0.1, evidence_ids: ['entropy:file:js/x.js'] },
+        ] },
+      },
+      sast_results: { scan_error: true, files_scanned: 0, sast_findings: {} },
+      virustotal_analysis: { enabled: true, files_found_in_vt: 5 },
+    } as unknown as RawScanResult;
+    const vm = normalizeScanResult(raw);
+    expect(vm.keyFindings[0].title).toBe('Limited code coverage');
+    expect(vm.keyFindings[0].evidence!.analyzer).toBe('SAST');
   });
 });

--- a/frontend/src/utils/normalizeScanResult.test.ts
+++ b/frontend/src/utils/normalizeScanResult.test.ts
@@ -18,6 +18,7 @@ import {
   hasScoringV2,
   coherentRiskLevel,
   extractFindingsByLayer,
+  toRelativeEvidencePath,
 } from './normalizeScanResult';
 import type { RawScanResult, ReportViewModel } from './reportTypes';
 
@@ -1453,5 +1454,104 @@ describe('Key Findings synthetic evidence resolution', () => {
     const vm = normalizeScanResult(raw);
     expect(vm.keyFindings[0].title).toBe('Limited code coverage');
     expect(vm.keyFindings[0].evidence!.analyzer).toBe('SAST');
+  });
+});
+
+// =============================================================================
+// EVIDENCE PATH NORMALIZATION — no local filesystem leaks (audit follow-up)
+// =============================================================================
+
+const LEAK_FRAGMENTS = ['/Users/', '/home/', 'extensions_storage', 'extracted_'];
+const ABS_PATH = '/Users/stanzin/Developer/ExtensionShield/extensions_storage/extracted_ghbmnn.crx_85418/service_worker_bin_prod.js';
+
+describe('toRelativeEvidencePath', () => {
+  it('strips the local prefix down to the archive-relative path', () => {
+    expect(toRelativeEvidencePath(ABS_PATH)).toBe('service_worker_bin_prod.js');
+    expect(toRelativeEvidencePath('/Users/x/ExtensionShield/extensions_storage/extracted_xxx/js/background.js'))
+      .toBe('js/background.js');
+    expect(toRelativeEvidencePath('/home/ci/extensions_storage/extracted_y/js/background-combo.js'))
+      .toBe('js/background-combo.js');
+  });
+
+  it('keeps already-relative paths unchanged', () => {
+    expect(toRelativeEvidencePath('js/jsonpath.js')).toBe('js/jsonpath.js');
+    expect(toRelativeEvidencePath('service_worker_bin_prod.js')).toBe('service_worker_bin_prod.js');
+  });
+
+  it('falls back to the basename for any other absolute/local path (no leak)', () => {
+    expect(toRelativeEvidencePath('/Users/stanzin/secret/app.js')).toBe('app.js');
+    expect(toRelativeEvidencePath('C:/Users/dev/ext/background.js')).toBe('background.js');
+  });
+
+  it('never emits a local machine/user path fragment', () => {
+    for (const p of [ABS_PATH, '/home/ci/extensions_storage/extracted_a/js/x.js', 'C:/Users/d/y.js']) {
+      const out = toRelativeEvidencePath(p);
+      for (const frag of LEAK_FRAGMENTS) expect(out.includes(frag)).toBe(false);
+    }
+  });
+});
+
+describe('Key Findings evidence display uses relative paths (no local leak)', () => {
+  it('SAST finding with an absolute finding.path renders a relative file:line and preserves raw sourceViewerPath', () => {
+    const raw = {
+      extension_id: 'relpath1234567890abcdefghijklmno',
+      sast_results: { sast_findings: { 'service_worker_bin_prod.js': [
+        { check_id: 'src.extension_shield.config.c2.exfiltration.base64_encoded_data',
+          start: { line: 58 }, path: ABS_PATH,
+          extra: { severity: 'WARNING', message: 'Sends encoded data', lines: 'btoa(payload)' } },
+      ] } },
+      governance_bundle: { signal_pack: { evidence: [
+        { evidence_id: 'tool:sast:26605a6f', tool_name: 'sast', file_path: 'service_worker_bin_prod.js', line_start: 58 },
+      ] } },
+    } as unknown as RawScanResult;
+    const coded = extractFindingsByLayer(raw).security.find((f) => f.evidence && f.evidence.available && f.evidence.filePath);
+    expect(coded).toBeDefined();
+    // Displayed path + label are relative...
+    expect(coded!.evidence!.filePath).toBe('service_worker_bin_prod.js');
+    expect(coded!.evidence!.label).toBe('service_worker_bin_prod.js:58');
+    // ...while the raw path is preserved internally for the source viewer.
+    expect(coded!.evidence!.sourceViewerPath).toBe(ABS_PATH);
+    // No leak in the displayed fields.
+    for (const frag of LEAK_FRAGMENTS) {
+      expect(String(coded!.evidence!.filePath).includes(frag)).toBe(false);
+      expect(String(coded!.evidence!.label).includes(frag)).toBe(false);
+    }
+  });
+
+  it('governance rule label is unchanged by path normalization', () => {
+    const raw = {
+      extension_id: 'govrule1234567890abcdefghijklmno',
+      final_verdict: 'NEEDS_REVIEW',
+      scoring_v2: { overall_score: 80, decision: 'NEEDS_REVIEW', risk_level: 'low', hard_gates_triggered: [] },
+      governance_bundle: { decision: {
+        final_verdict: 'NEEDS_REVIEW',
+        final_reasons: ['Verify clipboard access'],
+        rationale: '[CWS_LIMITED_USE::R5] matched',
+      } },
+    } as unknown as RawScanResult;
+    const vm = normalizeScanResult(raw);
+    const gov = vm.keyFindings.find((k) => k.evidence && k.evidence.kind === 'governance' && k.evidence.rulepack);
+    expect(gov!.evidence!.label).toBe('Rule CWS_LIMITED_USE::R5');
+  });
+
+  it('no key finding evidence field leaks a local path fragment (Obfuscation w/ absolute-looking source)', () => {
+    const raw = {
+      extension_id: 'noleakkf1234567890abcdefghijklmn',
+      final_verdict: 'ALLOW',
+      scoring_v2: {
+        overall_score: 86, decision: 'ALLOW', risk_level: 'low', hard_gates_triggered: [],
+        security_layer: { layer_name: 'security', score: 82, risk: 0.18, confidence: 0.9, factors: [
+          { name: 'Obfuscation', severity: 0.9, confidence: 0.9, weight: 0.1, contribution: 0.2, evidence_ids: ['entropy:file:js/jsonpath.js'] },
+        ] },
+      },
+      governance_bundle: { signal_pack: { evidence: [
+        { evidence_id: 'tool:entropy:6572', tool_name: 'entropy', file_path: 'js/jsonpath.js' },
+      ] } },
+    } as unknown as RawScanResult;
+    const vm = normalizeScanResult(raw);
+    const displayText = vm.keyFindings
+      .map((k) => `${k.title} ${k.evidence?.label || ''} ${k.evidence?.filePath || ''}`)
+      .join(' | ');
+    for (const frag of LEAK_FRAGMENTS) expect(displayText.includes(frag)).toBe(false);
   });
 });

--- a/frontend/src/utils/normalizeScanResult.test.ts
+++ b/frontend/src/utils/normalizeScanResult.test.ts
@@ -1163,3 +1163,169 @@ describe('Governance review reason is promoted; publisher update age is context'
     expect(maint!.severity).toBe('medium');
   });
 });
+
+// =============================================================================
+// EVIDENCE-LINKED KEY FINDINGS (audit follow-up)
+// =============================================================================
+
+describe('Key Findings evidence links', () => {
+  it('SAST finding includes file path, line, and snippet when present', () => {
+    const raw = {
+      extension_id: 'sastev1234567890abcdefghijklmnop',
+      final_verdict: 'ALLOW',
+      scoring_v2: {
+        overall_score: 82, decision: 'ALLOW', risk_level: 'low', hard_gates_triggered: [],
+        security_layer: { layer_name: 'security', score: 82, risk: 0.18, confidence: 0.9,
+          factors: [{ name: 'SAST', severity: 0.5, confidence: 0.9, weight: 0.4, contribution: 0.1, evidence_ids: ['ev1'] }] },
+      },
+      governance_bundle: { signal_pack: { evidence: [
+        { evidence_id: 'ev1', file_path: 'js/content.js', line_start: 12, line_end: 14, snippet: 'eval(userInput)', tool_name: 'sast' },
+      ] } },
+    } as unknown as RawScanResult;
+    const vm = normalizeScanResult(raw);
+    const f = vm.keyFindings.find((k) => k.evidence && k.evidence.kind === 'sast' && k.evidence.available);
+    expect(f).toBeDefined();
+    expect(f!.evidence!.filePath).toBe('js/content.js');
+    expect(f!.evidence!.lineStart).toBe(12);
+    expect(f!.evidence!.snippet).toContain('eval');
+    expect(f!.evidence!.sourceViewerPath).toBe('js/content.js');
+  });
+
+  it('governance finding includes rulepack, rule, and reason when present', () => {
+    const raw = {
+      extension_id: 'govev12345678901abcdefghijklmnop',
+      final_verdict: 'NEEDS_REVIEW',
+      scoring_v2: { overall_score: 80, decision: 'NEEDS_REVIEW', risk_level: 'low', hard_gates_triggered: [] },
+      governance_bundle: { decision: {
+        final_verdict: 'NEEDS_REVIEW',
+        final_reasons: ['Verify clipboard access is limited to user-initiated copy/paste'],
+        action_required: 'Verify clipboard access is limited to user-initiated copy/paste',
+        rationale: '1. [CWS_LIMITED_USE::R5] Condition matched. Verdict: NEEDS_REVIEW',
+      } },
+    } as unknown as RawScanResult;
+    const vm = normalizeScanResult(raw);
+    const f = vm.keyFindings.find((k) => k.evidence && k.evidence.kind === 'governance' && k.evidence.rulepack);
+    expect(f).toBeDefined();
+    expect(f!.evidence!.rulepack).toBe('CWS_LIMITED_USE');
+    expect(f!.evidence!.ruleId).toBe('R5');
+    expect(f!.evidence!.finalReason).toContain('clipboard');
+  });
+
+  it('manifest/permission finding includes a permission reference', () => {
+    const raw = {
+      extension_id: 'manifev123456789abcdefghijklmnop',
+      final_verdict: 'ALLOW',
+      manifest: { permissions: ['tabs', 'cookies'], host_permissions: ['<all_urls>'] },
+      scoring_v2: {
+        overall_score: 78, decision: 'ALLOW', risk_level: 'low', hard_gates_triggered: [],
+        privacy_layer: { layer_name: 'privacy', score: 70, risk: 0.3, confidence: 0.8,
+          factors: [{ name: 'PermissionsBaseline', severity: 0.5, confidence: 0.9, weight: 0.4, contribution: 0.1, evidence_ids: [], details: { description: 'Broad permissions requested' } }] },
+      },
+    } as unknown as RawScanResult;
+    const vm = normalizeScanResult(raw);
+    const f = vm.keyFindings.find((k) => k.evidence && k.evidence.kind === 'manifest');
+    expect(f).toBeDefined();
+    expect(f!.evidence!.permission).toBe('tabs');
+    expect(f!.evidence!.hostPermission).toBe('<all_urls>');
+  });
+
+  it('VirusTotal finding includes hash and result counts when present', () => {
+    const raw = {
+      extension_id: 'vtev123456789012abcdefghijklmnop',
+      final_verdict: 'ALLOW',
+      virustotal_analysis: { enabled: true, files_analyzed: 5, files_found_in_vt: 5, total_malicious: 3, total_suspicious: 1, summary: { threat_level: 'malicious' }, file_results: [{ hashes: { sha256: 'abc123def456' } }] },
+      scoring_v2: {
+        overall_score: 40, decision: 'ALLOW', risk_level: 'medium', hard_gates_triggered: [],
+        security_layer: { layer_name: 'security', score: 40, risk: 0.6, confidence: 0.9,
+          factors: [{ name: 'VirusTotal', severity: 0.8, confidence: 1.0, weight: 0.3, contribution: 0.24, evidence_ids: [] }] },
+      },
+    } as unknown as RawScanResult;
+    const vm = normalizeScanResult(raw);
+    const f = vm.keyFindings.find((k) => k.evidence && k.evidence.kind === 'virustotal' && k.evidence.available);
+    expect(f).toBeDefined();
+    expect(f!.evidence!.hash).toBe('abc123def456');
+    expect(f!.evidence!.malicious).toBe(3);
+    expect(f!.evidence!.coverageState).toBe('malicious');
+  });
+
+  it('coverage-cap finding includes analyzer and coverage reason', () => {
+    const raw = {
+      extension_id: 'covev123456789012abcdefghijklmno',
+      final_verdict: 'NEEDS_REVIEW',
+      scoring_v2: { overall_score: 65, decision: 'NEEDS_REVIEW', risk_level: 'medium', hard_gates_triggered: [], coverage_cap_applied: true },
+      sast_results: { scan_error: true, files_scanned: 0, sast_findings: {} },
+      virustotal_analysis: { enabled: true, files_found_in_vt: 5 },
+    } as unknown as RawScanResult;
+    const vm = normalizeScanResult(raw);
+    expect(vm.keyFindings[0].title).toBe('Limited code coverage');
+    expect(vm.keyFindings[0].evidence!.kind).toBe('coverage');
+    expect(vm.keyFindings[0].evidence!.analyzer).toBe('SAST');
+    expect(vm.keyFindings[0].evidence!.reason).toContain('SAST');
+  });
+
+  it('a finding without resolvable evidence is marked summary-only and does not crash', () => {
+    const raw = {
+      extension_id: 'noevid123456789abcdefghijklmnop1',
+      final_verdict: 'ALLOW',
+      scoring_v2: {
+        overall_score: 80, decision: 'ALLOW', risk_level: 'low', hard_gates_triggered: [],
+        security_layer: { layer_name: 'security', score: 80, risk: 0.2, confidence: 0.9,
+          factors: [{ name: 'SAST', severity: 0.5, confidence: 0.9, weight: 0.4, contribution: 0.1, evidence_ids: [] }] },
+      },
+    } as unknown as RawScanResult;
+    const vm = normalizeScanResult(raw);
+    expect(vm).toBeDefined();
+    const f = vm.keyFindings.find((k) => k.evidence && k.evidence.kind === 'sast');
+    expect(f!.evidence!.available).toBe(false);
+  });
+
+  it('old payloads without evidence still normalize safely (legacy summary.key_findings)', () => {
+    const vm = normalizeScanResult(legacyRawResult);
+    expect(vm).toBeDefined();
+    expect(vm.keyFindings.length).toBeGreaterThan(0);
+    // Legacy findings are summary-only, never crash on missing evidence.
+    vm.keyFindings.forEach((k) => {
+      if (k.evidence) expect(k.evidence.available).toBe(false);
+    });
+  });
+
+  it('preserves ordering: coverage first, governance reason before ordinary factors', () => {
+    const raw = {
+      extension_id: 'orderev12345678abcdefghijklmnop1',
+      final_verdict: 'NEEDS_REVIEW',
+      metadata: { last_updated: 'January 1, 2024' },
+      scoring_v2: {
+        overall_score: 65, decision: 'NEEDS_REVIEW', risk_level: 'medium', hard_gates_triggered: [], coverage_cap_applied: true,
+        security_layer: { layer_name: 'security', score: 65, risk: 0.35, confidence: 0.9,
+          factors: [{ name: 'Maintenance', severity: 0.8, confidence: 0.9, weight: 0.1, contribution: 0.072 }] },
+      },
+      sast_results: { scan_error: true, files_scanned: 0, sast_findings: {} },
+      virustotal_analysis: { enabled: true, files_found_in_vt: 5 },
+      governance_bundle: { decision: {
+        final_verdict: 'NEEDS_REVIEW',
+        final_reasons: ['Verify clipboard access is limited to user-initiated copy/paste'],
+        rationale: '[CWS_LIMITED_USE::R5] Condition matched.',
+      } },
+    } as unknown as RawScanResult;
+    const vm = normalizeScanResult(raw);
+    expect(vm.keyFindings[0].title).toBe('Limited code coverage');
+    const govIdx = vm.keyFindings.findIndex((k) => k.evidence && k.evidence.kind === 'governance' && k.evidence.rulepack);
+    const maintIdx = vm.keyFindings.findIndex((k) => k.title === 'Publisher update age');
+    expect(govIdx).toBeGreaterThan(0);
+    if (maintIdx >= 0) expect(maintIdx).toBeGreaterThan(govIdx);
+  });
+
+  it('publisher update age under threshold (severity <= 0.4) stays out of Key Findings', () => {
+    const raw = {
+      extension_id: 'maintlow12345678abcdefghijklmnop',
+      final_verdict: 'ALLOW',
+      scoring_v2: {
+        overall_score: 90, decision: 'ALLOW', risk_level: 'low', hard_gates_triggered: [],
+        security_layer: { layer_name: 'security', score: 90, risk: 0.1, confidence: 0.9,
+          factors: [{ name: 'Maintenance', severity: 0.4, confidence: 0.9, weight: 0.1, contribution: 0.036 }] },
+      },
+    } as unknown as RawScanResult;
+    const vm = normalizeScanResult(raw);
+    expect(vm.keyFindings.some((k) => k.title === 'Publisher update age')).toBe(false);
+  });
+});

--- a/frontend/src/utils/normalizeScanResult.ts
+++ b/frontend/src/utils/normalizeScanResult.ts
@@ -435,7 +435,7 @@ export function coherentRiskLevel(
 
 const GATE_HUMAN_TITLE: Record<string, string> = {
   CRITICAL_SAST: 'Dangerous code pattern detected',
-  SENSITIVE_EXFIL: 'May send your data to external servers',
+  SENSITIVE_EXFIL: 'Requests permissions that could send data externally',
   PURPOSE_MISMATCH: "Behavior doesn't match stated purpose",
   VT_MALWARE: 'Flagged by antivirus engines',
   TOS_VIOLATION: 'Chrome Web Store policy violation',
@@ -504,7 +504,7 @@ const SAST_BEHAVIOR_TITLE: Record<string, string> = {
   server_list: 'Contains hardcoded server list',
   periodic_beacon: 'Beacons to external servers',
   image_steganography: 'May hide data in images',
-  base64_encoded_data: 'Sends encoded data',
+  base64_encoded_data: 'Encoded data pattern detected',
   dns_tunneling: 'May tunnel data over DNS',
   url_and_userid: 'Sends user id to a URL',
   override_fetch_xhr: 'Intercepts network requests',
@@ -595,7 +595,7 @@ export function extractFindingsByLayer(raw: RawScanResult | null | undefined): {
   // 1. Extract SAST findings for Security layer (prioritize high severity)
   if (sastResults) {
     const sastFindings = sastResults.sast_findings || sastResults.sastFindings || {};
-    const sastFindingsList: Array<{ severity: FindingSeverity; title: string; summary: string; filePath: string; lineNum?: number; snippet?: string }> = [];
+    const sastFindingsList: Array<{ severity: FindingSeverity; title: string; summary: string; checkId?: string; filePath: string; lineNum?: number; snippet?: string }> = [];
 
     if (typeof sastFindings === 'object' && !Array.isArray(sastFindings)) {
       Object.entries(sastFindings).forEach(([filePath, findings]) => {
@@ -620,6 +620,7 @@ export function extractFindingsByLayer(raw: RawScanResult | null | undefined): {
               severity: findingSeverity,
               title: humanizeSastCheckId(checkId),
               summary: message,
+              checkId: String(checkId),
               filePath: finding.path || filePath,
               lineNum: typeof lineNum === 'number' ? lineNum : undefined,
               snippet,
@@ -649,11 +650,22 @@ export function extractFindingsByLayer(raw: RawScanResult | null | undefined): {
             label: codeEvidenceLabel(filePath, lineStart), evidenceIds: [],
           }
         : { kind: 'sast', available: false };
+      // Pattern-only exfil/encoded detections have no destination evidence here —
+      // clarify so the finding is not read as confirmed exfiltration.
+      const suffix = String(f.checkId || '').toLowerCase().split('.').pop() || '';
+      const PATTERN_ONLY_EXFIL = new Set([
+        'base64_encoded_data', 'periodic_beacon', 'image_steganography',
+        'dns_tunneling', 'override_fetch_xhr', 'url_and_userid',
+      ]);
+      let summary = f.summary.length > 100 ? `${f.summary.substring(0, 97)}...` : f.summary;
+      if (PATTERN_ONLY_EXFIL.has(suffix)) {
+        summary = `${summary} — no confirmed external destination shown.`;
+      }
       result.security.push({
         title: f.title,
         severity: f.severity,
         layer: 'security',
-        summary: f.summary.length > 100 ? `${f.summary.substring(0, 97)}...` : f.summary,
+        summary,
         evidenceIds: [],
         evidence,
       });

--- a/frontend/src/utils/normalizeScanResult.ts
+++ b/frontend/src/utils/normalizeScanResult.ts
@@ -643,7 +643,7 @@ export function extractFindingsByLayer(raw: RawScanResult | null | undefined): {
       const lineStart = f.lineNum ?? spHit?.lineStart ?? null;
       const evidence: KeyFindingEvidence = filePath
         ? {
-            kind: 'sast', available: true, filePath,
+            kind: 'sast', available: true, filePath: toRelativeEvidencePath(filePath),
             lineStart, lineEnd: spHit?.lineEnd ?? null,
             snippet: f.snippet ?? spHit?.snippet, sourceViewerPath: filePath,
             label: codeEvidenceLabel(filePath, lineStart), evidenceIds: [],
@@ -1053,9 +1053,33 @@ function parseRulepackRule(rationale: unknown): { rulepack?: string; ruleId?: st
   return m ? { rulepack: m[1], ruleId: m[2] } : {};
 }
 
+/**
+ * Normalize a code-evidence path for DISPLAY: strip any local/machine prefix so
+ * only the extension/archive-relative path is shown (e.g.
+ * "/Users/…/extensions_storage/extracted_xxx/js/background.js" -> "js/background.js").
+ * Never returns a string containing "/Users/", "/home/", a drive root,
+ * "extensions_storage" or "extracted_". The raw path is preserved separately
+ * (evidence.sourceViewerPath) for internal use.
+ */
+export function toRelativeEvidencePath(path: unknown): string {
+  if (typeof path !== 'string' || !path) return '';
+  const s = path.replace(/\\/g, '/');
+  // Prefer the archive-relative tail after the extraction dir.
+  const extracted = s.match(/(?:^|\/)extracted_[^/]*\/(.+)$/);
+  if (extracted) return extracted[1];
+  const storage = s.match(/(?:^|\/)extensions_storage\/(.+)$/);
+  if (storage) return storage[1];
+  // Any remaining absolute/local path -> keep only the basename to avoid leaks.
+  if (s.startsWith('/') || /^[a-zA-Z]:\//.test(s) || /\/(?:Users|home)\//i.test(s)) {
+    return s.split('/').filter(Boolean).pop() || '';
+  }
+  return s;
+}
+
 function codeEvidenceLabel(filePath?: string, lineStart?: number | null): string | undefined {
   if (!filePath) return undefined;
-  return typeof lineStart === 'number' && lineStart > 0 ? `${filePath}:${lineStart}` : filePath;
+  const rel = toRelativeEvidencePath(filePath);
+  return typeof lineStart === 'number' && lineStart > 0 ? `${rel}:${lineStart}` : rel;
 }
 
 /**
@@ -1135,7 +1159,7 @@ function resolveFactorEvidence(
     if (hit && hit.filePath) {
       return {
         kind: 'sast', available: true,
-        filePath: hit.filePath, lineStart: hit.lineStart, lineEnd: hit.lineEnd,
+        filePath: toRelativeEvidencePath(hit.filePath), lineStart: hit.lineStart, lineEnd: hit.lineEnd,
         snippet: hit.snippet, evidenceIds: ids, sourceViewerPath: hit.filePath,
         label: codeEvidenceLabel(hit.filePath, hit.lineStart),
       };
@@ -1213,7 +1237,7 @@ function resolveFactorEvidence(
   const hit = direct || resolveSyntheticCodeEvidence(ids, fileIndex);
   if (hit && hit.filePath) {
     return {
-      kind: 'sast', available: true, filePath: hit.filePath,
+      kind: 'sast', available: true, filePath: toRelativeEvidencePath(hit.filePath),
       lineStart: hit.lineStart, lineEnd: hit.lineEnd, snippet: hit.snippet,
       evidenceIds: ids, sourceViewerPath: hit.filePath, label: codeEvidenceLabel(hit.filePath, hit.lineStart),
     };

--- a/frontend/src/utils/normalizeScanResult.ts
+++ b/frontend/src/utils/normalizeScanResult.ts
@@ -827,7 +827,13 @@ function gateDecisionToBand(decision: string | null | undefined): ScoreBand | nu
 function factorIssueBand(layer: RawLayerScore | null | undefined): ScoreBand | null {
   const factors = layer?.factors;
   if (!Array.isArray(factors)) return null;
-  return factors.some((f) => (f?.severity ?? 0) >= 0.4) ? 'WARN' : null;
+  return factors.some((f) => {
+    // Publisher update age below the key-finding threshold (0.6) is routine
+    // context, not an issue — mirror the buildKeyFindings carve-out so the card
+    // band agrees with its own "No issues" pill instead of showing amber.
+    if (f?.name === 'Maintenance' && (f?.severity ?? 0) < 0.6) return false;
+    return (f?.severity ?? 0) >= 0.4;
+  }) ? 'WARN' : null;
 }
 
 /**

--- a/frontend/src/utils/normalizeScanResult.ts
+++ b/frontend/src/utils/normalizeScanResult.ts
@@ -588,12 +588,15 @@ export function extractFindingsByLayer(raw: RawScanResult | null | undefined): {
   const scoringV2 = raw.scoring_v2 || raw.governance_bundle?.scoring_v2 || null;
   const sastResults = raw.sast_results;
   const permsAnalysis = raw.permissions_analysis;
+  // Evidence lookups (shared by the SAST + factor findings below).
+  const evLookup = buildEvidenceIndex(raw);
+  const fileIndex = buildSignalPackFileIndex(raw);
 
   // 1. Extract SAST findings for Security layer (prioritize high severity)
   if (sastResults) {
     const sastFindings = sastResults.sast_findings || sastResults.sastFindings || {};
-    const sastFindingsList: Array<{ severity: FindingSeverity; title: string; summary: string }> = [];
-    
+    const sastFindingsList: Array<{ severity: FindingSeverity; title: string; summary: string; filePath: string; lineNum?: number; snippet?: string }> = [];
+
     if (typeof sastFindings === 'object' && !Array.isArray(sastFindings)) {
       Object.entries(sastFindings).forEach(([filePath, findings]) => {
         if (Array.isArray(findings)) {
@@ -603,7 +606,8 @@ export function extractFindingsByLayer(raw: RawScanResult | null | undefined): {
             const message = extra.message || finding.check_id || 'SAST finding';
             const checkId = finding.check_id || 'unknown';
             const lineNum = finding.start?.line;
-            
+            const snippet = typeof extra.lines === 'string' ? extra.lines : undefined;
+
             // Map severity to finding level
             let findingSeverity: FindingSeverity = 'low';
             if (severity === 'CRITICAL' || severity === 'ERROR') {
@@ -616,28 +620,59 @@ export function extractFindingsByLayer(raw: RawScanResult | null | undefined): {
               severity: findingSeverity,
               title: humanizeSastCheckId(checkId),
               summary: message,
+              filePath: finding.path || filePath,
+              lineNum: typeof lineNum === 'number' ? lineNum : undefined,
+              snippet,
             });
           });
         }
       });
     }
-    
+
     // Sort by severity (high > medium > low) and take top 10
     sastFindingsList.sort((a, b) => {
       const order = { high: 3, medium: 2, low: 1 };
       return (order[b.severity] || 0) - (order[a.severity] || 0);
     });
-    
+
     sastFindingsList.slice(0, 10).forEach(f => {
+      // Prefer the canonical signal_pack.evidence line for this file, else the
+      // finding's own start line. Evidence is display-only (not drawer-openable).
+      const spHit = f.filePath ? fileIndex[`sast::${f.filePath}`] : undefined;
+      const filePath = f.filePath || spHit?.filePath;
+      const lineStart = f.lineNum ?? spHit?.lineStart ?? null;
+      const evidence: KeyFindingEvidence = filePath
+        ? {
+            kind: 'sast', available: true, filePath,
+            lineStart, lineEnd: spHit?.lineEnd ?? null,
+            snippet: f.snippet ?? spHit?.snippet, sourceViewerPath: filePath,
+            label: codeEvidenceLabel(filePath, lineStart), evidenceIds: [],
+          }
+        : { kind: 'sast', available: false };
       result.security.push({
         title: f.title,
         severity: f.severity,
         layer: 'security',
         summary: f.summary.length > 100 ? `${f.summary.substring(0, 97)}...` : f.summary,
         evidenceIds: [],
+        evidence,
       });
     });
   }
+
+  // Attach the structured evidence a factor already carries (resolves synthetic
+  // ids to signal_pack.evidence by tool+file). Display-only; ordering unaffected.
+  const factorEvidence = (f: RawFactorScore, layer: 'security' | 'privacy' | 'governance'): KeyFindingEvidence =>
+    resolveFactorEvidence({
+      name: safeGet(f.name, 'Unknown'),
+      severity: safeGet(f.severity, 0),
+      confidence: safeGet(f.confidence, 0),
+      weight: f.weight,
+      riskContribution: f.contribution,
+      evidenceIds: safeGet(f.evidence_ids, []),
+      details: f.details,
+      layer,
+    }, raw, evLookup);
 
   // 2. Extract factors from scoring_v2 (already categorized by layer)
   // Only include factors with significant severity (>= 0.3) to avoid noise
@@ -652,6 +687,7 @@ export function extractFindingsByLayer(raw: RawScanResult | null | undefined): {
             layer: 'security',
             summary: humanizeFactorSummary(f, 'security'),
             evidenceIds: safeGet(f.evidence_ids, []),
+            evidence: factorEvidence(f, 'security'),
           });
         }
       });
@@ -667,6 +703,7 @@ export function extractFindingsByLayer(raw: RawScanResult | null | undefined): {
             layer: 'privacy',
             summary: humanizeFactorSummary(f, 'privacy'),
             evidenceIds: safeGet(f.evidence_ids, []),
+            evidence: factorEvidence(f, 'privacy'),
           });
         }
       });
@@ -682,6 +719,7 @@ export function extractFindingsByLayer(raw: RawScanResult | null | undefined): {
             layer: 'governance',
             summary: humanizeFactorSummary(f, 'governance'),
             evidenceIds: safeGet(f.evidence_ids, []),
+            evidence: factorEvidence(f, 'governance'),
           });
         }
       });
@@ -1021,6 +1059,54 @@ function codeEvidenceLabel(filePath?: string, lineStart?: number | null): string
 }
 
 /**
+ * Parse a synthetic factor evidence id into (tool, file, token). Factor ids
+ * encode the signal, not a content hash, e.g.:
+ *   "entropy:file:js/jsonpath.js"                         -> tool=entropy, file=js/jsonpath.js
+ *   "sast:src...base64_encoded_data:service_worker.js"    -> tool=sast,    file=service_worker.js
+ *   "perm:high_risk:cookies" / "manifest:issue:missing_csp" / "combo:broad_host_access"
+ * The file is the last ":"-segment (extension file paths use "/", not ":");
+ * the token is that same last segment, used for permission/manifest references.
+ */
+function parseSyntheticEvidenceId(id: unknown): { tool: string; file: string; token: string } {
+  if (typeof id !== 'string' || !id.includes(':')) return { tool: '', file: '', token: '' };
+  const parts = id.split(':');
+  const last = parts[parts.length - 1];
+  return { tool: parts[0].toLowerCase(), file: last, token: last };
+}
+
+/**
+ * Index signal_pack.evidence by `${tool_name}::${file_path}` so a factor's
+ * synthetic id (which shares the tool + file, not the content hash) can be
+ * resolved to the real file/line/snippet the payload already carries.
+ */
+function buildSignalPackFileIndex(raw: RawScanResult): Record<string, EvidenceItemVM> {
+  const idx: Record<string, EvidenceItemVM> = {};
+  try {
+    extractEvidenceItems(raw).forEach(({ evidence }) => {
+      if (evidence && evidence.toolName && evidence.filePath) {
+        idx[`${String(evidence.toolName).toLowerCase()}::${evidence.filePath}`] = evidence;
+      }
+    });
+  } catch { /* never throw — evidence is best-effort */ }
+  return idx;
+}
+
+/** Resolve the first file-backed (sast/entropy) synthetic id to its signal-pack evidence. */
+function resolveSyntheticCodeEvidence(
+  ids: string[],
+  fileIndex: Record<string, EvidenceItemVM>,
+): EvidenceItemVM | null {
+  for (const id of ids) {
+    const { tool, file } = parseSyntheticEvidenceId(id);
+    if ((tool === 'sast' || tool === 'entropy') && file) {
+      const hit = fileIndex[`${tool}::${file}`];
+      if (hit && hit.filePath) return hit;
+    }
+  }
+  return null;
+}
+
+/**
  * Resolve a structured evidence reference for a scoring-factor finding using the
  * evidence the payload already carries. Never fabricates: returns
  * `{ available: false }` when nothing is resolvable.
@@ -1037,16 +1123,21 @@ function resolveFactorEvidence(
     manifest?: { permissions?: unknown; host_permissions?: unknown };
     metadata?: { last_updated?: unknown };
   };
+  // Synthetic factor ids (entropy:file:*, sast:*:file) don't match the
+  // content-hash-keyed evidence index; resolve them by (tool, file) instead.
+  const fileIndex = buildSignalPackFileIndex(raw);
 
-  // SAST / obfuscation — resolve the first evidence item to file/line/snippet.
+  // SAST / obfuscation — resolve to file/line/snippet, first by direct id then by
+  // the (tool, file) match against signal_pack.evidence.
   if (name === 'SAST' || name === 'Obfuscation') {
-    const first = ids.map((id) => evLookup[id]).find(Boolean);
-    if (first && first.filePath) {
+    const direct = ids.map((id) => evLookup[id]).find((e) => e && e.filePath);
+    const hit = direct || resolveSyntheticCodeEvidence(ids, fileIndex);
+    if (hit && hit.filePath) {
       return {
         kind: 'sast', available: true,
-        filePath: first.filePath, lineStart: first.lineStart, lineEnd: first.lineEnd,
-        snippet: first.snippet, evidenceIds: ids, sourceViewerPath: first.filePath,
-        label: codeEvidenceLabel(first.filePath, first.lineStart),
+        filePath: hit.filePath, lineStart: hit.lineStart, lineEnd: hit.lineEnd,
+        snippet: hit.snippet, evidenceIds: ids, sourceViewerPath: hit.filePath,
+        label: codeEvidenceLabel(hit.filePath, hit.lineStart),
       };
     }
     return { kind: 'sast', available: false, evidenceIds: ids };
@@ -1070,18 +1161,37 @@ function resolveFactorEvidence(
     return { kind: 'virustotal', available: false };
   }
 
-  // Manifest / permission factors — permission + host permission references.
+  // Manifest / permission factors — surface the SPECIFIC permission or manifest
+  // issue named in the synthetic evidence id, falling back to the manifest.
   if (['Manifest', 'PermissionsBaseline', 'PermissionCombos', 'CaptureSignals', 'NetworkExfil'].includes(name)) {
     const manifest = anyRaw.manifest || {};
     const perms: string[] = Array.isArray(manifest.permissions) ? manifest.permissions as string[] : [];
     const hosts: string[] = Array.isArray(manifest.host_permissions) ? manifest.host_permissions as string[] : [];
     const details = (factor.details || {}) as { description?: unknown };
     const explanation = typeof details.description === 'string' ? details.description : undefined;
-    if (perms.length || hosts.length || explanation) {
+    const tokens = ids.map((id) => parseSyntheticEvidenceId(id).token).filter(Boolean);
+    const token = tokens[0];
+
+    if (name === 'Manifest') {
+      // token is a manifest issue (e.g. missing_csp, broad_host_access)
+      const issue = token;
+      if (issue || hosts.length || explanation) {
+        return {
+          kind: 'manifest', available: true,
+          manifestField: issue || 'permissions', hostPermission: hosts[0], explanation,
+          label: issue ? issue.replace(/_/g, ' ') : (perms[0] || hosts[0] || 'manifest'),
+        };
+      }
+      return { kind: 'manifest', available: false };
+    }
+
+    // Permission / combo / capture — token is the specific permission or signal.
+    const permission = token || perms[0];
+    if (permission || hosts.length || explanation) {
       return {
         kind: 'manifest', available: true,
-        permission: perms[0], hostPermission: hosts[0], manifestField: 'permissions',
-        explanation, label: perms[0] || hosts[0] || 'manifest',
+        permission, hostPermission: hosts[0], manifestField: 'permissions', explanation,
+        label: permission || hosts[0] || 'manifest',
       };
     }
     return { kind: 'manifest', available: false };
@@ -1097,13 +1207,15 @@ function resolveFactorEvidence(
     };
   }
 
-  // Fallback: resolve any evidence ids to code, else mark unavailable (summary-only).
-  const first = ids.map((id) => evLookup[id]).find(Boolean);
-  if (first && first.filePath) {
+  // Fallback: resolve any evidence ids to code (direct or synthetic), else
+  // mark unavailable (summary-only).
+  const direct = ids.map((id) => evLookup[id]).find((e) => e && e.filePath);
+  const hit = direct || resolveSyntheticCodeEvidence(ids, fileIndex);
+  if (hit && hit.filePath) {
     return {
-      kind: 'sast', available: true, filePath: first.filePath,
-      lineStart: first.lineStart, lineEnd: first.lineEnd, snippet: first.snippet,
-      evidenceIds: ids, sourceViewerPath: first.filePath, label: codeEvidenceLabel(first.filePath, first.lineStart),
+      kind: 'sast', available: true, filePath: hit.filePath,
+      lineStart: hit.lineStart, lineEnd: hit.lineEnd, snippet: hit.snippet,
+      evidenceIds: ids, sourceViewerPath: hit.filePath, label: codeEvidenceLabel(hit.filePath, hit.lineStart),
     };
   }
   return { kind: 'summary', available: false, evidenceIds: ids };

--- a/frontend/src/utils/normalizeScanResult.ts
+++ b/frontend/src/utils/normalizeScanResult.ts
@@ -36,6 +36,7 @@ import type {
   FactorsByLayerVM,
   FactorVM,
   KeyFindingVM,
+  KeyFindingEvidence,
   FindingSeverity,
   PermissionsVM,
   EvidenceItemVM,
@@ -1003,6 +1004,111 @@ function buildEvidenceIndex(raw: RawScanResult): Record<string, EvidenceItemVM> 
  * headline reason matches the score driver. They are coverage limitations, not
  * confirmed threats (each summary says so explicitly).
  */
+// =============================================================================
+// KEY FINDING EVIDENCE — additive, verifiable references (never fabricated)
+// =============================================================================
+
+/** Parse a "[CWS_LIMITED_USE::R5]" rulepack::rule token from a governance rationale. */
+function parseRulepackRule(rationale: unknown): { rulepack?: string; ruleId?: string } {
+  if (typeof rationale !== 'string') return {};
+  const m = rationale.match(/\[([A-Za-z0-9_]+)::([A-Za-z0-9_]+)\]/);
+  return m ? { rulepack: m[1], ruleId: m[2] } : {};
+}
+
+function codeEvidenceLabel(filePath?: string, lineStart?: number | null): string | undefined {
+  if (!filePath) return undefined;
+  return typeof lineStart === 'number' && lineStart > 0 ? `${filePath}:${lineStart}` : filePath;
+}
+
+/**
+ * Resolve a structured evidence reference for a scoring-factor finding using the
+ * evidence the payload already carries. Never fabricates: returns
+ * `{ available: false }` when nothing is resolvable.
+ */
+function resolveFactorEvidence(
+  factor: FactorVM & { layer: string },
+  raw: RawScanResult,
+  evLookup: Record<string, EvidenceItemVM>,
+): KeyFindingEvidence {
+  const name = factor.name;
+  const ids = Array.isArray(factor.evidenceIds) ? factor.evidenceIds : [];
+  const anyRaw = raw as unknown as {
+    virustotal_analysis?: any;
+    manifest?: { permissions?: unknown; host_permissions?: unknown };
+    metadata?: { last_updated?: unknown };
+  };
+
+  // SAST / obfuscation — resolve the first evidence item to file/line/snippet.
+  if (name === 'SAST' || name === 'Obfuscation') {
+    const first = ids.map((id) => evLookup[id]).find(Boolean);
+    if (first && first.filePath) {
+      return {
+        kind: 'sast', available: true,
+        filePath: first.filePath, lineStart: first.lineStart, lineEnd: first.lineEnd,
+        snippet: first.snippet, evidenceIds: ids, sourceViewerPath: first.filePath,
+        label: codeEvidenceLabel(first.filePath, first.lineStart),
+      };
+    }
+    return { kind: 'sast', available: false, evidenceIds: ids };
+  }
+
+  // VirusTotal / threat intel — reputation counts + first file hash.
+  if (name === 'VirusTotal' || name === 'ChromeStats') {
+    const vt = anyRaw.virustotal_analysis || {};
+    const fileResults = Array.isArray(vt.file_results) ? vt.file_results : [];
+    const hash = fileResults[0]?.hashes?.sha256 || fileResults[0]?.hashes?.sha1;
+    const threat = vt.summary?.threat_level;
+    const available = vt.enabled !== false && (Number(vt.files_found_in_vt ?? 0) > 0 || Number(vt.files_analyzed ?? 0) > 0);
+    if (available) {
+      return {
+        kind: 'virustotal', available: true, hash,
+        malicious: Number(vt.total_malicious ?? 0), suspicious: Number(vt.total_suspicious ?? 0),
+        coverageState: threat,
+        label: threat ? `VirusTotal: ${threat}` : `VirusTotal: ${Number(vt.total_malicious ?? 0)} malicious`,
+      };
+    }
+    return { kind: 'virustotal', available: false };
+  }
+
+  // Manifest / permission factors — permission + host permission references.
+  if (['Manifest', 'PermissionsBaseline', 'PermissionCombos', 'CaptureSignals', 'NetworkExfil'].includes(name)) {
+    const manifest = anyRaw.manifest || {};
+    const perms: string[] = Array.isArray(manifest.permissions) ? manifest.permissions as string[] : [];
+    const hosts: string[] = Array.isArray(manifest.host_permissions) ? manifest.host_permissions as string[] : [];
+    const details = (factor.details || {}) as { description?: unknown };
+    const explanation = typeof details.description === 'string' ? details.description : undefined;
+    if (perms.length || hosts.length || explanation) {
+      return {
+        kind: 'manifest', available: true,
+        permission: perms[0], hostPermission: hosts[0], manifestField: 'permissions',
+        explanation, label: perms[0] || hosts[0] || 'manifest',
+      };
+    }
+    return { kind: 'manifest', available: false };
+  }
+
+  // Publisher update age (Maintenance) — advisory context from the store listing.
+  if (name === 'Maintenance') {
+    const lastUpdated = anyRaw.metadata?.last_updated;
+    return {
+      kind: 'summary', available: Boolean(lastUpdated),
+      explanation: 'Based on the store listing last-updated date.',
+      label: typeof lastUpdated === 'string' ? `Updated ${lastUpdated}` : undefined,
+    };
+  }
+
+  // Fallback: resolve any evidence ids to code, else mark unavailable (summary-only).
+  const first = ids.map((id) => evLookup[id]).find(Boolean);
+  if (first && first.filePath) {
+    return {
+      kind: 'sast', available: true, filePath: first.filePath,
+      lineStart: first.lineStart, lineEnd: first.lineEnd, snippet: first.snippet,
+      evidenceIds: ids, sourceViewerPath: first.filePath, label: codeEvidenceLabel(first.filePath, first.lineStart),
+    };
+  }
+  return { kind: 'summary', available: false, evidenceIds: ids };
+}
+
 function buildCoverageKeyFindings(
   scoringV2: RawScoringV2 | null,
   raw: RawScanResult
@@ -1024,8 +1130,8 @@ function buildCoverageKeyFindings(
   if (!capApplied && !insufficient) return [];
 
   const findings: KeyFindingVM[] = [];
-  const mk = (title: string, summary: string): KeyFindingVM => ({
-    title, severity: 'high', layer: 'security', summary, evidenceIds: [],
+  const mk = (title: string, summary: string, evidence: KeyFindingEvidence): KeyFindingVM => ({
+    title, severity: 'high', layer: 'security', summary, evidenceIds: [], evidence,
   });
 
   const sp = (anyRaw.governance_bundle?.signal_pack || {}) as Record<string, any>;
@@ -1040,10 +1146,12 @@ function buildCoverageKeyFindings(
 
   if (sast.scan_error) {
     findings.push(mk('Limited code coverage',
-      'The code analyzer (SAST) did not complete, so the extension’s code could not be checked. This is why it needs review — not a confirmed threat.'));
+      'The code analyzer (SAST) did not complete, so the extension’s code could not be checked. This is why it needs review — not a confirmed threat.',
+      { kind: 'coverage', available: true, analyzer: 'SAST', reason: 'Code analysis (SAST) failed to complete', coverageState: 'failed', label: 'Coverage: SAST failed' }));
   } else if (!sastRan) {
     findings.push(mk('No analyzable code scanned',
-      'No analyzable code was scanned (often minified or bundled code). The code was not statically analyzed, so it cannot be cleared as safe.'));
+      'No analyzable code was scanned (often minified or bundled code). The code was not statically analyzed, so it cannot be cleared as safe.',
+      { kind: 'coverage', available: true, analyzer: 'SAST', reason: 'No analyzable code was scanned', coverageState: 'no_code_scanned', label: 'Coverage: no code scanned' }));
   }
 
   const vt = (sp.virustotal || {}) as { enabled?: boolean; total_engines?: number; files_found_in_vt?: number };
@@ -1054,15 +1162,17 @@ function buildCoverageKeyFindings(
   const vtAvailable = vtEnabled !== false && (vtEngines > 0 || vtFound > 0);
   if (!vtAvailable) {
     findings.push(mk('Limited malware reputation coverage',
-      'The extension’s files were not found in VirusTotal (or the malware scan was unavailable), so malware reputation could not be confirmed.'));
+      'The extension’s files were not found in VirusTotal (or the malware scan was unavailable), so malware reputation could not be confirmed.',
+      { kind: 'coverage', available: true, analyzer: 'VirusTotal', reason: 'Files not found in VirusTotal, or the malware scan was unavailable', coverageState: 'unavailable', label: 'Coverage: VirusTotal unavailable' }));
   }
 
   if (findings.length === 0) {
     const reason = anyV2.coverage_cap_reason || anyRaw.governance_bundle?.scoring_v2?.coverage_cap_reason;
-    findings.push(mk('Limited analysis coverage',
-      typeof reason === 'string' && reason.trim()
-        ? reason
-        : 'Some analyzers did not run at scan time, so this extension could not be fully cleared.'));
+    const reasonText = typeof reason === 'string' && reason.trim()
+      ? reason
+      : 'Some analyzers did not run at scan time, so this extension could not be fully cleared.';
+    findings.push(mk('Limited analysis coverage', reasonText,
+      { kind: 'coverage', available: true, analyzer: 'multiple', reason: reasonText, coverageState: 'limited', label: 'Coverage limited' }));
   }
   return findings;
 }
@@ -1088,7 +1198,7 @@ function buildGovernanceReasonKeyFindings(
   if (verdict !== 'NEEDS_REVIEW' && verdict !== 'WARN' && verdict !== 'BLOCK') return [];
 
   const decision = (raw.governance_bundle?.decision || {}) as {
-    final_reasons?: unknown; action_required?: unknown;
+    final_reasons?: unknown; action_required?: unknown; rationale?: unknown;
   };
   let reasons = (Array.isArray(decision.final_reasons) ? decision.final_reasons : [])
     .filter((r): r is string => typeof r === 'string' && r.trim() !== '');
@@ -1098,12 +1208,20 @@ function buildGovernanceReasonKeyFindings(
   if (reasons.length === 0) return [];
 
   const severity: FindingSeverity = verdict === 'BLOCK' ? 'high' : 'medium';
+  const { rulepack, ruleId } = parseRulepackRule(decision.rationale);
+  const actionRequired = typeof decision.action_required === 'string' ? decision.action_required : undefined;
+  const label = rulepack && ruleId ? `Rule ${rulepack}::${ruleId}` : 'Governance rule';
   return reasons.slice(0, 3).map((reason) => ({
     title: reason,
     severity,
     layer: 'governance' as const,
     summary: reason,
     evidenceIds: [],
+    evidence: {
+      kind: 'governance' as const,
+      available: true,
+      rulepack, ruleId, finalReason: reason, actionRequired, label,
+    },
   }));
 }
 
@@ -1115,6 +1233,8 @@ function buildKeyFindings(
   raw: RawScanResult
 ): KeyFindingVM[] {
   const findings: KeyFindingVM[] = [];
+  // Resolve evidence ids -> file/line/snippet once for factor findings below.
+  const evLookup = buildEvidenceIndex(raw);
 
   // 1. Add hard gates as high severity findings with correct layer classification
   const hardGates = scoringV2?.hard_gates_triggered || [];
@@ -1126,6 +1246,12 @@ function buildKeyFindings(
       layer: layer,
       summary: humanizeGateId(gate),
       evidenceIds: [],
+      evidence: {
+        kind: 'governance',
+        available: true,
+        ruleId: gate,
+        label: `Gate: ${humanizeGateId(gate)}`,
+      },
     });
   });
 
@@ -1229,6 +1355,7 @@ function buildKeyFindings(
         layer: factor.layer,
         summary,
         evidenceIds: factor.evidenceIds,
+        evidence: resolveFactorEvidence(factor, raw, evLookup),
       });
     });
   
@@ -1242,10 +1369,11 @@ function buildKeyFindings(
         layer: 'governance',
         summary: reason,
         evidenceIds: [],
+        evidence: { kind: 'summary', available: false },
       });
     });
   }
-  
+
   // 4. If still no findings, add from legacy summary.key_findings
   if (findings.length === 0 && raw.summary?.key_findings) {
     raw.summary.key_findings.forEach((finding: string) => {
@@ -1255,10 +1383,11 @@ function buildKeyFindings(
         layer: 'security',
         summary: finding,
         evidenceIds: [],
+        evidence: { kind: 'summary', available: false },
       });
     });
   }
-  
+
   return findings;
 }
 

--- a/frontend/src/utils/reportDisplay.js
+++ b/frontend/src/utils/reportDisplay.js
@@ -318,6 +318,28 @@ export function evidenceCountLabel(count) {
 }
 
 /**
+ * Resolve the evidence label shown on a Key Findings row (display only).
+ *
+ * Precedence:
+ *  - resolvable evidence IDs (count > 0) -> the existing openable count label
+ *    (the "View evidence" button is gated on the same count, unchanged).
+ *  - else structured finding.evidence:
+ *      available + label -> "Evidence: <label>"
+ *      otherwise (available:false, or present but unlabelled) -> "Evidence: summary only"
+ *  - else (no IDs and no structured evidence) -> "Evidence not linked".
+ *
+ * Never generates a new label — it only selects the existing finding.evidence.label.
+ */
+export function resolveFindingEvidenceLabel(finding, evidenceCount) {
+  const n = Number(evidenceCount) || 0;
+  if (n > 0) return evidenceCountLabel(n);
+  const ev = finding && finding.evidence;
+  if (ev && ev.available === true && ev.label) return `Evidence: ${ev.label}`;
+  if (ev) return 'Evidence: summary only';
+  return evidenceCountLabel(0);
+}
+
+/**
  * Issue Overview counts by severity from a list of findings. Info stays 0 unless
  * findings are explicitly informational. Total is the sum of all buckets.
  */

--- a/frontend/src/utils/reportDisplay.test.js
+++ b/frontend/src/utils/reportDisplay.test.js
@@ -8,6 +8,7 @@ import {
   preciseFindingTitle,
   normalizeVerdictKey,
   evidenceCountLabel,
+  resolveFindingEvidenceLabel,
 } from './reportDisplay';
 
 const CHROMESTATS_DEFAULT = {
@@ -215,5 +216,46 @@ describe('resolveIssueOverview', () => {
   it('handles numeric severities and empty input', () => {
     expect(resolveIssueOverview([{ severity: 0.9 }, { severity: 0.5 }]).total).toBe(2);
     expect(resolveIssueOverview([]).total).toBe(0);
+  });
+});
+
+describe('resolveFindingEvidenceLabel — Key Findings row evidence label', () => {
+  it('shows the structured evidence label when there are no resolvable evidence IDs', () => {
+    const finding = { title: 'Limited malware reputation coverage', evidence: { available: true, label: 'Coverage: VirusTotal unavailable' } };
+    expect(resolveFindingEvidenceLabel(finding, 0)).toBe('Evidence: Coverage: VirusTotal unavailable');
+  });
+
+  it('shows a SAST file:line structured label when IDs are empty', () => {
+    const finding = { title: 'Code Safety', evidence: { available: true, kind: 'sast', label: 'js/content.js:12' } };
+    expect(resolveFindingEvidenceLabel(finding, 0)).toBe('Evidence: js/content.js:12');
+  });
+
+  it('keeps the existing openable count label when resolvable evidence IDs exist (gates the View evidence button)', () => {
+    const finding = { title: 'Code Safety', evidence: { available: true, label: 'js/content.js:12' } };
+    expect(resolveFindingEvidenceLabel(finding, 2)).toBe('2 evidence items');
+    expect(resolveFindingEvidenceLabel(finding, 1)).toBe('1 evidence item');
+  });
+
+  it('shows "Evidence: summary only" for available:false findings', () => {
+    const finding = { title: 'Passes checks', evidence: { available: false } };
+    expect(resolveFindingEvidenceLabel(finding, 0)).toBe('Evidence: summary only');
+  });
+
+  it('shows "Evidence: summary only" when structured evidence exists but has no label (never "not linked")', () => {
+    const finding = { title: 'x', evidence: { available: true } };
+    expect(resolveFindingEvidenceLabel(finding, 0)).toBe('Evidence: summary only');
+  });
+
+  it('shows "Evidence not linked" only when there are no IDs and no structured evidence', () => {
+    expect(resolveFindingEvidenceLabel({ title: 'x' }, 0)).toBe('Evidence not linked');
+    expect(resolveFindingEvidenceLabel({ title: 'x', evidence: null }, 0)).toBe('Evidence not linked');
+    expect(resolveFindingEvidenceLabel(null, 0)).toBe('Evidence not linked');
+  });
+
+  it('is label-only and never mutates the finding (ordering/severity unaffected)', () => {
+    const finding = { title: 'x', severity: 'high', evidence: { available: true, label: 'Rule CWS_LIMITED_USE::R5' } };
+    const before = JSON.stringify(finding);
+    resolveFindingEvidenceLabel(finding, 0);
+    expect(JSON.stringify(finding)).toBe(before);
   });
 });

--- a/frontend/src/utils/reportTypes.ts
+++ b/frontend/src/utils/reportTypes.ts
@@ -538,6 +538,54 @@ export interface KeyFindingVM {
   layer: 'security' | 'privacy' | 'governance';
   summary: string;
   evidenceIds: string[];
+  /**
+   * Optional, additive structured reference letting a user verify WHY this
+   * finding exists. Backward-compatible: absent on legacy payloads / findings
+   * with no derivable evidence. Never fabricated — `available: false` marks a
+   * summary-only finding. Ordering/severity are unaffected by this field.
+   */
+  evidence?: KeyFindingEvidence;
+}
+
+/**
+ * Structured, verifiable reference for a Key Finding. All fields except `kind`
+ * and `available` are optional and only present when the source payload carried
+ * them (no invented evidence). `label` is a short one-line reference for compact
+ * display; the type-specific fields back it.
+ */
+export interface KeyFindingEvidence {
+  kind: 'sast' | 'governance' | 'manifest' | 'virustotal' | 'coverage' | 'summary';
+  available: boolean;
+  label?: string;
+  // SAST / code
+  filePath?: string;
+  lineStart?: number | null;
+  lineEnd?: number | null;
+  snippet?: string;
+  evidenceIds?: string[];
+  /** File path the existing FileViewerModal / GET /api/scan/file endpoint can open. */
+  sourceViewerPath?: string;
+  // governance rulepack
+  rulepack?: string;
+  ruleId?: string;
+  finalReason?: string;
+  actionRequired?: string;
+  // manifest / permission
+  permission?: string;
+  hostPermission?: string;
+  manifestField?: string;
+  explanation?: string;
+  // virustotal
+  hash?: string;
+  malicious?: number;
+  suspicious?: number;
+  harmless?: number;
+  undetected?: number;
+  coverageState?: string;
+  // coverage-cap
+  analyzer?: string;
+  reason?: string;
+  confidence?: number | null;
 }
 
 /** Permissions view model */

--- a/src/extension_shield/core/report_view_model.py
+++ b/src/extension_shield/core/report_view_model.py
@@ -487,7 +487,7 @@ def build_unified_consumer_summary(
                 "Maintenance": "Update and maintenance status",
                 "PermissionsBaseline": "Permission risk level",
                 "PermissionCombos": "Risky permission combinations",
-                "NetworkExfil": "Data sent to external servers",
+                "NetworkExfil": "External data transfer capability",
                 "CaptureSignals": "Screen or input capture check",
                 "ToSViolations": "Policy compliance",
                 "Consistency": "Behavior consistency check",
@@ -563,7 +563,7 @@ def build_unified_consumer_summary(
             # Add hard gates in plain English (avoid raw gate IDs like "SENSITIVE_EXFIL")
             _gate_plain_names = {
                 "CRITICAL_SAST": "Dangerous code patterns detected",
-                "SENSITIVE_EXFIL": "May send sensitive data to external servers",
+                "SENSITIVE_EXFIL": "Requests permissions that could send data externally",
                 "PURPOSE_MISMATCH": "Behavior doesn't match its stated purpose",
                 "VT_MALWARE": "Flagged by antivirus engines",
                 "TOS_VIOLATION": "Chrome Web Store policy violation detected",

--- a/src/extension_shield/governance/decision_refresh.py
+++ b/src/extension_shield/governance/decision_refresh.py
@@ -39,7 +39,7 @@ logger = logging.getLogger(__name__)
 # stored verdict: rulepack `advisory` semantics, a rule's verdict, the resolve()
 # precedence chain, or this recompute. Rows whose stored decision_version differs
 # are refreshed on read (see api/payload_helpers.upgrade_legacy_payload).
-DECISION_VERSION = "1.0.0"
+DECISION_VERSION = "2.1.0"
 
 _RULEPACKS_DIR = Path(__file__).parent / "rulepacks"
 

--- a/src/extension_shield/governance/rulepacks/CWS_LIMITED_USE.yaml
+++ b/src/extension_shield/governance/rulepacks/CWS_LIMITED_USE.yaml
@@ -30,9 +30,12 @@ rules:
       extraction.status == "ok" AND
       signals contains type="SENSITIVE_API" AND
       declared_data_categories is empty
-    verdict: "BLOCK"
+    # Disclosure/compliance gap, not proof of malicious behavior: a sensitive API
+    # with no declared data category is a review requirement, not a hard block.
+    # An independent BLOCK rule (e.g. R10 malware) still yields a BLOCK verdict.
+    verdict: "NEEDS_REVIEW"
     confidence: 0.85
-    recommended_action: "Block — Limited Use policy requires explicit PII declaration"
+    recommended_action: "Review — Limited Use policy requires explicit PII/data-category declaration"
     citations: ["CWS_LIMITED_USE::SECTION_2"]
     evidence_refs: []
 

--- a/src/extension_shield/llm/prompts/layer_details_generation.yaml
+++ b/src/extension_shield/llm/prompts/layer_details_generation.yaml
@@ -14,7 +14,7 @@ layer_details_generation: |
     | SAST, static analysis | "security scan" |
     | Obfuscation, minification, high entropy | "hidden or hard-to-read code" |
     | eval(), new Function(), dynamic execution | "runs code it creates" |
-    | Exfiltration, data leakage | "sends data to external servers" |
+    | Exfiltration, data leakage | "could send data to external servers" |
     | webRequest, webRequestBlocking | "can see/modify your web traffic" |
     | <all_urls>, *://*/* | "runs on all websites" |
     | cookies permission | "can read your cookies" |
@@ -28,7 +28,7 @@ layer_details_generation: |
     | XSS, CSRF, injection | "security vulnerabilities" |
     | API, endpoint | "external server connection" |
     | CRITICAL_SAST | "dangerous code patterns" |
-    | SENSITIVE_EXFIL | "may leak sensitive data" |
+    | SENSITIVE_EXFIL | "could send sensitive data externally (capability, not confirmed)" |
     | PURPOSE_MISMATCH | "doesn't match what it claims to do" |
     | VT_MALWARE | "flagged by antivirus" |
     | TOS_VIOLATION | "breaks store rules" |
@@ -57,7 +57,7 @@ layer_details_generation: |
     ✅ GOOD: "Can read your cookies, see your web traffic, and view your open tabs."
     
     ❌ BAD: "SENSITIVE_EXFIL gate triggered due to network requests to external domains"
-    ✅ GOOD: "May send your browsing data to external servers."
+    ✅ GOOD: "Requests permissions that could send your browsing data to external servers."
     
     ❌ BAD: "The manifest contains externally_connectable with broad host patterns"
     ✅ GOOD: "Can communicate with other extensions and websites."

--- a/src/extension_shield/llm/prompts/summary_generation.yaml
+++ b/src/extension_shield/llm/prompts/summary_generation.yaml
@@ -10,7 +10,7 @@ summary_rewrite: |
     PLAIN ENGLISH CONTRACT - Translate all technical terms:
     - "Obfuscation" / "entropy" → "hidden or hard-to-read code"
     - "SAST" / "static analysis" → "code check" or "security scan"
-    - "Exfiltration" → "sends your data out"
+    - "Exfiltration" → "could expose data externally"
     - "webRequest permission" → "can see your web traffic"
     - "<all_urls>" / "*://*/*" → "runs on all websites"
     - "Content scripts" → "code that runs on pages you visit"
@@ -82,7 +82,7 @@ consumer_summary_unified: |
     |-----------|----------|
     | Obfuscation, entropy | "hidden or hard-to-read code" |
     | SAST, static analysis | "our security scan" |
-    | Exfiltration | "sends your data out" |
+    | Exfiltration | "could expose data externally" |
     | webRequest | "can see your web traffic" |
     | <all_urls> | "runs on all websites" |
     | activeTab, scripting | "can access the page you're viewing" / "runs scripts on pages" |
@@ -132,7 +132,7 @@ summary_generation: |
     MANDATORY TRANSLATIONS (always use plain English):
     - "Obfuscation" → "hidden or hard-to-read code"
     - "SAST findings" → "security scan found issues"
-    - "Exfiltration" → "sends your data out"
+    - "Exfiltration" → "could expose data externally"
     - "webRequest" → "can see your web traffic"
     - "<all_urls>" → "runs on all websites"
     - "eval" → "runs code it creates"

--- a/src/extension_shield/scoring/explain.py
+++ b/src/extension_shield/scoring/explain.py
@@ -455,7 +455,7 @@ class ExplanationBuilder:
     
     GATE_PLAIN_NAMES = {
         "CRITICAL_SAST": "dangerous code patterns",
-        "SENSITIVE_EXFIL": "data being sent to external servers",
+        "SENSITIVE_EXFIL": "permissions that could send data externally",
         "PURPOSE_MISMATCH": "behavior not matching its stated purpose",
         "VT_MALWARE": "antivirus flags",
         "TOS_VIOLATION": "policy violations",

--- a/src/extension_shield/scoring/gates.py
+++ b/src/extension_shield/scoring/gates.py
@@ -293,6 +293,40 @@ def _pm_behavior_suffix(check_id: str) -> str:
     return (check_id or "").strip().lower().split(".")[-1]
 
 
+# Placeholder / non-evidential snippets seen on minified/bundled single-line
+# files. These must NOT, on their own, support a high-confidence BLOCK.
+_PM_PLACEHOLDER_SNIPPETS = frozenset({
+    "", "requires login", "<snippet>", "...", "n/a", "na", "none", "null",
+})
+
+
+def _pm_standalone_high_quality(finding: "SastFindingNormalized", corroborated: bool) -> bool:
+    """Whether a standalone-dangerous SAST behavior is backed by high-quality
+    evidence strong enough to hard-BLOCK.
+
+    BLOCK is allowed only when EITHER:
+      - there is corroborating concrete evidence (a suspicious external
+        destination, remote-code loading, or read-secret+exfil), OR
+      - the match itself is real file/line evidence: line_number > 1 with a
+        non-placeholder code snippet that supports the behavior.
+
+    A line-1 match in a minified/bundled file with a weak/placeholder snippet and
+    no corroboration is NOT high-quality -> the gate downgrades to WARN (review),
+    so the final result is NEEDS_REVIEW, not BLOCK.
+    """
+    if corroborated:
+        return True
+    line = getattr(finding, "line_number", None)
+    snippet = (getattr(finding, "code_snippet", None) or "").strip()
+    return (
+        isinstance(line, int)
+        and line > 1
+        and bool(snippet)
+        and snippet.lower() not in _PM_PLACEHOLDER_SNIPPETS
+        and len(snippet) >= 8
+    )
+
+
 # =============================================================================
 # HARD GATES CLASS
 # =============================================================================
@@ -907,7 +941,11 @@ class HardGates:
         key_capture: List[str] = []
         exfil: List[str] = []
         remote_code: List[str] = []
-        standalone_dangerous: List[str] = []
+        # Standalone-dangerous findings are collected with their finding object so
+        # their evidence quality can be checked before they are allowed to BLOCK.
+        standalone_findings: List[tuple] = []
+        standalone_dangerous: List[str] = []  # high-quality -> BLOCK
+        standalone_weak: List[str] = []       # weak/line-1/placeholder -> REVIEW
         benign_compat: List[str] = []
         credentialed_send: List[str] = []
         suspicious_external: List[str] = []
@@ -924,7 +962,7 @@ class HardGates:
             if suffix in _PM_SUSPICIOUS_EXTERNAL:
                 suspicious_external.append(suffix)
             if suffix in _PM_STANDALONE_DANGEROUS:
-                standalone_dangerous.append(suffix)
+                standalone_findings.append((suffix, finding))
             if suffix in _PM_REMOTE_CODE:
                 remote_code.append(suffix)
             elif suffix in _PM_SECRET_READ:
@@ -942,6 +980,18 @@ class HardGates:
         # conservative: ambiguous cases become REVIEW, never SAFE.
         if (secret_read or key_capture) and not exfil and (credentialed_send or suspicious_external):
             exfil.extend(sorted(set(credentialed_send + suspicious_external)))
+
+        # Evidence-quality guard: a standalone-dangerous behavior may hard-BLOCK
+        # only with high-quality evidence — a corroborating concrete signal, or a
+        # real file/line match (line > 1, non-placeholder snippet). A line-1
+        # minified match with a weak/placeholder snippet and no corroboration is
+        # downgraded to WARN so the final result is NEEDS_REVIEW, not BLOCK.
+        corroborated_concrete = bool(suspicious_external) or bool(remote_code) or bool(secret_read and exfil)
+        for suffix, finding in standalone_findings:
+            if _pm_standalone_high_quality(finding, corroborated_concrete):
+                standalone_dangerous.append(suffix)
+            else:
+                standalone_weak.append(suffix)
 
         # Concerning permission combinations on an extension that CLAIMS to be a
         # simple/benign utility (purpose vs capability mismatch).
@@ -973,6 +1023,13 @@ class HardGates:
         # Ambiguous cases become REVIEW, never SAFE.
         # ------------------------------------------------------------------
         review_reasons: List[str] = []
+        if standalone_weak:
+            review_reasons.append(
+                "Potential "
+                + ", ".join(sorted(set(standalone_weak)))
+                + " pattern in minified/bundled code (weak match) — review; not a "
+                "confirmed behavior without file/line or destination evidence"
+            )
         if secret_read and not exfil:
             review_reasons.append(
                 "Reads form/credential values — review whether it stays local"
@@ -1022,6 +1079,7 @@ class HardGates:
             + [f"mismatch:key_capture:{s}" for s in sorted(set(key_capture))]
             + [f"mismatch:exfil:{s}" for s in sorted(set(exfil))]
             + [f"mismatch:standalone:{s}" for s in sorted(set(standalone_dangerous))]
+            + [f"mismatch:standalone_weak:{s}" for s in sorted(set(standalone_weak))]
         )[:6]
         return GateResult(
             gate_id=gate_id,
@@ -1125,9 +1183,9 @@ class HardGates:
         if has_network or has_network_patterns:
             risk_factors += 1
             if has_network:
-                reasons.append("Can send data to external servers")
+                reasons.append("Requests permissions that could send data externally")
             if has_network_patterns:
-                reasons.append(f"Code contains patterns that send data externally")
+                reasons.append("Code contains patterns that could send data externally")
         
         if not has_privacy_policy:
             risk_factors += 1
@@ -1135,6 +1193,13 @@ class HardGates:
         
         # WARN if 2+ risk factors (sensitive + network + no privacy)
         if risk_factors >= 2:
+            # This gate is a capability/disclosure warning, not proof of
+            # exfiltration. Make that explicit so the finding is not read as a
+            # confirmed data-theft behavior.
+            reasons.append(
+                "Capability warning; not confirmed exfiltration unless source/destination "
+                "evidence is shown"
+            )
             return GateResult(
                 gate_id=gate_id,
                 decision="WARN",

--- a/tests/governance/test_cws_limited_use_r2_review.py
+++ b/tests/governance/test_cws_limited_use_r2_review.py
@@ -1,0 +1,80 @@
+"""CWS_LIMITED_USE calibration (audit follow-up).
+
+A sensitive API with no declared data category is a disclosure/compliance
+*review* gap (R2), not proof of malicious behavior -> NEEDS_REVIEW, not BLOCK.
+Real malware (R10) must still BLOCK, and an independent BLOCK rule firing
+alongside the R2 review gap must still yield a BLOCK verdict.
+"""
+
+from pathlib import Path
+
+from extension_shield.governance.rules_engine import RulesEngine
+
+RULEPACKS_DIR = (
+    Path(__file__).parent.parent.parent
+    / "src" / "extension_shield" / "governance" / "rulepacks"
+)
+
+
+def _rulepacks():
+    rulepacks, errors = RulesEngine.load_rulepacks_with_report(str(RULEPACKS_DIR))
+    assert errors == [], f"rulepack validation errors: {errors}"
+    return rulepacks
+
+
+def _engine():
+    return RulesEngine(_rulepacks())
+
+
+def _verdict_for(results, rule_id):
+    for r in results.rule_results:
+        if r.rule_id == rule_id:
+            return r.verdict
+    return None
+
+
+def _eval(engine, facts, signals, store_listing):
+    return engine.evaluate(
+        scan_id="t", facts=facts, signals=signals,
+        store_listing=store_listing, context={"rulepacks": ["CWS_LIMITED_USE"]},
+    )
+
+
+def test_r2_definition_is_needs_review_and_r10_stays_block():
+    rp = next(rp for rp in _rulepacks() if rp.get("rulepack_id") == "CWS_LIMITED_USE")
+    by_id = {r["rule_id"]: r for r in rp["rules"]}
+    assert by_id["CWS_LIMITED_USE::R2"]["verdict"] == "NEEDS_REVIEW"
+    assert by_id["CWS_LIMITED_USE::R10"]["verdict"] == "BLOCK"
+
+
+def test_r2_sensitive_api_without_declaration_reviews_not_blocks():
+    results = _eval(
+        _engine(),
+        facts={},
+        signals=[{"type": "SENSITIVE_API", "evidence_refs": [], "confidence": 0.9, "severity": "high"}],
+        store_listing={"extraction": {"status": "ok"}, "declared_data_categories": []},
+    )
+    assert _verdict_for(results, "CWS_LIMITED_USE::R2") == "NEEDS_REVIEW"
+
+
+def test_r10_real_malware_still_blocks():
+    results = _eval(
+        _engine(),
+        facts={"security_findings": {"virustotal_threat_level": "malicious", "virustotal_malicious_count": 8}},
+        signals=[],
+        store_listing={"extraction": {"status": "ok"}},
+    )
+    assert _verdict_for(results, "CWS_LIMITED_USE::R10") == "BLOCK"
+
+
+def test_disclosure_gap_plus_malware_still_has_block_verdict():
+    # Part 1.3: an independent BLOCK rule (R10) firing alongside the R2 review gap
+    # must still surface a BLOCK verdict; R2 itself stays NEEDS_REVIEW.
+    results = _eval(
+        _engine(),
+        facts={"security_findings": {"virustotal_threat_level": "malicious", "virustotal_malicious_count": 8}},
+        signals=[{"type": "SENSITIVE_API", "evidence_refs": [], "confidence": 0.9, "severity": "high"}],
+        store_listing={"extraction": {"status": "ok"}, "declared_data_categories": []},
+    )
+    assert "BLOCK" in [r.verdict for r in results.rule_results]
+    assert _verdict_for(results, "CWS_LIMITED_USE::R2") == "NEEDS_REVIEW"

--- a/tests/llm/test_summary_prompt_wording.py
+++ b/tests/llm/test_summary_prompt_wording.py
@@ -1,0 +1,47 @@
+"""Wording guard for the active summary-generation prompts.
+
+Ensures capability-only exfiltration signals are described as a *possibility*
+("could expose data externally") and never regress to confirmed-exfiltration
+phrasing like "sends your data out". Wording-only; asserts nothing about
+scoring, gates, or verdicts.
+"""
+
+from extension_shield.llm.prompts import get_prompts
+
+# The three active user-facing summary prompts that carry the plain-English
+# translation table for the "Exfiltration" concept.
+SUMMARY_PROMPT_KEYS = ("summary_rewrite", "consumer_summary_unified", "summary_generation")
+
+# Confirmed-exfiltration phrasings that must not appear in these prompts.
+FORBIDDEN_PHRASES = ("sends your data out", "may leak", "send sensitive data")
+
+
+def _load_summary_prompts() -> dict:
+    return get_prompts("summary_generation")
+
+
+def test_summary_prompts_present():
+    prompts = _load_summary_prompts()
+    for key in SUMMARY_PROMPT_KEYS:
+        assert key in prompts, f"missing summary prompt: {key}"
+
+
+def test_no_confirmed_exfiltration_wording():
+    """Active summary prompts must not assert confirmed exfiltration."""
+    prompts = _load_summary_prompts()
+    for key in SUMMARY_PROMPT_KEYS:
+        text = prompts[key].lower()
+        for phrase in FORBIDDEN_PHRASES:
+            assert phrase not in text, f"{key} still contains confirmed-exfiltration phrasing: {phrase!r}"
+
+
+def test_exfiltration_uses_capability_wording():
+    """The Exfiltration translation stays capability/uncertainty language."""
+    prompts = _load_summary_prompts()
+    for key in SUMMARY_PROMPT_KEYS:
+        text = prompts[key]
+        # The concept must still be present (do not remove the data-transfer idea).
+        assert "Exfiltration" in text, f"{key} dropped the Exfiltration concept"
+        assert "could expose data externally" in text, (
+            f"{key} lost capability-only exfiltration wording"
+        )

--- a/tests/scoring/test_sensitive_exfil_wording.py
+++ b/tests/scoring/test_sensitive_exfil_wording.py
@@ -1,0 +1,30 @@
+"""SENSITIVE_EXFIL wording calibration (audit follow-up).
+
+The gate fires on a capability + disclosure combination (sensitive permission +
+network capability + no privacy policy) with no destination evidence. Its wording
+must present it as a capability warning, not confirmed exfiltration, and it must
+stay WARN (never BLOCK on capability alone).
+"""
+
+from extension_shield.governance.signal_pack import (
+    PermissionsSignalPack,
+    SastSignalPack,
+    WebstoreStatsSignalPack,
+)
+from extension_shield.scoring.gates import HardGates
+
+
+def test_sensitive_exfil_uses_capability_wording_not_confirmed_exfil():
+    gates = HardGates()
+    perms = PermissionsSignalPack(api_permissions=["cookies"], has_broad_host_access=True)
+    sast = SastSignalPack(deduped_findings=[], files_scanned=1, confidence=0.9)
+    webstore = WebstoreStatsSignalPack(has_privacy_policy=False)
+
+    r = gates.evaluate_sensitive_exfil(perms, sast, webstore)
+
+    assert r.decision == "WARN"  # capability only -> review, never BLOCK
+    text = " ".join(r.reasons).lower()
+    assert "could send data externally" in text
+    assert "not confirmed exfiltration" in text
+    # Must not claim confirmed exfiltration.
+    assert "sends your data to external servers" not in text

--- a/tests/test_purpose_mismatch_calibration.py
+++ b/tests/test_purpose_mismatch_calibration.py
@@ -101,8 +101,44 @@ def test_remote_code_loading_blocks():
     assert r.decision == "BLOCK"          # Indian Visa case (also has secret+exfil)
 
 
-def test_standalone_clipboard_hijack_blocks():
+def _pm_findings(findings, api_permissions=None, name="Tool", description="A helper", broad=False):
+    gates = HardGates()
+    sast = SastSignalPack(deduped_findings=findings, files_scanned=1, confidence=0.9)
+    perms = PermissionsSignalPack(api_permissions=api_permissions or [], has_broad_host_access=broad)
+    return gates.evaluate_purpose_mismatch(
+        {"name": name, "description": description}, sast, perms
+    )
+
+
+def test_standalone_weak_line1_placeholder_does_not_block():
+    # Evidence-quality guard: a standalone-dangerous rule that matched at line 1 in
+    # a minified file with a placeholder snippet ("requires login") and no
+    # corroboration is a weak match -> REVIEW, not BLOCK (Save to Pinterest case).
     r = _pm(["src.extension_shield.config.credential.theft.clipboard_hijack"])
+    assert r.decision == "WARN"
+    r2 = _pm(["src.extension_shield.config.cookie.theft.cookie_exfiltration"])
+    assert r2.decision == "WARN"
+
+
+def test_standalone_high_quality_evidence_blocks():
+    # Real file/line evidence (line > 1, non-placeholder snippet) still BLOCKs.
+    hq = SastFindingNormalized(
+        check_id="src.extension_shield.config.credential.theft.clipboard_hijack",
+        file_path="content.js", line_number=42, severity="ERROR",
+        message="Reads clipboard and replaces wallet address",
+        code_snippet="navigator.clipboard.readText().then(t=>replaceAddr(t))",
+    )
+    r = _pm_findings([hq])
+    assert r.decision == "BLOCK"
+
+
+def test_standalone_weak_but_corroborated_by_suspicious_domain_blocks():
+    # A weak standalone match corroborated by a concrete suspicious external
+    # destination still BLOCKs.
+    r = _pm([
+        "src.extension_shield.config.cookie.theft.cookie_exfiltration",
+        "src.extension_shield.config.c2.communication.random_domain_pattern",
+    ])
     assert r.decision == "BLOCK"
 
 


### PR DESCRIPTION
## Summary
This PR makes the scan report more evidence-based and less confusing.

Changes:
- Links Key Findings to existing evidence where available.
- Adds path-safe evidence labels without exposing local filesystem paths.
- Redesigns the Security, Privacy, and Governance detail modals.
- Adds Evidence & Technical Details tabs for permissions, manifest, code, network, VirusTotal, governance, and coverage.
- Folds the old standalone Analyzer Coverage card into the Coverage tab.
- Shows analyzers that did not run, like VirusTotal 0 engines or SAST 0 files, as `Not Analyzed` instead of `Cleared`.
- Keeps capability-only exfil/network wording as uncertainty, not confirmed theft.
- Calibrates governance display so weak/disclosure-only findings do not look stronger than the evidence supports.

## Not changed
- No scoring weights changed.
- No analyzer changes.
- No API payload shape changes.
- No backend risk flooring changes.
- No publisher-specific whitelist.
- `VT_MALWARE` behavior is unchanged.
- `scoring_version` remains `2.1.0`.

## Checks
- Frontend tests passed.
- Report UI tests passed.
- Frontend lint/build passed.
- Backend scoring/governance tests passed.
- Key report states were checked against local SQLite scans.
