### PR TITLE
report: add report domains and verdict authority labels

### DIFF
--- a/frontend/src/components/report/EvidenceTechnicalDetails.jsx
+++ b/frontend/src/components/report/EvidenceTechnicalDetails.jsx
@@ -34,7 +34,7 @@ const ANALYZER_ICON = {
 
 const LOCAL_PATH_RE = /(?:\/Users\/|\/home\/|\b[A-Za-z]:\/(?!\/)|extensions_storage\/|extracted_[^/\s]+\/)\S+/g;
 const HIGH_RISK_PERMISSIONS = new Set(['cookies', 'debugger', 'downloads', 'history', 'management', 'nativeMessaging', 'proxy', 'webRequest', 'webRequestBlocking']);
-const MEDIUM_RISK_PERMISSIONS = new Set(['tabs', 'webNavigation', 'activeTab', 'scripting', 'clipboardRead', 'clipboardWrite', 'identity']);
+const MEDIUM_RISK_PERMISSIONS = new Set(['tabs', 'webNavigation', 'activeTab', 'scripting', 'clipboardRead', 'clipboardWrite', 'identity', 'tabCapture', 'desktopCapture']);
 
 function asArray(value) {
   if (!value) return [];
@@ -87,7 +87,11 @@ function formatDate(iso) {
 }
 
 function permissionExplanation(name, type) {
-  if (type === 'Host') return 'Allows access to pages matching this host pattern.';
+  if (type === 'Host') {
+    return String(name).includes('<all_urls>') || String(name).includes('*://*/*')
+      ? 'Allows access to all matching web pages. This broad capability increases review scope, but is not proof of misuse.'
+      : 'Allows access to pages matching this host pattern.';
+  }
   const lower = String(name).toLowerCase();
   const explanations = {
     tabs: 'Read browser tab metadata and interact with tab state.',
@@ -98,6 +102,9 @@ function permissionExplanation(name, type) {
     webrequestblocking: 'Block or modify network requests.',
     scripting: 'Inject scripts into allowed pages.',
     activetab: 'Access the active tab after user interaction.',
+    tabcapture: 'Capture audio or video from a browser tab when the extension invokes the capture flow.',
+    desktopcapture: 'Request capture of a screen, window, or tab through Chrome’s desktop capture flow.',
+    debugger: 'Attach to a browser target through the DevTools protocol. Powerful capability; review whether it matches the extension purpose.',
     history: 'Read browsing history.',
     downloads: 'Manage browser downloads.',
   };
@@ -241,7 +248,7 @@ function extractNetworkRows(raw, viewModel) {
         target: cleanText(host),
         kind: 'Capability',
         status: 'Declared access',
-        evidence: 'Host permission; not proof of network exfiltration.',
+        evidence: 'Host permission capability; not proof of network exfiltration.',
       });
     });
   }
