### PR TITLE
fix(scoring): count privacy policy absence once

### DIFF
--- a/docs/adr/0002-scoring-layer-ownership.md
+++ b/docs/adr/0002-scoring-layer-ownership.md
@@ -16,10 +16,14 @@ to explain and tune:
    `scoring/weights.py:26-28` — 30% of the Security layer is
    reputation/context, not direct technical-security evidence.
 2. **A few signals are counted in more than one place** (duplicate-risk):
-   - **privacy-policy** absence is scored in `Webstore` (Security,
-     `normalizers.py:587-589`) *and* `DisclosureAlignment` (Governance,
-     `engine.py:695-706`), and is also a governance rulepack concern
-     (`CWS_LIMITED_USE.yaml`).
+   - **privacy-policy** absence — **RESOLVED in PR-2 (scoring_version 2.1.1).**
+     Was scored in `Webstore` (Security) *and* `DisclosureAlignment` (Governance).
+     `normalize_webstore_trust` (`normalizers.py`) no longer adds severity for a
+     missing privacy policy; `DisclosureAlignment` (`engine.py`) is now the sole
+     scored owner. Webstore retains `no_privacy_policy` as listing context only.
+     The `SENSITIVE_EXFIL` gate and the governance rulepacks still read the raw
+     `has_privacy_policy` field independently — that is a separate hard-gate /
+     policy concern (factor-vs-gate), unchanged here and tracked for PR-3.
    - **broad-host access** contributes to `Manifest` posture, `PermissionCombos`,
      `NetworkExfil`, the governance factors, and the `SENSITIVE_EXFIL` gate.
    - **purpose-mismatch**, **exfil**, and **ToS/policy** are each represented by
@@ -114,7 +118,10 @@ analyzer, or golden-snapshot change:
 
 ## Follow-up PR sequence (planned)
 
-1. **PR-2** — privacy-policy counted once (`DisclosureAlignment` owns it).
+1. **PR-2 — DONE (scoring_version 2.1.1)** — privacy-policy counted once
+   (`DisclosureAlignment` owns it). Removed the `Webstore` severity contribution
+   for a missing privacy policy; kept it as listing context/evidence. Golden
+   snapshots unchanged (they read static fixture values, not live scoring).
 2. **PR-3** — de-duplicate broad-host / purpose-mismatch / exfil / ToS
    (factor-vs-gate) so the same evidence is not double-penalized.
 3. **PR-4** — optional Security internal rebalance (`weights_version` bump).

--- a/src/extension_shield/scoring/engine.py
+++ b/src/extension_shield/scoring/engine.py
@@ -103,7 +103,10 @@ class ScoringEngine:
     # permission gate rework). Rows stamped with an older version are treated as
     # model_stale so they are re-scored on read and rescanned on trigger, instead
     # of serving pre-recalibration verdicts.
