### PR TITLE
chore(scoring): fix version drift and document scoring ownership

### DIFF
--- a/docs/adr/0002-scoring-layer-ownership.md
+++ b/docs/adr/0002-scoring-layer-ownership.md
@@ -1,0 +1,123 @@
+# ADR 0002: Scoring Layer Ownership and Staged Cleanup
+
+- **Status:** Accepted
+- **Date:** 2026-07-09
+- **Area:** Scoring engine (`scoring/`), governance pipeline (`governance/`, `workflow/`), report normalization (`frontend/`)
+
+## Context
+
+A source-backed audit of the backend scoring stack (weights, engine, gates,
+decision, normalizers, governance nodes, payload/recompute paths) found that the
+current model is coherent and safe, but mixes concerns in ways that make it hard
+to explain and tune:
+
+1. **Reputation/maintenance lives inside the Security scoring layer.**
+   `ChromeStats`, `Webstore`, and `Maintenance` are each weighted `0.10` in
+   `scoring/weights.py:26-28` — 30% of the Security layer is
+   reputation/context, not direct technical-security evidence.
+2. **A few signals are counted in more than one place** (duplicate-risk):
+   - **privacy-policy** absence is scored in `Webstore` (Security,
+     `normalizers.py:587-589`) *and* `DisclosureAlignment` (Governance,
+     `engine.py:695-706`), and is also a governance rulepack concern
+     (`CWS_LIMITED_USE.yaml`).
+   - **broad-host access** contributes to `Manifest` posture, `PermissionCombos`,
+     `NetworkExfil`, the governance factors, and the `SENSITIVE_EXFIL` gate.
+   - **purpose-mismatch**, **exfil**, and **ToS/policy** are each represented by
+     both a scoring factor (`Consistency` / `NetworkExfil` / `ToSViolations`) and
+     a hard gate (`PURPOSE_MISMATCH` / `SENSITIVE_EXFIL` / `TOS_VIOLATION`).
+3. **Version metadata drifted.** `scoring/explain.py` defaulted
+   `scoring_version` to `"2.0.0"` while `ScoringEngine.VERSION` was `"2.1.0"`
+   (`engine.py:106`). The production scan path passes the engine version
+   explicitly (`engine.py:856`), so stored scans and golden snapshots were
+   unaffected, but any explanation built without an explicit version (e.g.
+   `get_ui_explanation`) emitted stale metadata.
+
+**Task C** (report/domain reclassification + verdict-authority label, PR #267)
+is already merged and was **frontend/display-only**. It presents ChromeStats /
+Webstore / Maintenance under a **"Reputation & Maintenance Context"** section and
+shows the Decision Authority, but changed **no** backend score, weight, gate,
+threshold, rulepack, analyzer, persistence, or API payload shape. The frontend
+maps by backend `FactorScore.name`, so backend factor names and the
+`scoring_v2.{security,privacy,governance}_layer` emission shape are now a
+compatibility contract.
+
+## Decision
+
+Adopt a **staged** cleanup. This ADR records the current ownership and the
+target, and commits to a version-gated migration so cached scans stay safe and
+explainable. Best-practice basis: CVSS versions its scoring concepts and treats
+confidence/temporal factors as modifiers that never inflate a base score; OWASP
+Risk Rating separates technical from business/context impact; NIST CSF 2.0
+(GOVERN) expects risk policy to be documented and monitored. An ADR + regression
+tests **before** any recalibration is the OSS-safe order.
+
+### 1. Current backend layers are unchanged (this PR)
+
+- Backend scoring layers remain **Security / Privacy / Governance**.
+- Layer weights remain **0.34 / 0.33 / 0.33** (`weights.py:65-68`).
+- Factor weights are **unchanged**.
+- Reputation/Maintenance (`ChromeStats`, `Webstore`, `Maintenance`) **still live
+  in the Security scoring layer**. Task C only changes how they are *presented*.
+
+### 2. Target direction (future PRs, not this one)
+
+- **Reputation & Maintenance should become context/confidence**, not a co-equal
+  heavy scoring input: a bounded, downward-biased modifier (like a CVSS temporal
+  metric) that can nudge but never, on its own, drive `NEEDS_REVIEW`→`BLOCK`.
+- **Each duplicated signal gets one scored owner**, with the others demoted to
+  evidence-only or gate-only:
+  - privacy-policy → single owner in Governance (`DisclosureAlignment`).
+  - broad-host → single scored owner in Privacy (`PermissionCombos`).
+  - purpose-mismatch / exfil / ToS → the graded factor and the hard gate must not
+    double-penalize the **same** evidence without explicit intent.
+- **Reputation/maintenance must never be a standalone BLOCK authority** — there
+  is no reputation gate and no reputation rung in `decision.resolve()`, and that
+  must stay true. Enforced by `tests/scoring/test_no_double_count.py`.
+
+### 3. Versioning rules for any future scoring change
+
+- Any **weight or scoring-formula change** requires bumping `weights_version`
+  (`weights.py`) **and** `ScoringEngine.VERSION` (drives `scoring_version`), plus
+  **regenerating golden snapshots** (`tests/test_golden_snapshots.py`) with a
+  before/after verdict diff.
+- Any **decision precedence or rulepack verdict/advisory change** requires
+  bumping `DECISION_VERSION` (`governance/decision_refresh.py:42`).
+- The read-time recompute paths (`api/payload_helpers.py`,
+  `governance/decision_refresh.py`) already refresh cached rows when a stored
+  version differs, so a version bump is the migration mechanism; a revert of the
+  version constants is the rollback.
+
+## Scope of this PR (PR-1)
+
+Hygiene only — **no** score, verdict, weight, threshold, gate, rulepack,
+analyzer, or golden-snapshot change:
+
+- Fix the `scoring_version` drift: `explain.py` now sources the version from
+  `ScoringEngine.VERSION` (via a lazy helper to avoid the `engine → explain`
+  circular import) instead of a hardcoded `"2.0.0"` default.
+- Add `tests/scoring/test_scoring_version_consistency.py` (fails if a stale
+  version default is reintroduced).
+- Add `tests/scoring/test_no_double_count.py` (tracks the duplicate-risk areas
+  above and enforces the reputation-never-BLOCK invariant).
+- Add this ADR.
+
+## Consequences
+
+- The emitted `scoring_version` metadata is now consistent everywhere; no stored
+  score or verdict changes (the production path already emitted `2.1.0`).
+- The duplicate-risk areas are now covered by tracking tests, so the future
+  de-duplication PRs must update them deliberately (a visible, reviewed signal).
+- A follow-up hygiene item: `scoring/models.py:327-328` also defaults
+  `scoring_version` to `"2.0.0"`, but it is always overridden by the engine
+  (`engine.py:473,857`) and never emitted stale in stored scans; consolidate it
+  in a later pass.
+
+## Follow-up PR sequence (planned)
+
+1. **PR-2** — privacy-policy counted once (`DisclosureAlignment` owns it).
+2. **PR-3** — de-duplicate broad-host / purpose-mismatch / exfil / ToS
+   (factor-vs-gate) so the same evidence is not double-penalized.
+3. **PR-4** — optional Security internal rebalance (`weights_version` bump).
+4. **PR-5** — reputation-as-modifier + layer re-weight, gated on a labeled
+   benign/malicious/review corpus (`weights_version` + `scoring_version`, golden
+   regen, rollback documented).

--- a/src/extension_shield/scoring/explain.py
+++ b/src/extension_shield/scoring/explain.py
@@ -26,6 +26,21 @@ from extension_shield.scoring.models import (
 )
 
 
+def _current_scoring_version() -> str:
+    """Single source of truth for the emitted ``scoring_version``.
+
+    The canonical version lives on ``ScoringEngine.VERSION``. It is imported
+    lazily (inside the function, not at module scope) because ``engine.py``
+    imports this module at load time — a module-level ``from ...engine import
+    ScoringEngine`` here would create a circular import. Resolving at call time
+    is safe: the engine module is always fully loaded before any explanation is
+    built. This keeps ``explain.py`` from drifting behind the engine version.
+    """
+    from extension_shield.scoring.engine import ScoringEngine
+
+    return ScoringEngine.VERSION
+
+
 # =============================================================================
 # EXPLANATION DATA STRUCTURES
 # =============================================================================
@@ -136,7 +151,8 @@ class ExplanationPayload:
     hard_gates: Dict[str, Any] = field(default_factory=dict)
     triggered_gates: List[str] = field(default_factory=list)
     
-    scoring_version: str = "2.0.0"
+    # Sourced from ScoringEngine.VERSION so this never drifts behind the engine.
+    scoring_version: str = field(default_factory=_current_scoring_version)
     weights_version: str = "v1"
     computed_at: str = ""
     overall_confidence: float = 1.0  # Per Phase 1 fixups: layer-weighted avg of layer confidences
@@ -202,17 +218,19 @@ class ExplanationBuilder:
     
     def __init__(
         self,
-        scoring_version: str = "2.0.0",
+        scoring_version: Optional[str] = None,
         weights_version: str = "v1",
     ):
         """
         Initialize ExplanationBuilder.
-        
+
         Args:
-            scoring_version: Version of the scoring engine
+            scoring_version: Version of the scoring engine. Defaults to the
+                canonical ScoringEngine.VERSION when not supplied, so the emitted
+                metadata never drifts behind the engine.
             weights_version: Version of the weight preset used
         """
-        self.scoring_version = scoring_version
+        self.scoring_version = scoring_version if scoring_version is not None else _current_scoring_version()
         self.weights_version = weights_version
     
     def build(
@@ -730,18 +748,19 @@ class ExplanationBuilder:
 def build_explanation(
     result: ScoringResult,
     gate_results: List[GateResult],
-    scoring_version: str = "2.0.0",
+    scoring_version: Optional[str] = None,
     weights_version: str = "v1",
 ) -> ExplanationPayload:
     """
     Convenience function to build explanation from ScoringResult.
-    
+
     Args:
         result: Complete ScoringResult
         gate_results: List of GateResult from evaluation
-        scoring_version: Scoring engine version
+        scoring_version: Scoring engine version. Defaults to the canonical
+            ScoringEngine.VERSION when not supplied.
         weights_version: Weight preset version
-        
+
     Returns:
         ExplanationPayload
     """

--- a/tests/scoring/test_no_double_count.py
+++ b/tests/scoring/test_no_double_count.py
@@ -1,0 +1,179 @@
+"""No-double-count guardrails (PR-1 tracking + one hard invariant).
+
+These tests DO NOT change scoring behavior. They pin the *current* state of the
+known duplicate-risk areas surfaced by the backend scoring audit so that the
+future de-duplication PRs (PR-2/PR-3) are forced to update them deliberately,
+and they enforce the one invariant that must hold in every version:
+
+    reputation / maintenance context can never, by itself, produce a BLOCK.
+
+Duplicate-risk trackers (documented, not yet fixed — see
+docs/adr/0002-scoring-layer-ownership.md):
+
+  * privacy-policy absence is scored in BOTH Security (Webstore) and Governance
+    (DisclosureAlignment).
+  * broad-host access is counted in BOTH Security (Manifest posture) and Privacy
+    (PermissionCombos).
+  * purpose-mismatch / exfil / ToS are each represented by BOTH a scoring factor
+    AND a hard gate.
+
+When a future PR consolidates an owner, the corresponding assertion below will
+flip — that is the intended signal to update the tracker (and the ADR).
+"""
+
+import pytest
+
+from extension_shield.scoring.engine import ScoringEngine
+from extension_shield.scoring.gates import HardGates
+from extension_shield.scoring.decision import resolve, DecisionPolicy
+from extension_shield.scoring.models import Decision
+from extension_shield.scoring.weights import SECURITY_WEIGHTS_V1
+from extension_shield.governance.signal_pack import (
+    WebstoreStatsSignalPack,
+    PermissionsSignalPack,
+    SastSignalPack,
+    VirusTotalSignalPack,
+)
+from tests.scoring.utils import make_min_signal_pack
+
+
+MV3_MANIFEST = {"name": "Test Extension", "description": "a tool", "manifest_version": 3}
+REPUTATION_FACTORS = {"Webstore", "ChromeStats", "Maintenance"}
+
+
+def _factors_by_name(layer):
+    return {f.name: f for f in (layer.factors if layer else [])}
+
+
+def _all_factor_names(result):
+    names = set()
+    for layer in (result.security_layer, result.privacy_layer, result.governance_layer):
+        names |= set(_factors_by_name(layer).keys())
+    return names
+
+
+# ---------------------------------------------------------------------------
+# Duplicate-risk trackers (current state; flip when a single owner is chosen)
+# ---------------------------------------------------------------------------
+
+def test_tracker_privacy_policy_scored_in_security_and_governance():
+    """TRACKING: privacy-policy absence is scored in two layers today.
+
+    PR-2/PR-3 will make Governance/DisclosureAlignment the single scored owner
+    and drop the Security/Webstore contribution. When that lands, the Webstore
+    assertion flips — update this tracker and the ADR then.
+    """
+    pack = make_min_signal_pack()
+    pack.webstore_stats = WebstoreStatsSignalPack(
+        has_privacy_policy=False, rating_avg=4.5, installs=100_000, last_updated="June 1, 2026"
+    )
+    pack.permissions = PermissionsSignalPack(
+        api_permissions=["cookies"], high_risk_permissions=["cookies"], total_permissions=1
+    )
+    result = ScoringEngine().calculate_scores(pack, manifest=MV3_MANIFEST)
+    sec = _factors_by_name(result.security_layer)
+    gov = _factors_by_name(result.governance_layer)
+
+    # Security/Webstore scores privacy-policy absence today (to be removed later).
+    assert "no_privacy_policy" in sec["Webstore"].flags
+    # Governance/DisclosureAlignment ALSO scores it today (the intended owner).
+    assert any("no_privacy_policy" in flag for flag in gov["DisclosureAlignment"].flags)
+
+
+def test_tracker_broad_host_counted_in_security_and_privacy():
+    """TRACKING: broad-host access is counted in two layers today.
+
+    PR-3 will choose one scored owner (Privacy/PermissionCombos) and demote the
+    others to evidence/gate-only. When that lands, the Manifest assertion flips.
+    """
+    pack = make_min_signal_pack()
+    pack.permissions = PermissionsSignalPack(
+        api_permissions=["tabs"],
+        host_permissions=["<all_urls>"],
+        has_broad_host_access=True,
+        broad_host_patterns=["<all_urls>"],
+        total_permissions=1,
+    )
+    result = ScoringEngine().calculate_scores(pack, manifest=MV3_MANIFEST)
+    sec = _factors_by_name(result.security_layer)
+    priv = _factors_by_name(result.privacy_layer)
+
+    # Security/Manifest posture counts broad host today (to be demoted later).
+    assert "broad_host_access" in sec["Manifest"].flags
+    # Privacy/PermissionCombos ALSO counts broad host today (the intended owner).
+    assert "broad_host_access" in priv["PermissionCombos"].details.get("triggered_combos", [])
+
+
+@pytest.mark.parametrize(
+    "factor_name, gate_id",
+    [
+        ("Consistency", "PURPOSE_MISMATCH"),  # purpose-mismatch
+        ("NetworkExfil", "SENSITIVE_EXFIL"),  # exfiltration
+        ("ToSViolations", "TOS_VIOLATION"),   # ToS / policy
+    ],
+)
+def test_tracker_concept_represented_by_both_factor_and_gate(factor_name, gate_id):
+    """TRACKING: each concept is represented by BOTH a scoring factor and a gate.
+
+    This is allowed by design (a graded factor + a hard-stop gate), but PR-3
+    must ensure the SAME piece of evidence is not double-penalized (factor
+    severity AND gate penalty) without explicit intent. This test documents the
+    dual representation; refine it when the de-dup design lands.
+    """
+    result = ScoringEngine().calculate_scores(make_min_signal_pack(), manifest=MV3_MANIFEST)
+    assert factor_name in _all_factor_names(result)
+    assert gate_id in HardGates.GATES
+
+
+# ---------------------------------------------------------------------------
+# Hard invariant (must hold in every version)
+# ---------------------------------------------------------------------------
+
+def test_no_reputation_hard_gate_exists():
+    assert set(HardGates.GATES) == {
+        "VT_MALWARE", "CRITICAL_SAST", "TOS_VIOLATION", "PURPOSE_MISMATCH", "SENSITIVE_EXFIL",
+    }
+    for rep in REPUTATION_FACTORS:
+        assert rep not in HardGates.GATES
+
+
+def test_reputation_factor_weights_are_capped_low():
+    # Small weights => reputation alone cannot drive the overall score below the
+    # BLOCK threshold. This is the numeric half of "reputation never BLOCKs".
+    for rep in REPUTATION_FACTORS:
+        assert SECURITY_WEIGHTS_V1[rep] <= 0.10
+
+
+def test_resolve_never_blocks_from_a_reputation_driven_score():
+    # No org block, no baseline governance BLOCK, no hard gate: a review-band
+    # score (>= BLOCK_SCORE) can only reach NEEDS_REVIEW, never BLOCK.
+    review = resolve(
+        overall_score=70, security_score=70,
+        blocking_gates=(), warning_gates=(),
+        baseline_block_reasons=None, baseline_review_reasons=None,
+    )
+    assert review.verdict == Decision.NEEDS_REVIEW
+    assert review.authority == "score_threshold"
+    assert "reputation" not in review.authority
+
+    clean = resolve(
+        overall_score=90, security_score=90,
+        blocking_gates=(), warning_gates=(), overall_confidence=1.0,
+    )
+    assert clean.verdict == Decision.ALLOW
+
+
+def test_reputation_only_bad_extension_never_blocks_end_to_end():
+    # Real code/malware coverage present (so the coverage cap is not the driver),
+    # and ONLY reputation is bad: low rating, few installs, very stale, but a
+    # privacy policy exists and there are no permission/code/malware issues.
+    pack = make_min_signal_pack()
+    pack.sast = SastSignalPack(files_scanned=5)
+    pack.virustotal = VirusTotalSignalPack(
+        enabled=True, total_engines=70, malicious_count=0, suspicious_count=0
+    )
+    pack.webstore_stats = WebstoreStatsSignalPack(
+        has_privacy_policy=True, rating_avg=1.0, installs=10, last_updated="January 1, 2020"
+    )
+    result = ScoringEngine().calculate_scores(pack, manifest=MV3_MANIFEST)
+    assert result.decision != Decision.BLOCK

--- a/tests/scoring/test_scoring_version_consistency.py
+++ b/tests/scoring/test_scoring_version_consistency.py
@@ -1,0 +1,82 @@
+"""Regression guard: the explanation payload's ``scoring_version`` must always
+match the canonical ``ScoringEngine.VERSION``.
+
+Background (PR-1, scoring hygiene): ``explain.py`` used to hardcode a default of
+``"2.0.0"`` while the engine was on ``"2.1.0"``. That default surfaced on any
+path that built an explanation without explicitly passing a version (e.g.
+``get_ui_explanation``), so the emitted metadata could silently drift behind the
+engine. The defaults now resolve from ``ScoringEngine.VERSION``.
+
+These tests fail if someone reintroduces a hardcoded/stale default. They assert
+metadata only — no score, verdict, weight, threshold, or golden snapshot is
+touched.
+"""
+
+from extension_shield.scoring.engine import ScoringEngine
+from extension_shield.scoring.explain import (
+    ExplanationBuilder,
+    ExplanationPayload,
+    build_explanation,
+    _current_scoring_version,
+)
+
+
+def _minimal_explanation_dict():
+    """Build an explanation via the real emission path with empty inputs."""
+    payload = ExplanationBuilder().build(
+        security_factors=[],
+        privacy_factors=[],
+        governance_factors=[],
+        gate_results=[],
+        layer_scores={"security": 100, "privacy": 100, "governance": 100},
+        decision="ALLOW",
+        reasons=["All checks passed"],
+    )
+    return payload.to_dict()
+
+
+def test_helper_resolves_to_engine_version():
+    assert _current_scoring_version() == ScoringEngine.VERSION
+
+
+def test_builder_default_scoring_version_tracks_engine():
+    # The stale hardcode ("2.0.0") must not come back as a default.
+    assert ExplanationBuilder().scoring_version == ScoringEngine.VERSION
+    assert ExplanationBuilder().scoring_version != "2.0.0"
+
+
+def test_payload_default_scoring_version_tracks_engine():
+    payload = ExplanationPayload(
+        scan_id="s",
+        extension_id="e",
+        overall_score=100,
+        decision="ALLOW",
+        decision_rationale="",
+    )
+    assert payload.scoring_version == ScoringEngine.VERSION
+    assert payload.to_dict()["scoring_version"] == ScoringEngine.VERSION
+
+
+def test_emitted_explanation_metadata_matches_engine_version():
+    assert _minimal_explanation_dict()["scoring_version"] == ScoringEngine.VERSION
+
+
+def test_build_explanation_convenience_default_tracks_engine():
+    # A minimal ScoringResult routed through the convenience function with no
+    # explicit version must still emit the engine version.
+    result = ScoringEngine().calculate_scores(_make_min_pack())
+    payload = build_explanation(result, gate_results=[])
+    assert payload.to_dict()["scoring_version"] == ScoringEngine.VERSION
+
+
+def test_explicit_version_override_is_still_honored():
+    # Engine passes scoring_version=self.VERSION explicitly; that path must be
+    # unaffected by the default change.
+    assert ExplanationBuilder(scoring_version="9.9.9").scoring_version == "9.9.9"
+
+
+def _make_min_pack():
+    # Local import to keep the module importable even if test utils move.
+    from tests.scoring.utils import make_min_signal_pack
+
+    return make_min_signal_pack()


### PR DESCRIPTION
- Fixes scoring_version metadata drift in explain.py by sourcing the current engine version lazily.
- Adds regression tests so scoring explanation version cannot drift again.
- Adds no-double-count guardrail tests for future backend scoring cleanup.
- Adds ADR documenting current scoring ownership and future migration rules.
- No scoring weights, thresholds, gates, rulepacks, analyzers, verdicts, golden snapshots, frontend files, or DB migrations changed.
- Tests: 166 passed, 0 failed.