@@ -334,14 +341,16 @@ function EvidenceTechnicalDetails({ rawScanResult, viewModel }) {
   const data = useMemo(() => {
     const raw = rawScanResult || {};
     const vm = viewModel || {};
+    const coverage = resolveAnalyzerCoverage(raw);
     return {
       permissions: buildPermissionsRows(vm),
       manifest: buildManifestRows(raw),
       code: extractSastRows(raw, vm),
+      codeStatus: coverage.find((row) => row.key === 'sast') || null,
       network: extractNetworkRows(raw, vm),
       virustotal: extractVirusTotalRows(raw),
       governance: extractGovernanceRows(raw),
-      coverage: resolveAnalyzerCoverage(raw),
+      coverage,
     };
   }, [rawScanResult, viewModel]);
   const counts = buildCounts(data);
@@ -377,7 +386,7 @@ function EvidenceTechnicalDetails({ rawScanResult, viewModel }) {
       <div className="etd-panel" id={`etd-panel-${activeTab}`} role="tabpanel" aria-labelledby={`etd-tab-${activeTab}`}>
         {activeTab === 'permissions' && <PermissionsPanel rows={data.permissions} />}
         {activeTab === 'manifest' && <ManifestPanel rows={data.manifest} />}
-        {activeTab === 'code' && <CodePanel rows={data.code} />}
+        {activeTab === 'code' && <CodePanel rows={data.code} status={data.codeStatus} />}
         {activeTab === 'network' && <NetworkPanel rows={data.network} />}
         {activeTab === 'virustotal' && <VirusTotalPanel summary={data.virustotal.summary} rows={data.virustotal.rows} />}
         {activeTab === 'governance' && <GovernancePanel rows={data.governance} />}
@@ -422,8 +431,20 @@ function ManifestPanel({ rows }) {
   );
 }
 
-function CodePanel({ rows }) {
-  if (!rows.length) return <EmptyState>No SAST findings or code evidence were included in the scan payload.</EmptyState>;
+function CodePanel({ rows, status }) {
+  if (!rows.length) {
+    let message = 'No SAST findings or code evidence were included in the scan payload.';
+    if (status?.state === 'failed') {
+      message = 'Code/SAST did not complete. No SAST findings are available from this scan.';
+    } else if (status?.state === 'no_code_scanned') {
+      message = 'Code/SAST analyzed 0 files. The extension code was not statically analyzed; this is not a clean result.';
+    } else if (status?.state === 'not_run') {
+      message = 'Code/SAST did not run for this scan. No code evidence is available.';
+    } else if (status?.state === 'scanned' || status?.state === 'full') {
+      message = 'Code/SAST ran and reported no code findings in the scan payload.';
+    }
+    return <EmptyState>{message}</EmptyState>;
+  }
   return (
     <div className="etd-list">
       {rows.map((row) => (

--- a/frontend/src/components/report/EvidenceTechnicalDetails.test.jsx
+++ b/frontend/src/components/report/EvidenceTechnicalDetails.test.jsx
@@ -109,6 +109,29 @@ describe('EvidenceTechnicalDetails', () => {
     expect(within(panel).getByText('Host')).toBeInTheDocument();
   });
 
+  it('explains broad host, debugger, and capture permissions as capabilities without claiming abuse', () => {
+    renderDetails(
+      {
+        manifest: { permissions: ['debugger', 'tabCapture', 'desktopCapture'], host_permissions: ['*://*/*'] },
+      },
+      {
+        permissions: {
+          apiPermissions: ['debugger', 'tabCapture', 'desktopCapture'],
+          hostPermissions: ['*://*/*'],
+          highRiskPermissions: ['debugger'],
+          broadHostPatterns: ['*://*/*'],
+        },
+        evidenceIndex: {},
+      }
+    );
+
+    const panel = screen.getByRole('tabpanel');
+    expect(within(panel).getByText(/DevTools protocol/i)).toBeInTheDocument();
+    expect(within(panel).getByText(/Capture audio or video from a browser tab/i)).toBeInTheDocument();
+    expect(within(panel).getByText(/Request capture of a screen, window, or tab/i)).toBeInTheDocument();
+    expect(within(panel).getByText(/capability increases review scope, but is not proof of misuse/i)).toBeInTheDocument();
+  });
+
   it('renders manifest, CSP, host, and content script fields', () => {
     renderDetails();
     clickTab(/Manifest/);
@@ -127,6 +150,19 @@ describe('EvidenceTechnicalDetails', () => {
     expect(screen.getByText('eval(userInput);')).toBeInTheDocument();
     expect(container.textContent).not.toContain('/Users/');
     expect(container.textContent).not.toContain('extensions_storage');
+  });
+
+  it('shows failed/not-analyzed Code/SAST status when no SAST findings are present', () => {
+    renderDetails(
+      {
+        timestamp: '2026-07-08T12:00:00Z',
+        sast_results: { scan_error: true, files_scanned: 0, sast_findings: {} },
+      },
+      { permissions: {}, evidenceIndex: {} }
+    );
+    clickTab(/Code\/SAST/);
+    expect(screen.getByText(/Code\/SAST did not complete/i)).toBeInTheDocument();
+    expect(screen.queryByText(/code is clean/i)).toBeNull();
   });
 
   it('renders VirusTotal coverage, counts, hash, and file details', () => {

--- a/frontend/src/components/report/LayerModal.jsx
+++ b/frontend/src/components/report/LayerModal.jsx
@@ -8,8 +8,14 @@ import {
   DialogTitle,
 } from '../ui/dialog';
 import { AlertTriangle, Check, ChevronDown, HelpCircle, Info, Landmark, Lock, Shield } from 'lucide-react';
-import { buildLayerModalModel } from './layerFactors';
+import { buildLayerModalModel, REPORT_DOMAIN, REPORT_DOMAINS } from './layerFactors';
 import './LayerModal.scss';
+
+// Advisory caption shown once per layer when a reputation/maintenance-context
+// factor (Store Reputation, Threat Intel, Publisher update age) is present, so
+// these context signals are not read as standalone security verdicts.
+const REPUTATION_CONTEXT_NOTE =
+  REPORT_DOMAINS.find((d) => d.id === REPORT_DOMAIN.REPUTATION_MAINTENANCE)?.note || '';
 
 // Short, sentence-case tags used as a secondary caption on flagged/uncovered rows.
 const CATEGORY_TAG = {
@@ -159,7 +165,9 @@ const PrimaryCheckRow = ({ item, index, expanded, onToggle }) => {
           {item.title || item.label}
           {item.description && <InfoTooltip text={item.description} />}
         </span>
-        {CATEGORY_TAG[item.category] ? (
+        {item.domainLabel ? (
+          <span className="lm-check-tag lm-check-tag--domain" data-domain={item.domain}>{item.domainLabel}</span>
+        ) : CATEGORY_TAG[item.category] ? (
           <span className="lm-check-tag">{CATEGORY_TAG[item.category]}</span>
         ) : item.source ? (
           <span className="lm-check-tag">{item.source}</span>
@@ -228,6 +236,11 @@ const LayerModal = ({
     [factors, keyFindings, gateResults, layerReasons]
   );
   const hasChecks = all.length > 0;
+  // Reputation/maintenance factors (e.g. Store Reputation, Publisher update age)
+  // are scored inside the Security layer but are trust CONTEXT, not standalone
+  // security evidence. Surface the disclaimer once when any are present.
+  const hasReputationContext = [...issues, ...notAnalyzed, ...cleared]
+    .some((row) => row.domain === REPORT_DOMAIN.REPUTATION_MAINTENANCE);
   const tabs = [
     { key: 'issues', label: 'Open Issues', count: issues.length },
     { key: 'cleared', label: 'Cleared', count: cleared.length },
@@ -295,6 +308,10 @@ const LayerModal = ({
               </button>
             ))}
           </div>
+
+          {hasReputationContext && REPUTATION_CONTEXT_NOTE && (
+            <p className="lm-reputation-note">{REPUTATION_CONTEXT_NOTE}</p>
+          )}
 
           {activeTab === 'issues' && (
             <section className="lm-tier lm-tier--issues" id="lm-panel-issues" role="tabpanel" aria-label="Open issues">

--- a/frontend/src/components/report/LayerModal.scss
+++ b/frontend/src/components/report/LayerModal.scss
@@ -361,6 +361,26 @@
   text-transform: uppercase;
 }
 
+// Report-domain chip (Technical Security / Privacy & Data / Governance / Policy
+// / Reputation / Coverage). Slightly stronger than the plain category tag so the
+// concept-first grouping reads clearly on each factor row.
+.lm-check-tag--domain {
+  color: var(--theme-text-secondary);
+  background: var(--theme-bg-secondary);
+}
+
+// Reputation/maintenance disclaimer shown once per layer when a reputation
+// factor (Store Reputation, Threat Intel, Publisher update age) is present.
+.lm-reputation-note {
+  margin: 8px 0 0;
+  padding: 6px 10px;
+  font-size: 0.72rem;
+  line-height: 1.35;
+  color: var(--theme-text-muted);
+  background: var(--theme-bg-tertiary);
+  border-radius: 6px;
+}
+
 .lm-check-evidence {
   display: block;
   min-width: 0;

--- a/frontend/src/components/report/LayerModal.test.jsx
+++ b/frontend/src/components/report/LayerModal.test.jsx
@@ -356,4 +356,31 @@ describe('LayerModal rendering', () => {
     expect(document.body.textContent).toContain('background.js:12');
     expect(document.body.textContent).not.toMatch(/\/Users|\/home|extensions_storage|extracted_/);
   });
+
+  it('tags each factor with its report domain and shows the reputation context note', () => {
+    // A Security-layer modal that mixes a technical factor and a reputation
+    // factor: both are scored in Security, but they must read as different
+    // report domains, and the reputation disclaimer must appear.
+    renderModal({
+      factors: [
+        { name: 'Webstore', severity: 0.5, details: { rating_avg: 2.1 } },
+        { name: 'SAST', severity: 0.5 },
+      ],
+      keyFindings: [],
+    });
+
+    // Domain chips (kept distinct from the "Security" layer title).
+    expect(screen.getByText('Reputation')).toBeInTheDocument();
+    expect(screen.getByText('Technical Security')).toBeInTheDocument();
+    // Reputation/maintenance disclaimer.
+    expect(
+      screen.getByText('Context signal — informs confidence, not a standalone verdict.')
+    ).toBeInTheDocument();
+  });
+
+  it('does not show the reputation context note when no reputation factor is present', () => {
+    // Default fixture: Manifest / SAST / VirusTotal / NetworkExfil — no reputation.
+    renderModal();
+    expect(screen.queryByText(/Context signal — informs confidence/)).toBeNull();
+  });
 });

--- a/frontend/src/components/report/LayerModal.test.jsx
+++ b/frontend/src/components/report/LayerModal.test.jsx
@@ -125,7 +125,7 @@ describe('LayerModal triage ordering', () => {
 
   it('separates the three tiers correctly', () => {
     const { issues, notAnalyzed, cleared } = triageFactors(factors);
-    expect(issues.map((i) => i.label)).toEqual(['Policy Violations', 'Screen Capture']); // severe first
+    expect(issues.map((i) => i.label)).toEqual(['Potential Policy Issue', 'Screen Capture']); // severe first
     expect(notAnalyzed.map((i) => i.label)).toEqual(['Data Sharing']);
     expect(cleared.map((i) => i.label)).toEqual(['Code Safety', 'Store Reputation']); // alphabetical
   });
@@ -156,6 +156,13 @@ describe('factorEvidenceCaption', () => {
       .toBe('Last updated 508 days ago');
     expect(factorEvidenceCaption({ name: 'Maintenance', details: { days_since_update: 1 } }))
       .toBe('Last updated 1 day ago');
+  });
+
+  it('renders permission combo evidence with the actual combination', () => {
+    expect(factorEvidenceCaption({
+      name: 'PermissionCombos',
+      details: { triggered_combos: ['debugger+tabs', 'broad_host_access'] },
+    })).toBe('Combination: debugger + tabs, broad host access');
   });
 
   it('renders a relative file:line reference and never a local absolute path', () => {

--- a/frontend/src/components/report/SummaryPanel.jsx
+++ b/frontend/src/components/report/SummaryPanel.jsx
@@ -351,7 +351,7 @@ const SummaryPanel = ({
                 </p>
               )}
               {finding.evidence && finding.evidence.available === false && (
-                <p className="summary-finding-evidence-ref summary-finding-evidence-ref--none">Evidence: summary only</p>
+                <p className="summary-finding-evidence-ref summary-finding-evidence-ref--none">Based on summary only</p>
               )}
               {typeof onViewEvidence === 'function' && finding.evidenceIds.length > 0 && (
                 <button

--- a/frontend/src/components/report/SummaryPanel.jsx
+++ b/frontend/src/components/report/SummaryPanel.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import './SummaryPanel.scss';
 import { normalizeHighlights, resolveCoverage, resolveProvenance, resolveAnalyzerStatus } from '../../utils/normalizeScanResult';
+import { resolveDecisionAuthorityDisplay, POLICY_DECISION_LABEL } from '../../utils/reportDisplay';
 
 /**
  * SummaryPanel – consumer-friendly scan summary.
@@ -36,6 +37,22 @@ const SummaryPanel = ({
   const decisionAuthority = typeof scores?.decisionAuthority === 'string' && scores.decisionAuthority.trim()
     ? scores.decisionAuthority
     : null;
+
+  // "Why this verdict" authority element: state WHICH authority in the backend
+  // Decision Authority chain produced the verdict (governance rule / hard gate /
+  // limited coverage / score), derived from data the payload already carries.
+  // A reputation/maintenance signal is never an authority in the chain, so it
+  // can never surface here as the decision basis.
+  const authorityScoringV2 = rawScanResult?.scoring_v2 || rawScanResult?.governance_bundle?.scoring_v2 || {};
+  const authorityGovFinding = (keyFindings || []).find(
+    (f) => f?.evidence?.kind === 'governance' && (f.evidence.ruleId || f.evidence.rulepack)
+  );
+  const authorityDisplay = resolveDecisionAuthorityDisplay(decisionAuthority, {
+    coverageCapApplied: Boolean(authorityScoringV2.coverage_cap_applied),
+    rulepack: authorityGovFinding?.evidence?.rulepack || null,
+    ruleId: authorityGovFinding?.evidence?.ruleId || null,
+    gate: Array.isArray(authorityScoringV2.hard_gates_triggered) ? authorityScoringV2.hard_gates_triggered[0] : null,
+  });
 
   // SAST/engine keyFindings – use for Quick Summary concerns when they add value
   const engineConcerns = (keyFindings || [])
@@ -134,13 +151,6 @@ const SummaryPanel = ({
       tone: 'neutral',
       detail: 'Not enough structured data is available to confidently classify this extension yet.',
     };
-  };
-
-  const formatDecisionAuthority = (authority) => {
-    if (!authority) return null;
-    return authority
-      .replace(/_/g, ' ')
-      .replace(/\b\w/g, (ch) => ch.toUpperCase());
   };
 
   const riskHeadline = getRiskHeadline();
@@ -311,8 +321,19 @@ const SummaryPanel = ({
             </ul>
           </div>
         )}
-        {decisionAuthority && (
-          <p className="summary-why-authority">Decision basis: {formatDecisionAuthority(decisionAuthority)}</p>
+        {authorityDisplay && (
+          authorityDisplay.description ? (
+            <p className="summary-why-authority" data-authority={authorityDisplay.authority}>
+              {authorityDisplay.isPolicyDecision && (
+                <strong className="summary-why-authority-tag">{POLICY_DECISION_LABEL}: </strong>
+              )}
+              {authorityDisplay.description}
+            </p>
+          ) : (
+            <p className="summary-why-authority" data-authority={authorityDisplay.authority}>
+              Decision basis: {authorityDisplay.fallbackLabel}
+            </p>
+          )
         )}
       </details>
     );

--- a/frontend/src/components/report/SummaryPanel.scss
+++ b/frontend/src/components/report/SummaryPanel.scss
@@ -250,6 +250,13 @@
     color: var(--theme-text-muted);
   }
 
+  // "Policy decision:" tag — keeps the governance rulepack outcome visibly
+  // distinct from the numeric governance score.
+  .summary-why-authority-tag {
+    font-weight: 800;
+    color: var(--theme-text-secondary);
+  }
+
   // Explicit analyzer coverage (SAST / VirusTotal / network) — readable contrast.
   .summary-analyzers {
     margin: 8px 0;

--- a/frontend/src/components/report/SummaryPanel.test.jsx
+++ b/frontend/src/components/report/SummaryPanel.test.jsx
@@ -108,6 +108,30 @@ describe('SummaryPanel', () => {
     expect(screen.queryByText('High Risk')).toBeNull();
   });
 
+  it('renders summary-only finding evidence without placeholder wording', () => {
+    render(
+      <SummaryPanel
+        scores={{
+          overall: { score: 57, band: 'WARN', confidence: 0.7 },
+          decision: 'WARN',
+        }}
+        rawScanResult={{ scoring_v2: { decision: 'NEEDS_REVIEW', overall_score: 57 } }}
+        topFindings={[
+          {
+            title: 'Policy Review',
+            summary: 'Potential policy issue needs review.',
+            severity: 'medium',
+            evidenceIds: [],
+            evidence: { available: false, kind: 'summary' },
+          },
+        ]}
+      />
+    );
+
+    expect(screen.getByText('Based on summary only')).toBeInTheDocument();
+    expect(screen.queryByText(/Evidence: summary only/i)).toBeNull();
+  });
+
   it('UX calibration: a high-score REVIEW shows a plain evidence-backed bridge, not a failure', () => {
     render(
       <SummaryPanel

--- a/frontend/src/components/report/SummaryPanel.test.jsx
+++ b/frontend/src/components/report/SummaryPanel.test.jsx
@@ -157,4 +157,59 @@ describe('SummaryPanel', () => {
     // Not harsh block language on a review.
     expect(screen.queryByText(/do not install/i)).toBeNull();
   });
+
+  it('explains a governance rulepack verdict as a Policy decision, distinct from the score', () => {
+    render(
+      <SummaryPanel
+        scores={{
+          overall: { score: 65, band: 'WARN', confidence: 0.78 },
+          decision: 'BLOCK',
+          decisionAuthority: 'baseline_governance',
+          reasons: ['Block — Limited Use policy requires explicit PII declaration'],
+        }}
+        rawScanResult={{
+          scoring_v2: { decision: 'BLOCK', overall_score: 65 },
+          governance_bundle: {
+            decision: { final_reasons: ['Block — Limited Use policy requires explicit PII declaration'] },
+          },
+        }}
+        keyFindings={[
+          {
+            title: 'Limited Use policy',
+            severity: 'high',
+            layer: 'governance',
+            evidence: { kind: 'governance', rulepack: 'CWS_LIMITED_USE', ruleId: 'R2' },
+          },
+        ]}
+      />
+    );
+
+    // The verdict basis is surfaced as a governance policy review with its rule id...
+    expect(
+      screen.getByText(/Decided by Chrome Web Store policy review \(governance rule CWS_LIMITED_USE::R2\)\./i)
+    ).toBeInTheDocument();
+    // ...and tagged a "Policy decision" so it reads as separate from the numeric score.
+    expect(screen.getByText(/Policy decision:/i)).toBeInTheDocument();
+  });
+
+  it('names the hard gate that drove the verdict, and does not tag it a Policy decision', () => {
+    render(
+      <SummaryPanel
+        scores={{
+          overall: { score: 85, band: 'WARN', confidence: 0.8 },
+          decision: 'BLOCK',
+          decisionAuthority: 'hard_gate',
+          reasons: ['Loads and runs code from a remote/external source'],
+        }}
+        rawScanResult={{
+          scoring_v2: { decision: 'BLOCK', overall_score: 85, hard_gates_triggered: ['PURPOSE_MISMATCH'] },
+        }}
+      />
+    );
+
+    expect(
+      screen.getByText(/Decided by a hard security\/privacy gate \(PURPOSE_MISMATCH\)\./i)
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/Policy decision:/i)).toBeNull();
+  });
 });

--- a/frontend/src/components/report/layerFactors.domain.test.js
+++ b/frontend/src/components/report/layerFactors.domain.test.js
@@ -1,0 +1,118 @@
+/**
+ * Report domain classification tests (presentation-only reclassification).
+ *
+ * Verifies the concept-first grouping used by the report: reputation/maintenance
+ * signals (Webstore, ChromeStats, Publisher update age) are presented under
+ * "Reputation & Maintenance Context" even though they are scored inside the
+ * Security layer. Pure logic — no score is read or changed here.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  REPORT_DOMAIN,
+  REPORT_DOMAINS,
+  domainForFactor,
+  groupFactorsByDomain,
+  humanizeFactor,
+} from './layerFactors';
+
+describe('domainForFactor', () => {
+  it('maps technical-security factors (code/malware/manifest) to Technical Security', () => {
+    ['SAST', 'VirusTotal', 'Obfuscation', 'Manifest'].forEach((name) => {
+      expect(domainForFactor(name).id).toBe(REPORT_DOMAIN.TECHNICAL_SECURITY);
+    });
+  });
+
+  it('maps permission/capture/network factors to Privacy & Data Access', () => {
+    ['PermissionsBaseline', 'PermissionCombos', 'NetworkExfil', 'CaptureSignals'].forEach((name) => {
+      expect(domainForFactor(name).id).toBe(REPORT_DOMAIN.PRIVACY_DATA_ACCESS);
+    });
+  });
+
+  it('maps policy factors to Governance / Policy / Disclosure', () => {
+    ['ToSViolations', 'Consistency', 'DisclosureAlignment'].forEach((name) => {
+      expect(domainForFactor(name).id).toBe(REPORT_DOMAIN.GOVERNANCE_POLICY);
+    });
+  });
+
+  it('maps Webstore, ChromeStats, and Maintenance to Reputation & Maintenance Context', () => {
+    ['Webstore', 'ChromeStats', 'Maintenance'].forEach((name) => {
+      expect(domainForFactor(name).id).toBe(REPORT_DOMAIN.REPUTATION_MAINTENANCE);
+    });
+  });
+
+  it('overrides category for ChromeStats: threat-intel is reputation CONTEXT, not Technical Security', () => {
+    // VirusTotal and ChromeStats share the FACTOR_HUMAN category 'threat', but
+    // only VirusTotal is technical malware evidence.
+    expect(domainForFactor('VirusTotal').id).toBe(REPORT_DOMAIN.TECHNICAL_SECURITY);
+    expect(domainForFactor('ChromeStats').id).toBe(REPORT_DOMAIN.REPUTATION_MAINTENANCE);
+  });
+
+  it('accepts either a factor object or a bare name', () => {
+    expect(domainForFactor({ name: 'Maintenance', severity: 0.6 }).id).toBe(REPORT_DOMAIN.REPUTATION_MAINTENANCE);
+    expect(domainForFactor('Maintenance').id).toBe(REPORT_DOMAIN.REPUTATION_MAINTENANCE);
+  });
+
+  it('falls back to Technical Security for an unknown factor', () => {
+    expect(domainForFactor('SomethingNew').id).toBe(REPORT_DOMAIN.TECHNICAL_SECURITY);
+    expect(domainForFactor(undefined).id).toBe(REPORT_DOMAIN.TECHNICAL_SECURITY);
+  });
+
+  it('exposes the reputation context disclaimer note', () => {
+    const rep = REPORT_DOMAINS.find((d) => d.id === REPORT_DOMAIN.REPUTATION_MAINTENANCE);
+    expect(rep.note).toMatch(/Context signal — informs confidence, not a standalone verdict/);
+    // Chip labels stay distinct from the Security/Privacy/Governance layer titles.
+    REPORT_DOMAINS.forEach((d) => {
+      expect(['Security', 'Privacy', 'Governance']).not.toContain(d.shortLabel);
+    });
+  });
+});
+
+describe('groupFactorsByDomain', () => {
+  it('splits the Security-layer factors into Technical Security and Reputation & Maintenance Context', () => {
+    // The real Security scoring layer: technical checks + reputation/maintenance.
+    const securityFactors = [
+      { name: 'SAST', severity: 0.1 },
+      { name: 'VirusTotal', severity: 0 },
+      { name: 'Obfuscation', severity: 0.2 },
+      { name: 'Manifest', severity: 0.3 },
+      { name: 'ChromeStats', severity: 0 },
+      { name: 'Webstore', severity: 0.1 },
+      { name: 'Maintenance', severity: 0.6 },
+    ];
+    const groups = groupFactorsByDomain(securityFactors);
+    const byId = Object.fromEntries(groups.map((g) => [g.domain.id, g.factors.map((f) => f.name)]));
+
+    expect(byId[REPORT_DOMAIN.TECHNICAL_SECURITY]).toEqual(['SAST', 'VirusTotal', 'Obfuscation', 'Manifest']);
+    expect(byId[REPORT_DOMAIN.REPUTATION_MAINTENANCE]).toEqual(['ChromeStats', 'Webstore', 'Maintenance']);
+  });
+
+  it('returns domains in canonical order and omits empty domains', () => {
+    const groups = groupFactorsByDomain([
+      { name: 'Maintenance', severity: 0.6 },
+      { name: 'SAST', severity: 0.1 },
+    ]);
+    // Technical Security precedes Reputation in REPORT_DOMAINS order, even though
+    // Maintenance was listed first.
+    expect(groups.map((g) => g.domain.id)).toEqual([
+      REPORT_DOMAIN.TECHNICAL_SECURITY,
+      REPORT_DOMAIN.REPUTATION_MAINTENANCE,
+    ]);
+  });
+
+  it('handles empty / non-array input without throwing', () => {
+    expect(groupFactorsByDomain([])).toEqual([]);
+    expect(groupFactorsByDomain(undefined)).toEqual([]);
+  });
+});
+
+describe('humanizeFactor domain annotation', () => {
+  it('attaches the domain id and chip label to a humanized factor', () => {
+    const webstore = humanizeFactor({ name: 'Webstore', severity: 0.5 });
+    expect(webstore.domain).toBe(REPORT_DOMAIN.REPUTATION_MAINTENANCE);
+    expect(webstore.domainLabel).toBe('Reputation');
+
+    const sast = humanizeFactor({ name: 'SAST', severity: 0.5 });
+    expect(sast.domain).toBe(REPORT_DOMAIN.TECHNICAL_SECURITY);
+    expect(sast.domainLabel).toBe('Technical Security');
+  });
+});

--- a/frontend/src/components/report/layerFactors.js
+++ b/frontend/src/components/report/layerFactors.js
@@ -21,6 +21,35 @@ function scrubLocalPaths(text) {
   return LOCAL_PATH_RE.test(cleaned) ? '' : cleaned;
 }
 
+function asStringArray(value) {
+  if (!value) return [];
+  if (Array.isArray(value)) return value.flatMap(asStringArray).filter(Boolean);
+  if (typeof value === 'string') {
+    return value.split(',').map((v) => v.trim()).filter(Boolean);
+  }
+  return [];
+}
+
+function humanizeSignalToken(token) {
+  return String(token || '')
+    .trim()
+    .replace(/^prohibited_perm:/, '')
+    .replace(/broad_host_access/g, 'broad host access')
+    .replace(/travel_docs_tos_automation_risk/g, 'travel-docs automation policy risk')
+    .replace(/travel_docs_third_party_processor_risk/g, 'travel-docs third-party processor policy risk')
+    .replace(/broad_access_with_vt_detection/g, 'broad access with malware reputation detection')
+    .replace(/\+/g, ' + ')
+    .replace(/_/g, ' ')
+    .replace(/\s+/g, ' ');
+}
+
+function summarizeTokens(values, limit = 5) {
+  const unique = Array.from(new Set(values.map(humanizeSignalToken).filter(Boolean)));
+  if (!unique.length) return '';
+  const shown = unique.slice(0, limit).join(', ');
+  return unique.length > limit ? `${shown} +${unique.length - limit} more` : shown;
+}
+
 /**
  * Build a short, truthful evidence caption for a single factor from real
  * analyzer output only — never invents text. Preference order:
@@ -37,6 +66,32 @@ export function factorEvidenceCaption(factor) {
 
   if (typeof details.description === 'string' && details.description.trim()) {
     return scrubLocalPaths(details.description);
+  }
+
+  if (factor?.name === 'PermissionsBaseline') {
+    const permissions = [
+      ...asStringArray(details.high_risk_permissions),
+      ...asStringArray(details.unreasonable_permissions),
+      ...asStringArray(details.permission),
+      ...asStringArray(details.permission_name),
+    ];
+    const text = summarizeTokens(permissions);
+    if (text) return `Sensitive permissions: ${text}`;
+  }
+
+  if (factor?.name === 'PermissionCombos') {
+    const combos = [
+      ...asStringArray(details.triggered_combos),
+      ...asStringArray(details.combo),
+      ...asStringArray(details.combination),
+    ];
+    const text = summarizeTokens(combos);
+    if (text) return `Combination: ${text}`;
+  }
+
+  if (factor?.name === 'ToSViolations') {
+    const text = summarizeTokens(asStringArray(details.violations));
+    if (text) return `Potential policy flags: ${text}`;
   }
 
   const days = details.days_since_update;
@@ -117,6 +172,22 @@ export function factorEvidenceDetails(factor) {
 
   const hostPermission = details.hostPermission ?? details.host_permissions ?? details.host;
   if (hostPermission !== permission) pushEvidenceRow(rows, 'Host access', hostPermission);
+
+  const highRiskPermissions = summarizeTokens([
+    ...asStringArray(details.high_risk_permissions),
+    ...asStringArray(details.unreasonable_permissions),
+  ]);
+  pushEvidenceRow(rows, 'Sensitive permissions', highRiskPermissions);
+
+  const triggeredCombos = summarizeTokens([
+    ...asStringArray(details.triggered_combos),
+    ...asStringArray(details.combo),
+    ...asStringArray(details.combination),
+  ]);
+  pushEvidenceRow(rows, 'Combination', triggeredCombos);
+
+  const policyFlags = summarizeTokens(asStringArray(details.violations));
+  pushEvidenceRow(rows, 'Policy flags', policyFlags);
 
   const manifestField = details.manifest_field ?? details.manifestField ?? details.field;
   pushEvidenceRow(rows, 'Manifest', manifestField);
@@ -309,10 +380,10 @@ const FACTOR_HUMAN = {
   Webstore:             { label: 'Store Reputation',      category: 'trust',  desc: 'Chrome Web Store ratings and user reviews' },
   Maintenance:          { label: 'Publisher update age',   category: 'trust',  desc: 'How recently the extension was updated by its developer' },
   PermissionsBaseline:  { label: 'Permission Risk',       category: 'access', desc: 'Evaluates the sensitivity of requested browser permissions' },
-  PermissionCombos:     { label: 'Dangerous Combos',      category: 'access', desc: 'Flags risky combinations of permissions that enable data theft' },
+  PermissionCombos:     { label: 'Dangerous Combos',      category: 'access', desc: 'Flags risky permission combinations or broad-access capability signals' },
   NetworkExfil:         { label: 'Data Sharing',          category: 'data',   desc: 'Detects if data is sent to external servers' },
   CaptureSignals:       { label: 'Screen Capture',        category: 'data',   desc: 'Checks for screen or tab recording capabilities' },
-  ToSViolations:        { label: 'Policy Violations',     category: 'policy', desc: 'Checks compliance with Chrome Web Store policies' },
+  ToSViolations:        { label: 'Potential Policy Issue', category: 'policy', desc: 'Surfaces potential Chrome Web Store policy issues from governance evidence' },
   Consistency:          { label: 'Behavior Match',        category: 'policy', desc: 'Compares stated purpose vs actual behavior' },
   DisclosureAlignment:  { label: 'Disclosure Accuracy',   category: 'policy', desc: 'Validates privacy policy against actual data collection' },
 };

--- a/frontend/src/components/report/layerFactors.js
+++ b/frontend/src/components/report/layerFactors.js
@@ -274,6 +274,8 @@ function factorIssueRow(item, index) {
     title: item.label,
     category: item.category,
     source: item.category,
+    domain: item.domain,
+    domainLabel: item.domainLabel,
     status: item.status,
     statusType: item.statusType,
     tone: item.tone,
@@ -388,6 +390,133 @@ const FACTOR_HUMAN = {
   DisclosureAlignment:  { label: 'Disclosure Accuracy',   category: 'policy', desc: 'Validates privacy policy against actual data collection' },
 };
 
+// ---------------------------------------------------------------------------
+// Report domain classification (PRESENTATION ONLY).
+//
+// The scoring engine groups factors into Security / Privacy / Governance
+// scoring LAYERS (backend src/extension_shield/scoring/weights.py). For the
+// report we present a concept-first grouping so reputation / maintenance
+// context does not read as direct technical-security evidence. This is a
+// display lens only: it never changes a score, weight, cap, or verdict. Each
+// factor's scoring home is unchanged — e.g. Webstore / ChromeStats /
+// Maintenance are still scored inside the Security layer but are presented
+// here under "Reputation & Maintenance Context".
+// ---------------------------------------------------------------------------
+
+export const REPORT_DOMAIN = {
+  TECHNICAL_SECURITY: 'technical-security',
+  PRIVACY_DATA_ACCESS: 'privacy-data-access',
+  GOVERNANCE_POLICY: 'governance-policy',
+  REPUTATION_MAINTENANCE: 'reputation-maintenance',
+  COVERAGE_CONFIDENCE: 'coverage-confidence',
+};
+
+// Ordered domain metadata. `shortLabel` is the compact chip label (kept
+// distinct from the Security/Privacy/Governance layer-card titles). `note` is
+// an advisory caption shown where the domain's signals appear.
+export const REPORT_DOMAINS = [
+  {
+    id: REPORT_DOMAIN.TECHNICAL_SECURITY,
+    label: 'Technical Security',
+    shortLabel: 'Technical Security',
+    question: 'Did the code, package, or manifest show technical risk?',
+  },
+  {
+    id: REPORT_DOMAIN.PRIVACY_DATA_ACCESS,
+    label: 'Privacy & Data Access',
+    shortLabel: 'Privacy & Data',
+    question: 'What user data can this extension access, capture, or transmit?',
+  },
+  {
+    id: REPORT_DOMAIN.GOVERNANCE_POLICY,
+    label: 'Governance / Policy / Disclosure',
+    shortLabel: 'Governance / Policy',
+    question: 'Does the declared purpose, disclosure, and policy posture match what it can do?',
+  },
+  {
+    id: REPORT_DOMAIN.REPUTATION_MAINTENANCE,
+    label: 'Reputation & Maintenance Context',
+    shortLabel: 'Reputation',
+    question: 'What context affects trust, freshness, and review priority?',
+    note: 'Context signal — informs confidence, not a standalone verdict.',
+  },
+  {
+    id: REPORT_DOMAIN.COVERAGE_CONFIDENCE,
+    label: 'Coverage & Confidence',
+    shortLabel: 'Coverage',
+    question: 'How complete was the scan, and where should you be cautious?',
+  },
+];
+
+const REPORT_DOMAIN_BY_ID = REPORT_DOMAINS.reduce((acc, d) => {
+  acc[d.id] = d;
+  return acc;
+}, {});
+
+// Explicit factor -> domain map. Reuses the FACTOR_HUMAN categories, with the
+// two overrides the category alone cannot express:
+//   - VirusTotal (category 'threat') is technical malware evidence.
+//   - ChromeStats (category 'threat') is reputation / threat-intel CONTEXT.
+const FACTOR_DOMAIN = {
+  SAST: REPORT_DOMAIN.TECHNICAL_SECURITY,
+  VirusTotal: REPORT_DOMAIN.TECHNICAL_SECURITY,
+  Obfuscation: REPORT_DOMAIN.TECHNICAL_SECURITY,
+  Manifest: REPORT_DOMAIN.TECHNICAL_SECURITY,
+  PermissionsBaseline: REPORT_DOMAIN.PRIVACY_DATA_ACCESS,
+  PermissionCombos: REPORT_DOMAIN.PRIVACY_DATA_ACCESS,
+  NetworkExfil: REPORT_DOMAIN.PRIVACY_DATA_ACCESS,
+  CaptureSignals: REPORT_DOMAIN.PRIVACY_DATA_ACCESS,
+  ToSViolations: REPORT_DOMAIN.GOVERNANCE_POLICY,
+  Consistency: REPORT_DOMAIN.GOVERNANCE_POLICY,
+  DisclosureAlignment: REPORT_DOMAIN.GOVERNANCE_POLICY,
+  Webstore: REPORT_DOMAIN.REPUTATION_MAINTENANCE,
+  ChromeStats: REPORT_DOMAIN.REPUTATION_MAINTENANCE,
+  Maintenance: REPORT_DOMAIN.REPUTATION_MAINTENANCE,
+};
+
+// Fallback for an unknown factor: map its FACTOR_HUMAN category to a domain.
+const CATEGORY_DOMAIN = {
+  code: REPORT_DOMAIN.TECHNICAL_SECURITY,
+  threat: REPORT_DOMAIN.TECHNICAL_SECURITY,
+  access: REPORT_DOMAIN.PRIVACY_DATA_ACCESS,
+  data: REPORT_DOMAIN.PRIVACY_DATA_ACCESS,
+  policy: REPORT_DOMAIN.GOVERNANCE_POLICY,
+  trust: REPORT_DOMAIN.REPUTATION_MAINTENANCE,
+  coverage: REPORT_DOMAIN.COVERAGE_CONFIDENCE,
+};
+
+/**
+ * Resolve a factor (or factor name) to its report-domain metadata. Explicit
+ * factor map first, then the factor's FACTOR_HUMAN category, then Technical
+ * Security as a safe default. Presentation only — never affects any score.
+ */
+export function domainForFactor(factorOrName) {
+  const name = typeof factorOrName === 'string' ? factorOrName : factorOrName?.name;
+  let id = FACTOR_DOMAIN[name];
+  if (!id) {
+    const category = FACTOR_HUMAN[name]?.category;
+    id = CATEGORY_DOMAIN[category] || REPORT_DOMAIN.TECHNICAL_SECURITY;
+  }
+  return REPORT_DOMAIN_BY_ID[id];
+}
+
+/**
+ * Group scoring factors into the ordered report domains for a concept-first
+ * presentation. Returns only the domains that actually have factors. Pure
+ * display grouping — factors and their scores are passed through untouched.
+ */
+export function groupFactorsByDomain(factors = []) {
+  const buckets = new Map();
+  (Array.isArray(factors) ? factors : []).forEach((factor) => {
+    const domain = domainForFactor(factor);
+    if (!buckets.has(domain.id)) buckets.set(domain.id, []);
+    buckets.get(domain.id).push(factor);
+  });
+  return REPORT_DOMAINS
+    .filter((domain) => buckets.has(domain.id))
+    .map((domain) => ({ domain, factors: buckets.get(domain.id) }));
+}
+
 /**
  * A check whose underlying analysis did not run has no coverage and must not be
  * shown as "Clear" (that overstates certainty). The network/exfil analyzer
@@ -421,6 +550,7 @@ export function humanizeFactor(factor) {
     category: 'other',
     desc: '',
   };
+  const domain = domainForFactor(factor);
   const severity = factor.severity ?? 0;
   // Publisher update age is a trust/caution signal, not a code-safety finding.
   // It must never present as standalone "High severity" — cap it at an advisory
@@ -446,7 +576,17 @@ export function humanizeFactor(factor) {
     tone = 'good';
     status = 'Clear';
   }
-  return { ...info, status, statusType, tone, severity, evidence: factorEvidenceCaption(factor), raw: factor };
+  return {
+    ...info,
+    domain: domain.id,
+    domainLabel: domain.shortLabel,
+    status,
+    statusType,
+    tone,
+    severity,
+    evidence: factorEvidenceCaption(factor),
+    raw: factor,
+  };
 }
 
 /**

--- a/frontend/src/utils/normalizeScanResult.test.ts
+++ b/frontend/src/utils/normalizeScanResult.test.ts
@@ -953,7 +953,7 @@ describe('Coverage-cap reasons are promoted into Key Findings', () => {
     const vm = normalizeScanResult(raw);
     // The PRIMARY key finding explains the real reason, not publisher update age.
     expect(vm.keyFindings[0].title).toBe('No analyzable code scanned');
-    expect(vm.keyFindings[0].severity).toBe('high');
+    expect(vm.keyFindings[0].severity).toBe('medium');
     // Publisher update age is still present but demoted to advisory.
     const maint = vm.keyFindings.find((f) => f.title === 'Publisher update age');
     expect(maint!.severity).toBe('medium');
@@ -1231,6 +1231,71 @@ describe('Key Findings evidence links', () => {
     expect(f).toBeDefined();
     expect(f!.evidence!.permission).toBe('tabs');
     expect(f!.evidence!.hostPermission).toBe('<all_urls>');
+  });
+
+  it('permission risk summary names concrete permissions instead of generic moderate-findings text', () => {
+    const raw = {
+      extension_id: 'permsummary123456789abcdefghijk',
+      final_verdict: 'NEEDS_REVIEW',
+      manifest: { permissions: ['storage', 'debugger', 'tabCapture'], host_permissions: ['*://*/*'] },
+      scoring_v2: {
+        overall_score: 57, decision: 'NEEDS_REVIEW', risk_level: 'medium', hard_gates_triggered: [],
+        privacy_layer: { layer_name: 'privacy', score: 41, risk: 0.59, confidence: 0.8,
+          factors: [{ name: 'PermissionsBaseline', severity: 0.62, confidence: 0.9, weight: 0.4, contribution: 0.2,
+            evidence_ids: ['perm:high_risk:debugger', 'perm:high_risk:tabCapture'],
+            details: { high_risk_permissions: ['debugger', 'tabCapture'], total_permissions: 3 } }] },
+      },
+    } as unknown as RawScanResult;
+    const vm = normalizeScanResult(raw);
+    const perm = vm.keyFindings.find((k) => k.title === 'Permission Risk');
+    expect(perm).toBeDefined();
+    expect(perm!.summary).toContain('debugger');
+    expect(perm!.summary).toContain('tabCapture');
+    expect(perm!.summary).not.toMatch(/Moderate findings in/i);
+    expect(perm!.evidence!.label).toContain('debugger');
+  });
+
+  it('dangerous-combo evidence shows the actual combination and broad-access signal', () => {
+    const raw = {
+      extension_id: 'combosummary123456789abcdefghi',
+      final_verdict: 'NEEDS_REVIEW',
+      manifest: { permissions: ['debugger', 'tabs'], host_permissions: ['*://*/*'] },
+      scoring_v2: {
+        overall_score: 57, decision: 'NEEDS_REVIEW', risk_level: 'medium', hard_gates_triggered: [],
+        privacy_layer: { layer_name: 'privacy', score: 41, risk: 0.59, confidence: 0.8,
+          factors: [{ name: 'PermissionCombos', severity: 0.7, confidence: 1, weight: 0.25, contribution: 0.175,
+            evidence_ids: ['combo:debugger+tabs', 'combo:broad_host_access'],
+            details: { triggered_combos: ['debugger+tabs', 'broad_host_access'] } }] },
+      },
+    } as unknown as RawScanResult;
+    const vm = normalizeScanResult(raw);
+    const combo = vm.keyFindings.find((k) => k.title === 'Dangerous Combos');
+    expect(combo).toBeDefined();
+    expect(combo!.summary).toContain('debugger + tabs');
+    expect(combo!.summary).toContain('broad host access');
+    expect(combo!.summary).toMatch(/capability signal, not proof of abuse/i);
+    expect(combo!.evidence!.label).toContain('debugger + tabs');
+  });
+
+  it('potential policy issues are not worded as confirmed Chrome Web Store violations', () => {
+    const raw = {
+      extension_id: 'policysummary123456789abcdefg',
+      final_verdict: 'NEEDS_REVIEW',
+      scoring_v2: {
+        overall_score: 57, decision: 'NEEDS_REVIEW', risk_level: 'medium',
+        hard_gates_triggered: ['TOS_VIOLATION'],
+        governance_layer: { layer_name: 'governance', score: 49, risk: 0.51, confidence: 0.8,
+          factors: [{ name: 'ToSViolations', severity: 0.5, confidence: 0.9, weight: 0.5, contribution: 0.25,
+            evidence_ids: ['tos:prohibited_perm:debugger'],
+            details: { violations: ['prohibited_perm:debugger'] } }] },
+      },
+    } as unknown as RawScanResult;
+    const vm = normalizeScanResult(raw);
+    expect(vm.keyFindings.some((k) => k.title === 'Potential Chrome Web Store policy issue')).toBe(true);
+    const policy = vm.keyFindings.find((k) => k.title === 'Potential Policy Issue');
+    expect(policy).toBeDefined();
+    expect(policy!.summary).toMatch(/Potential policy issue/i);
+    expect(policy!.summary).not.toMatch(/Chrome Web Store policy violation/i);
   });
 
   it('VirusTotal finding includes hash and result counts when present', () => {

--- a/frontend/src/utils/normalizeScanResult.ts
+++ b/frontend/src/utils/normalizeScanResult.ts
@@ -438,7 +438,7 @@ const GATE_HUMAN_TITLE: Record<string, string> = {
   SENSITIVE_EXFIL: 'Requests permissions that could send data externally',
   PURPOSE_MISMATCH: "Behavior doesn't match stated purpose",
   VT_MALWARE: 'Flagged by antivirus engines',
-  TOS_VIOLATION: 'Chrome Web Store policy violation',
+  TOS_VIOLATION: 'Potential Chrome Web Store policy issue',
   MANIFEST_POSTURE: 'Suspicious extension configuration',
   CAPTURE_SIGNALS: 'May capture your screen or input',
 };
@@ -458,7 +458,7 @@ const FACTOR_HUMAN_TITLE: Record<string, string> = {
   PermissionCombos: 'Dangerous Combos',
   NetworkExfil: 'Data Sharing',
   CaptureSignals: 'Screen Capture',
-  ToSViolations: 'Policy Violations',
+  ToSViolations: 'Potential Policy Issue',
   Consistency: 'Behavior Match',
   DisclosureAlignment: 'Disclosure Accuracy',
 };
@@ -532,6 +532,46 @@ function humanizeFactorName(name: string): string {
   return FACTOR_HUMAN_TITLE[name] || name.replace(/([A-Z])/g, ' $1').trim();
 }
 
+function stringList(value: unknown): string[] {
+  if (!value) return [];
+  if (Array.isArray(value)) {
+    return value
+      .flatMap((v) => stringList(v))
+      .filter(Boolean);
+  }
+  if (typeof value === 'string') {
+    return value
+      .split(',')
+      .map((v) => v.trim())
+      .filter(Boolean);
+  }
+  return [];
+}
+
+function humanizeRiskToken(token: unknown): string {
+  const raw = String(token || '').trim();
+  if (!raw) return '';
+  return raw
+    .replace(/^prohibited_perm:/, '')
+    .replace(/^policy:/, '')
+    .replace(/broad_host_access/g, 'broad host access')
+    .replace(/travel_docs_tos_automation_risk/g, 'travel-docs automation policy risk')
+    .replace(/travel_docs_third_party_processor_risk/g, 'travel-docs third-party processor policy risk')
+    .replace(/broad_access_with_vt_detection/g, 'broad access with malware reputation detection')
+    .replace(/\+/g, ' + ')
+    .replace(/_/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function readableList(values: unknown[], limit = 5): string {
+  const clean = values.map(humanizeRiskToken).filter(Boolean);
+  const unique = Array.from(new Set(clean));
+  const shown = unique.slice(0, limit);
+  const extra = unique.length > limit ? ` +${unique.length - limit} more` : '';
+  return `${shown.join(', ')}${extra}`;
+}
+
 function humanizeFactorSummary(factor: RawFactorScore, layer: string): string {
   const name = factor.name || 'Unknown';
   const severity = factor.severity ?? 0;
@@ -539,6 +579,47 @@ function humanizeFactorSummary(factor: RawFactorScore, layer: string): string {
   const desc = typeof details === 'object' ? (details as any).description : '';
 
   if (desc) return desc;
+
+  if (typeof details === 'object' && details) {
+    const d = details as Record<string, unknown>;
+    if (name === 'PermissionsBaseline') {
+      const permissions = [
+        ...stringList(d.high_risk_permissions),
+        ...stringList(d.unreasonable_permissions),
+        ...stringList(d.permission),
+        ...stringList(d.permission_name),
+      ];
+      const label = readableList(permissions);
+      return label
+        ? `Sensitive permissions declared: ${label}. Review whether these capabilities are required for the stated purpose.`
+        : 'Sensitive browser permissions were declared. Review whether these capabilities are required for the stated purpose.';
+    }
+    if (name === 'PermissionCombos') {
+      const combos = [
+        ...stringList(d.triggered_combos),
+        ...stringList(d.combo),
+        ...stringList(d.combination),
+      ];
+      const label = readableList(combos);
+      return label
+        ? `Risky permission combination or broad-access signal: ${label}. This is a capability signal, not proof of abuse.`
+        : 'Risky permission combination or broad-access signal detected. This is a capability signal, not proof of abuse.';
+    }
+    if (name === 'ToSViolations') {
+      const flags = stringList(d.violations);
+      const label = readableList(flags);
+      return label
+        ? `Potential policy issue: ${label}. Review against Chrome Web Store policy before treating this as a confirmed violation.`
+        : 'Potential Chrome Web Store policy issue. Review the governance evidence before treating this as a confirmed violation.';
+    }
+    if (name === 'Maintenance') {
+      const days = Number(d.days_since_update);
+      if (Number.isFinite(days) && days >= 0) {
+        return `Publisher update age: last updated ${days} day${days === 1 ? '' : 's'} ago. This is maintenance context, not a confirmed security threat.`;
+      }
+      return 'Publisher update age is maintenance context, not a confirmed security threat.';
+    }
+  }
 
   const level = severity >= 0.7 ? 'significant' : severity >= 0.4 ? 'moderate' : 'minor';
   const humanName = humanizeFactorName(name).toLowerCase();
@@ -1209,7 +1290,7 @@ function resolveFactorEvidence(
     const manifest = anyRaw.manifest || {};
     const perms: string[] = Array.isArray(manifest.permissions) ? manifest.permissions as string[] : [];
     const hosts: string[] = Array.isArray(manifest.host_permissions) ? manifest.host_permissions as string[] : [];
-    const details = (factor.details || {}) as { description?: unknown };
+    const details = (factor.details || {}) as Record<string, unknown> & { description?: unknown };
     const explanation = typeof details.description === 'string' ? details.description : undefined;
     const tokens = ids.map((id) => parseSyntheticEvidenceId(id).token).filter(Boolean);
     const token = tokens[0];
@@ -1227,13 +1308,32 @@ function resolveFactorEvidence(
       return { kind: 'manifest', available: false };
     }
 
+    const triggeredCombos = [
+      ...stringList(details.triggered_combos),
+      ...stringList(details.combo),
+      ...stringList(details.combination),
+    ];
+    const highRiskPermissions = [
+      ...stringList(details.high_risk_permissions),
+      ...stringList(details.unreasonable_permissions),
+    ];
+    const labelParts = name === 'PermissionCombos'
+      ? (triggeredCombos.length ? triggeredCombos : tokens)
+      : (highRiskPermissions.length ? highRiskPermissions : tokens);
+    const labelText = readableList(labelParts.length ? labelParts : [token || perms[0] || hosts[0]]);
+
     // Permission / combo / capture — token is the specific permission or signal.
-    const permission = token || perms[0];
+    const permission = name === 'PermissionCombos'
+      ? (labelText || token || perms[0])
+      : (token || highRiskPermissions[0] || perms[0]);
     if (permission || hosts.length || explanation) {
       return {
         kind: 'manifest', available: true,
-        permission, hostPermission: hosts[0], manifestField: 'permissions', explanation,
-        label: permission || hosts[0] || 'manifest',
+        permission,
+        hostPermission: hosts.join(', ') || undefined,
+        manifestField: 'permissions',
+        explanation: explanation || humanizeFactorSummary(factor as RawFactorScore, factor.layer),
+        label: labelText || permission || hosts[0] || 'manifest',
       };
     }
     return { kind: 'manifest', available: false };
@@ -1285,7 +1385,7 @@ function buildCoverageKeyFindings(
 
   const findings: KeyFindingVM[] = [];
   const mk = (title: string, summary: string, evidence: KeyFindingEvidence): KeyFindingVM => ({
-    title, severity: 'high', layer: 'security', summary, evidenceIds: [], evidence,
+    title, severity: 'medium', layer: 'security', summary, evidenceIds: [], evidence,
   });
 
   const sp = (anyRaw.governance_bundle?.signal_pack || {}) as Record<string, any>;
@@ -1492,16 +1592,13 @@ function buildKeyFindings(
     .slice(0, 3)
     .forEach((factor) => {
       const humanTitle = humanizeFactorName(factor.name);
-      const details = factor.details || {};
-      const desc = typeof details === 'object' ? (details as any).description : '';
 
       let findingSeverity = severityToFindingLevel(factor.severity);
       if (factor.name === 'Maintenance' && findingSeverity === 'high' && !hasStrongEvidence) {
         findingSeverity = 'medium';
       }
 
-      const level = findingSeverity === 'high' ? 'significant' : findingSeverity === 'medium' ? 'moderate' : 'minor';
-      const summary = desc || `${level.charAt(0).toUpperCase() + level.slice(1)} findings in ${humanTitle.toLowerCase()}`;
+      const summary = humanizeFactorSummary(factor as RawFactorScore, factor.layer);
 
       findings.push({
         title: humanTitle,
@@ -2014,4 +2111,3 @@ export function isDevelopmentMode(): boolean {
 
 // Default export
 export default normalizeScanResult;
-

--- a/frontend/src/utils/reportDisplay.js
+++ b/frontend/src/utils/reportDisplay.js
@@ -352,3 +352,85 @@ export function resolveIssueOverview(findings) {
   });
   return { ...counts, total: counts.high + counts.medium + counts.low + counts.info };
 }
+
+/**
+ * Labels that keep the numeric governance-layer SCORE distinct from the
+ * governance rulepack POLICY DECISION — they are separate concepts and can
+ * disagree (a high governance score can still carry a policy review/block).
+ */
+export const GOVERNANCE_SCORE_LABEL = 'Governance score';
+export const POLICY_DECISION_LABEL = 'Policy decision';
+
+/** Title-case an unknown authority token as a readable fallback. */
+function humanizeAuthorityToken(authority) {
+  return String(authority || '')
+    .replace(/_/g, ' ')
+    .replace(/\b\w/g, (ch) => ch.toUpperCase())
+    .trim();
+}
+
+/**
+ * Explain WHICH authority produced the final verdict, in one plain sentence.
+ *
+ * The backend Decision Authority (src/extension_shield/scoring/decision.py)
+ * resolves the verdict through a fixed precedence chain; this surfaces that
+ * precedence to the reader so a governance-rule or coverage-driven review is
+ * never mistaken for a technical-security or reputation finding. Display only.
+ *
+ * A reputation/maintenance signal is never an authority in the chain, so it can
+ * never be rendered here as the decision basis.
+ *
+ * Returns a rich sentence for a known authority, or `null` for an unrecognized
+ * token (callers fall back to a humanized label).
+ */
+export function describeDecisionAuthority(authority, context = {}) {
+  const {
+    coverageCapApplied = false,
+    ruleId = null,
+    rulepack = null,
+    gate = null,
+  } = context;
+
+  const rule = rulepack && ruleId ? `${rulepack}::${ruleId}` : (ruleId || rulepack || null);
+
+  switch (authority) {
+    case 'org_block':
+      return 'Decided by organization policy (blocklist).';
+    case 'org_allow_exception':
+      return 'Decided by organization policy (allow exception).';
+    case 'baseline_governance':
+      return rule
+        ? `Decided by Chrome Web Store policy review (governance rule ${rule}).`
+        : 'Decided by Chrome Web Store policy review (governance policy rule).';
+    case 'hard_gate':
+      return `Decided by a hard security/privacy gate${gate ? ` (${gate})` : ''}.`;
+    case 'score_threshold':
+      return coverageCapApplied
+        ? 'Limited by analysis coverage; needs review.'
+        : 'Decided by overall score threshold.';
+    case 'insufficient_data':
+    case 'low_confidence':
+      return 'Limited by analysis coverage; needs review.';
+    case 'score_pass':
+      return 'All checks passed.';
+    default:
+      return null;
+  }
+}
+
+/**
+ * Full "why this verdict" element model: the plain sentence, whether a
+ * governance rulepack drove it (so the UI can tag it a POLICY_DECISION distinct
+ * from the governance score), and a humanized fallback label for unknown
+ * authorities. Returns null when there is no authority to explain.
+ */
+export function resolveDecisionAuthorityDisplay(authority, context = {}) {
+  if (!authority) return null;
+  const description = describeDecisionAuthority(authority, context);
+  return {
+    authority,
+    description,
+    fallbackLabel: humanizeAuthorityToken(authority),
+    isPolicyDecision: authority === 'baseline_governance',
+  };
+}

--- a/frontend/src/utils/reportDisplay.js
+++ b/frontend/src/utils/reportDisplay.js
@@ -325,7 +325,8 @@ export function evidenceCountLabel(count) {
  *    (the "View evidence" button is gated on the same count, unchanged).
  *  - else structured finding.evidence:
  *      available + label -> "Evidence: <label>"
- *      otherwise (available:false, or present but unlabelled) -> "Evidence: summary only"
+ *      otherwise (available:false, or present but unlabelled) -> a plain
+ *      summary/reason-only label, not placeholder text
  *  - else (no IDs and no structured evidence) -> "Evidence not linked".
  *
  * Never generates a new label — it only selects the existing finding.evidence.label.
@@ -335,7 +336,8 @@ export function resolveFindingEvidenceLabel(finding, evidenceCount) {
   if (n > 0) return evidenceCountLabel(n);
   const ev = finding && finding.evidence;
   if (ev && ev.available === true && ev.label) return `Evidence: ${ev.label}`;
-  if (ev) return 'Evidence: summary only';
+  if (ev && ev.available === true) return 'Based on reported reason only';
+  if (ev) return 'Based on summary only';
   return evidenceCountLabel(0);
 }
 

--- a/frontend/src/utils/reportDisplay.test.js
+++ b/frontend/src/utils/reportDisplay.test.js
@@ -236,14 +236,14 @@ describe('resolveFindingEvidenceLabel — Key Findings row evidence label', () =
     expect(resolveFindingEvidenceLabel(finding, 1)).toBe('1 evidence item');
   });
 
-  it('shows "Evidence: summary only" for available:false findings', () => {
+  it('shows a non-placeholder summary-only label for available:false findings', () => {
     const finding = { title: 'Passes checks', evidence: { available: false } };
-    expect(resolveFindingEvidenceLabel(finding, 0)).toBe('Evidence: summary only');
+    expect(resolveFindingEvidenceLabel(finding, 0)).toBe('Based on summary only');
   });
 
-  it('shows "Evidence: summary only" when structured evidence exists but has no label (never "not linked")', () => {
+  it('shows a reported-reason label when structured evidence exists but has no label (never "not linked")', () => {
     const finding = { title: 'x', evidence: { available: true } };
-    expect(resolveFindingEvidenceLabel(finding, 0)).toBe('Evidence: summary only');
+    expect(resolveFindingEvidenceLabel(finding, 0)).toBe('Based on reported reason only');
   });
 
   it('shows "Evidence not linked" only when there are no IDs and no structured evidence', () => {

--- a/frontend/src/utils/reportDisplay.test.js
+++ b/frontend/src/utils/reportDisplay.test.js
@@ -9,6 +9,10 @@ import {
   normalizeVerdictKey,
   evidenceCountLabel,
   resolveFindingEvidenceLabel,
+  describeDecisionAuthority,
+  resolveDecisionAuthorityDisplay,
+  GOVERNANCE_SCORE_LABEL,
+  POLICY_DECISION_LABEL,
 } from './reportDisplay';
 
 const CHROMESTATS_DEFAULT = {
@@ -257,5 +261,77 @@ describe('resolveFindingEvidenceLabel — Key Findings row evidence label', () =
     const before = JSON.stringify(finding);
     resolveFindingEvidenceLabel(finding, 0);
     expect(JSON.stringify(finding)).toBe(before);
+  });
+});
+
+describe('describeDecisionAuthority — verdict authority explanation', () => {
+  it('names a governance rulepack decision with its rule id (Chrome Web Store policy review)', () => {
+    expect(
+      describeDecisionAuthority('baseline_governance', { rulepack: 'CWS_LIMITED_USE', ruleId: 'R2' })
+    ).toBe('Decided by Chrome Web Store policy review (governance rule CWS_LIMITED_USE::R2).');
+  });
+
+  it('degrades gracefully when the rule id is unknown', () => {
+    expect(describeDecisionAuthority('baseline_governance', {})).toBe(
+      'Decided by Chrome Web Store policy review (governance policy rule).'
+    );
+  });
+
+  it('names the hard gate that drove a block', () => {
+    expect(describeDecisionAuthority('hard_gate', { gate: 'SENSITIVE_EXFIL' })).toBe(
+      'Decided by a hard security/privacy gate (SENSITIVE_EXFIL).'
+    );
+  });
+
+  it('reads a coverage-capped score threshold as a coverage limitation, not a threat', () => {
+    expect(describeDecisionAuthority('score_threshold', { coverageCapApplied: true })).toBe(
+      'Limited by analysis coverage; needs review.'
+    );
+    expect(describeDecisionAuthority('score_threshold', { coverageCapApplied: false })).toBe(
+      'Decided by overall score threshold.'
+    );
+  });
+
+  it('treats insufficient-data / low-confidence as coverage limitations', () => {
+    expect(describeDecisionAuthority('insufficient_data')).toBe('Limited by analysis coverage; needs review.');
+    expect(describeDecisionAuthority('low_confidence')).toBe('Limited by analysis coverage; needs review.');
+  });
+
+  it('reports a clean pass and organization overrides', () => {
+    expect(describeDecisionAuthority('score_pass')).toBe('All checks passed.');
+    expect(describeDecisionAuthority('org_block')).toBe('Decided by organization policy (blocklist).');
+    expect(describeDecisionAuthority('org_allow_exception')).toBe('Decided by organization policy (allow exception).');
+  });
+
+  it('returns null for an unrecognized authority token', () => {
+    expect(describeDecisionAuthority('coverage_cap')).toBeNull();
+    expect(describeDecisionAuthority(undefined)).toBeNull();
+  });
+});
+
+describe('resolveDecisionAuthorityDisplay — full authority element model', () => {
+  it('flags only a governance rulepack outcome as a Policy decision (distinct from the governance score)', () => {
+    const gov = resolveDecisionAuthorityDisplay('baseline_governance', { rulepack: 'CWS_LIMITED_USE', ruleId: 'R2' });
+    expect(gov.isPolicyDecision).toBe(true);
+    expect(gov.description).toMatch(/Chrome Web Store policy review/);
+
+    const gate = resolveDecisionAuthorityDisplay('hard_gate', { gate: 'PURPOSE_MISMATCH' });
+    expect(gate.isPolicyDecision).toBe(false);
+
+    // The score and the policy decision are labelled as separate concepts.
+    expect(GOVERNANCE_SCORE_LABEL).toBe('Governance score');
+    expect(POLICY_DECISION_LABEL).toBe('Policy decision');
+  });
+
+  it('gives a humanized fallback label (and null description) for unknown authorities', () => {
+    const d = resolveDecisionAuthorityDisplay('coverage_cap');
+    expect(d.description).toBeNull();
+    expect(d.fallbackLabel).toBe('Coverage Cap');
+    expect(d.isPolicyDecision).toBe(false);
+  });
+
+  it('returns null when there is no authority', () => {
+    expect(resolveDecisionAuthorityDisplay(null)).toBeNull();
+    expect(resolveDecisionAuthorityDisplay('')).toBeNull();
   });
 });


### PR DESCRIPTION
Display-only report cleanup.

Adds explicit report-domain labels, reputation/maintenance context wording, and a clearer verdict-authority explanation. This helps users understand whether a finding is technical security, privacy/data access, governance/policy, reputation context, or coverage confidence.

No scoring, backend, rulepack, API payload, score, or verdict behavior changed.