### PR TITLE
fix(scoring): count broad-host access once

### DIFF
--- a/docs/adr/0002-scoring-layer-ownership.md
+++ b/docs/adr/0002-scoring-layer-ownership.md
@@ -24,8 +24,23 @@ to explain and tune:
      The `SENSITIVE_EXFIL` gate and the governance rulepacks still read the raw
      `has_privacy_policy` field independently — that is a separate hard-gate /
      policy concern (factor-vs-gate), unchanged here and tracked for PR-3.
-   - **broad-host access** contributes to `Manifest` posture, `PermissionCombos`,
-     `NetworkExfil`, the governance factors, and the `SENSITIVE_EXFIL` gate.
+   - **broad-host access** — bare-capability double-count **RESOLVED in PR-3a
+     (scoring_version 2.1.2).** Was scored unconditionally by both `Manifest`
+     posture (Security) *and* `PermissionCombos` (Privacy). `normalize_manifest_posture`
+     no longer adds severity for bare broad-host; `PermissionCombos` is now the
+     sole scored owner. Manifest retains `broad_host_access` as manifest context.
+     The **compound** broad-host uses are intentionally distinct AND-conditions and
+     remain unchanged: `ToSViolations` (broad-host **+ VT malicious**), `CaptureSignals`
+     (broad-host **+ capture perm**), `NetworkExfil` (exfil risk **when analysis
+     ran**), `DisclosureAlignment` (broad-host **+ no privacy policy**). Gates
+     (`PURPOSE_MISMATCH`, `SENSITIVE_EXFIL`) read the raw `has_broad_host_access`
+     field independently of any factor and are unchanged.
+     *Second-order note:* removing the Manifest severity means a benign-named
+     extension (e.g. "New Tab") with broad-host + missing CSP and no other
+     high-severity signal no longer crosses the Governance/`Consistency`
+     `has_high_security_risk` (> 0.5) boundary, so its `benign_claim_risky_behavior`
+     flag no longer fires via the Manifest path. Expected and acceptable — broad-host
+     is still scored once (PermissionCombos); no test-corpus verdict changed.
    - **purpose-mismatch**, **exfil**, and **ToS/policy** are each represented by
      both a scoring factor (`Consistency` / `NetworkExfil` / `ToSViolations`) and
      a hard gate (`PURPOSE_MISMATCH` / `SENSITIVE_EXFIL` / `TOS_VIOLATION`).
@@ -122,8 +137,14 @@ analyzer, or golden-snapshot change:
    (`DisclosureAlignment` owns it). Removed the `Webstore` severity contribution
    for a missing privacy policy; kept it as listing context/evidence. Golden
    snapshots unchanged (they read static fixture values, not live scoring).