-    VERSION = "2.1.0"
+    # Bumped 2.1.0 -> 2.1.1: privacy-policy absence is no longer scored by the
+    # Security/Webstore factor (it was a double-count); Governance/DisclosureAlignment
+    # is now the sole scored owner. See docs/adr/0002-scoring-layer-ownership.md.
+    VERSION = "2.1.1"
     
     def __init__(
         self,

--- a/src/extension_shield/scoring/normalizers.py
+++ b/src/extension_shield/scoring/normalizers.py
@@ -536,14 +536,17 @@ def normalize_webstore_trust(stats: WebstoreStatsSignalPack) -> FactorScore:
           tools have small user bases. Low user count alone should never
           significantly impact the score.
         - Rating quality matters more than popularity.
-        - Missing privacy policy is a concrete compliance gap.
+        - Missing privacy policy is a disclosure/compliance concern that is scored
+          by Governance/DisclosureAlignment; Webstore surfaces it as listing
+          context only (see docs/adr/0002-scoring-layer-ownership.md).
         - Severity from user count is capped low and affects CONFIDENCE
           (less community vetting) rather than implying the extension is dangerous.
 
     Formula:
         - Low rating (<3.0) → higher severity (objective quality signal)
         - Very low users (<50) → minor severity bump (less vetting, not inherently risky)
-        - Missing privacy policy → +0.15
+        - Missing privacy policy → listing context only, no severity (owned by
+          Governance/DisclosureAlignment)
         - confidence = lower when less community data available
 
     Args:
@@ -583,9 +586,12 @@ def normalize_webstore_trust(stats: WebstoreStatsSignalPack) -> FactorScore:
         severity += 0.05  # Unknown user count
         issues.append("unknown_users")
 
-    # Privacy policy check — concrete compliance gap
+    # Privacy-policy absence is a GOVERNANCE / disclosure concern and is scored
+    # solely by Governance/DisclosureAlignment (engine._compute_governance_factors)
+    # as of scoring_version 2.1.1 — see docs/adr/0002-scoring-layer-ownership.md.
+    # Webstore keeps it as listing context/evidence only; it no longer contributes
+    # to the Security/Webstore severity (previously a double-count).
     if not stats.has_privacy_policy:
-        severity += 0.15
         issues.append("no_privacy_policy")
 
     # Cap at 1.0

--- a/tests/scoring/test_no_double_count.py
+++ b/tests/scoring/test_no_double_count.py
@@ -56,28 +56,49 @@ def _all_factor_names(result):
 # Duplicate-risk trackers (current state; flip when a single owner is chosen)
 # ---------------------------------------------------------------------------
 
-def test_tracker_privacy_policy_scored_in_security_and_governance():
-    """TRACKING: privacy-policy absence is scored in two layers today.
+def test_privacy_policy_scored_only_by_governance_disclosure():
+    """PR-2 (DONE): Governance/DisclosureAlignment is the SOLE scored owner of
+    privacy-policy absence (scoring_version 2.1.1, ADR 0002).
 
-    PR-2/PR-3 will make Governance/DisclosureAlignment the single scored owner
-    and drop the Security/Webstore contribution. When that lands, the Webstore
-    assertion flips — update this tracker and the ADR then.
+    The Security/Webstore factor no longer adds severity for a missing privacy
+    policy — it may still surface ``no_privacy_policy`` as listing context. This
+    is a permanent regression guard: it fails if the Webstore double-count is
+    reintroduced, or if DisclosureAlignment stops scoring it.
     """
-    pack = make_min_signal_pack()
-    pack.webstore_stats = WebstoreStatsSignalPack(
-        has_privacy_policy=False, rating_avg=4.5, installs=100_000, last_updated="June 1, 2026"
+    from extension_shield.scoring.normalizers import normalize_webstore_trust
+
+    def _webstore(has_pp):
+        # Identical listing (clean rating/installs) apart from privacy policy, so
+        # any severity delta can only come from privacy-policy scoring.
+        return WebstoreStatsSignalPack(
+            has_privacy_policy=has_pp, rating_avg=4.5, installs=100_000,
+            last_updated="June 1, 2026",
+        )
+
+    sev_with_pp = normalize_webstore_trust(_webstore(True)).severity
+    sev_without_pp = normalize_webstore_trust(_webstore(False)).severity
+
+    # Webstore must NOT score privacy-policy absence: severity is unchanged.
+    assert sev_without_pp == sev_with_pp, (
+        "Webstore/Security must not add severity for a missing privacy policy "
+        "(owned by Governance/DisclosureAlignment)"
     )
+
+    # ...but it may still carry the flag as listing context/evidence (kept intact).
+    webstore_no_pp = normalize_webstore_trust(_webstore(False))
+    assert "no_privacy_policy" in webstore_no_pp.flags
+    assert webstore_no_pp.details.get("has_privacy_policy") is False
+
+    # Governance/DisclosureAlignment IS the sole scored owner (with data collection).
+    pack = make_min_signal_pack()
+    pack.webstore_stats = _webstore(False)
     pack.permissions = PermissionsSignalPack(
         api_permissions=["cookies"], high_risk_permissions=["cookies"], total_permissions=1
     )
     result = ScoringEngine().calculate_scores(pack, manifest=MV3_MANIFEST)
-    sec = _factors_by_name(result.security_layer)
     gov = _factors_by_name(result.governance_layer)
-
-    # Security/Webstore scores privacy-policy absence today (to be removed later).
-    assert "no_privacy_policy" in sec["Webstore"].flags
-    # Governance/DisclosureAlignment ALSO scores it today (the intended owner).
     assert any("no_privacy_policy" in flag for flag in gov["DisclosureAlignment"].flags)
+    assert gov["DisclosureAlignment"].severity > 0
 
 
 def test_tracker_broad_host_counted_in_security_and_privacy():


### PR DESCRIPTION
PR-2 removes the privacy-policy double count.

Missing privacy policy is now scored only by Governance / DisclosureAlignment, not also by Security / Webstore.

Changed:
- Removed no_privacy_policy severity from Webstore
- Kept privacy-policy info as Webstore context/evidence
- Left DisclosureAlignment scoring unchanged
- Bumped ScoringEngine.VERSION (2.1.0 -> 2.1.1)
- Updated ADR 0002 and no-double-count tests

Not changed:
No weights, gates, rulepacks, frontend, decision.py, or broad-host/exfil/ToS cleanup.

Tests: 489 passed, 0 failed (tests/scoring/, tests/governance/, tests/api/, tests/test_golden_snapshots.py, tests/test_scoring_gates.py, tests/test_verdict_risk.py, tests/test_scoring_recompute_consistency.py, tests/test_trust_contract.py, tests/test_report_view_model_governance_verdict.py, tests/test_report_view_model_verdict_copy.py, tests/test_layer_details_validators.py, tests/test_purpose_mismatch_calibration.py). Golden snapshots unchanged (they read static fixture values, not live scoring).