-2. **PR-3** — de-duplicate broad-host / purpose-mismatch / exfil / ToS
-   (factor-vs-gate) so the same evidence is not double-penalized.
+2. **PR-3a — DONE (scoring_version 2.1.2)** — broad-host counted once
+   (`PermissionCombos` owns the bare-capability signal). Removed the unconditional
+   `Manifest` severity contribution; kept it as manifest context. Compound
+   broad-host uses left intentionally separate. Golden snapshots unchanged.
+   - **PR-3b (deferred)** — purpose-mismatch / exfil / ToS factor-vs-gate: these
+     are graduated by design (small soft factor + large corroboration-gated hard
+     gate), **not** naive duplicates. Requires a case-by-case audit and, for any
+     gate-trigger change, a labeled corpus — deferred, not folded into PR-3a.
 3. **PR-4** — optional Security internal rebalance (`weights_version` bump).
 4. **PR-5** — reputation-as-modifier + layer re-weight, gated on a labeled
    benign/malicious/review corpus (`weights_version` + `scoring_version`, golden

--- a/src/extension_shield/scoring/engine.py
+++ b/src/extension_shield/scoring/engine.py
@@ -106,7 +106,12 @@ class ScoringEngine:
     # Bumped 2.1.0 -> 2.1.1: privacy-policy absence is no longer scored by the
     # Security/Webstore factor (it was a double-count); Governance/DisclosureAlignment
     # is now the sole scored owner. See docs/adr/0002-scoring-layer-ownership.md.
-    VERSION = "2.1.1"
+    # Bumped 2.1.1 -> 2.1.2: bare broad-host access is no longer scored by the
+    # Security/Manifest factor (it was an unconditional double-count);
+    # Privacy/PermissionCombos is now the sole scored owner. Compound broad-host
+    # uses (ToSViolations+VT, CaptureSignals, NetworkExfil, DisclosureAlignment)
+    # are unchanged. See docs/adr/0002-scoring-layer-ownership.md.
+    VERSION = "2.1.2"
     
     def __init__(
         self,

--- a/src/extension_shield/scoring/normalizers.py
+++ b/src/extension_shield/scoring/normalizers.py
@@ -426,7 +426,8 @@ def normalize_manifest_posture(
     Formula:
         - Missing CSP → +0.3
         - MV2 legacy → +0.2
-        - Broad host permissions → +0.3
+        - Broad host permissions → manifest context only, no severity (scored by
+          Privacy/PermissionCombos; see docs/adr/0002-scoring-layer-ownership.md)
         - Cap severity at 1.0
         - confidence = 1.0 if manifest parsed
     
@@ -452,9 +453,15 @@ def normalize_manifest_posture(
         severity += 0.2
         issues.append("mv2_legacy")
     
-    # Check for broad host permissions
+    # Broad host access is scored solely by Privacy/PermissionCombos
+    # (normalize_permission_combos) as of scoring_version 2.1.2 — see
+    # docs/adr/0002-scoring-layer-ownership.md. Manifest posture keeps it as
+    # manifest context/evidence only; it no longer contributes to the
+    # Security/Manifest severity (previously an unconditional double-count with
+    # PermissionCombos). Compound/conditional broad-host uses elsewhere
+    # (ToSViolations+VT, CaptureSignals+capture, NetworkExfil, DisclosureAlignment)
+    # are distinct AND-conditions and remain unchanged.
     if perms.has_broad_host_access:
-        severity += 0.3
         issues.append("broad_host_access")
     
     # Cap at 1.0

--- a/tests/scoring/test_no_double_count.py
+++ b/tests/scoring/test_no_double_count.py
@@ -101,28 +101,99 @@ def test_privacy_policy_scored_only_by_governance_disclosure():
     assert gov["DisclosureAlignment"].severity > 0
 
 
-def test_tracker_broad_host_counted_in_security_and_privacy():
-    """TRACKING: broad-host access is counted in two layers today.
-
-    PR-3 will choose one scored owner (Privacy/PermissionCombos) and demote the
-    others to evidence/gate-only. When that lands, the Manifest assertion flips.
-    """
-    pack = make_min_signal_pack()
-    pack.permissions = PermissionsSignalPack(
+def _broad_host_perms(**overrides):
+    kwargs = dict(
         api_permissions=["tabs"],
         host_permissions=["<all_urls>"],
         has_broad_host_access=True,
         broad_host_patterns=["<all_urls>"],
         total_permissions=1,
     )
-    result = ScoringEngine().calculate_scores(pack, manifest=MV3_MANIFEST)
-    sec = _factors_by_name(result.security_layer)
-    priv = _factors_by_name(result.privacy_layer)
+    kwargs.update(overrides)
+    return PermissionsSignalPack(**kwargs)
 
-    # Security/Manifest posture counts broad host today (to be demoted later).
-    assert "broad_host_access" in sec["Manifest"].flags
-    # Privacy/PermissionCombos ALSO counts broad host today (the intended owner).
-    assert "broad_host_access" in priv["PermissionCombos"].details.get("triggered_combos", [])
+
+def test_broad_host_scored_only_by_permission_combos():
+    """PR-3a (DONE): bare broad-host access is scored ONLY by
+    Privacy/PermissionCombos (scoring_version 2.1.2, ADR 0002).
+
+    The Security/Manifest posture factor no longer adds severity for bare
+    broad-host access — it may still surface ``broad_host_access`` as manifest
+    context. Permanent regression guard: fails if the Manifest double-count is
+    reintroduced, or if PermissionCombos stops scoring broad-host.
+    """
+    from extension_shield.scoring.normalizers import (
+        normalize_manifest_posture,
+        normalize_permission_combos,
+    )
+
+    broad = _broad_host_perms()
+    narrow = _broad_host_perms(host_permissions=[], has_broad_host_access=False,
+                               broad_host_patterns=[])
+
+    # Manifest posture must NOT score bare broad-host: severity unchanged.
+    sev_broad = normalize_manifest_posture({"manifest_version": 3}, broad).severity
+    sev_narrow = normalize_manifest_posture({"manifest_version": 3}, narrow).severity
+    assert sev_broad == sev_narrow, (
+        "Manifest/Security must not add severity for bare broad-host access "
+        "(owned by Privacy/PermissionCombos)"
+    )
+
+    # ...but Manifest keeps broad_host_access as context/evidence (kept intact).
+    manifest_broad = normalize_manifest_posture({"manifest_version": 3}, broad)
+    assert "broad_host_access" in manifest_broad.flags
+    assert manifest_broad.details.get("has_broad_host_access") is True
+
+    # Privacy/PermissionCombos IS the sole scored owner: broad-host adds severity.
+    combos = normalize_permission_combos(broad)
+    assert combos.severity > 0
+    assert "broad_host_access" in combos.details.get("triggered_combos", [])
+
+
+def test_broad_host_compound_uses_unchanged():
+    """PR-3a leaves the four COMPOUND (AND-conditioned) broad-host uses intact —
+    these are distinct behaviors, not duplicates of the bare-capability signal.
+    """
+    from extension_shield.scoring.normalizers import (
+        normalize_capture_signals,
+        normalize_network_exfil,
+    )
+    from extension_shield.governance.signal_pack import NetworkSignalPack
+
+    # (1) ToSViolations: broad-host + VirusTotal malicious detection (engine).
+    tos_pack = make_min_signal_pack()
+    tos_pack.permissions = _broad_host_perms()
+    tos_pack.virustotal = VirusTotalSignalPack(enabled=True, total_engines=70, malicious_count=3)
+    gov = _factors_by_name(
+        ScoringEngine().calculate_scores(tos_pack, manifest=MV3_MANIFEST).governance_layer
+    )
+    assert "broad_access_with_vt_detection" in gov["ToSViolations"].flags
+
+    # (2) CaptureSignals: capture permission + broad-host (normalizer). The
+    #     compound signal is recorded in details["capture_signals"].
+    capture = normalize_capture_signals(
+        _broad_host_perms(api_permissions=["tabCapture"]),
+        {"name": "Some Tool", "description": "does things"},
+    )
+    assert "capture_with_network" in capture.details.get("capture_signals", [])
+    assert capture.details.get("has_network_access") is True
+
+    # (3) NetworkExfil: broad-host contributes base exfil risk when analysis ran.
+    net = normalize_network_exfil(
+        NetworkSignalPack(enabled=True, confidence=0.9), _broad_host_perms()
+    )
+    assert net.details.get("has_network_permissions") is True
+    assert net.severity > 0
+
+    # (4) DisclosureAlignment: broad-host as governance qualifier when no privacy
+    #     policy and no direct data-collection perms (engine, elif has_network).
+    disc_pack = make_min_signal_pack()
+    disc_pack.webstore_stats = WebstoreStatsSignalPack(has_privacy_policy=False)
+    disc_pack.permissions = _broad_host_perms(high_risk_permissions=[])
+    gov2 = _factors_by_name(
+        ScoringEngine().calculate_scores(disc_pack, manifest=MV3_MANIFEST).governance_layer
+    )
+    assert "no_privacy_policy_with_network" in gov2["DisclosureAlignment"].flags
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
PR-3a removes the unconditional broad-host double count.

Bare broad-host access is now scored only by Privacy / PermissionCombos, not also by Security / Manifest.

Changed:
- Removed bare has_broad_host_access severity from Manifest
- Kept broad-host Manifest details/evidence as context
- Left PermissionCombos broad-host scoring unchanged
- Preserved compound broad-host uses in ToS, CaptureSignals, NetworkExfil, and DisclosureAlignment
- Bumped ScoringEngine.VERSION to 2.1.2
- Updated ADR 0002 and no-double-count tests

Not changed:
No weights, gates, rulepacks, frontend, decision.py, purpose-mismatch, exfil, or ToS logic changed.

Tests:
507 passed, 0 failed.

Note:
A second-order Consistency boundary change was observed for broad-host + missing-CSP cases, but no final verdict changed.