### PR TITLE
fix(scoring): document factor-gate layering and count ToS permissions once

### DIFF
--- a/docs/adr/0002-scoring-layer-ownership.md
+++ b/docs/adr/0002-scoring-layer-ownership.md
@@ -106,13 +106,15 @@ tests **before** any recalibration is the OSS-safe order.
   version differs, so a version bump is the migration mechanism; a revert of the
   version constants is the rollback.
 
-### 4. Factor-vs-gate audit outcomes (PR-3b — docs/tests only)
+### 4. Factor-vs-gate audit outcomes (PR-3b docs/tests + PR-3c dedup)
 
-PR-3b is documentation + regression guardrails only. It changes **no** scoring
-formula, weight, gate, threshold, rulepack, or `ScoringEngine.VERSION`. It closes
-two of the three factor-vs-gate items from §2 by proving, at the code level, that
-the factor and the gate consume **disjoint evidence** — a graded soft signal plus
-a hard, corroboration-gated stop — rather than double-penalizing the same input.
+PR-3b (docs/tests only — no scoring formula, weight, gate, threshold, rulepack,
+or `ScoringEngine.VERSION` change) closed two of the three factor-vs-gate items
+from §2 by proving, at the code level, that the factor and the gate consume
+**disjoint evidence** — a graded soft signal plus a hard, corroboration-gated
+stop — rather than double-penalizing the same input. PR-3c then resolved the
+third (ToS bare prohibited-permission), the one genuine narrow duplicate,
+bumping `ScoringEngine.VERSION` to `2.1.3`.
 
 - **purpose-mismatch — AUDITED: intentionally layered, not a duplicate.**
   The `Consistency` factor (`engine.py` `_compute_governance_factors`, ~594-696)
@@ -143,14 +145,33 @@ a hard, corroboration-gated stop — rather than double-penalizing the same inpu
   `test_sensitive_exfil_gate_and_network_factor_use_disjoint_evidence` and the
   WARN-only invariant `test_sensitive_exfil_gate_is_structurally_warn_only`.
 
-- **ToS bare prohibited-permission declaration — STILL OPEN, deferred to PR-3c.**
-  `ToSViolations` (`engine.py`) and the `TOS_VIOLATION` gate (`gates.py`) both key
-  a contribution off the **identical** `{"debugger", "proxy", "nativeMessaging"}`
-  set for a *bare declaration* (no corroborating evidence). This is a genuine
-  narrow duplicate and is **not** resolved here — its tracker test (the
-  `("ToSViolations", "TOS_VIOLATION")` case of
-  `test_tracker_concept_represented_by_both_factor_and_gate`) is left
-  **unchanged** so PR-3c converts it deliberately.
+- **ToS bare prohibited-permission declaration — RESOLVED in PR-3c
+  (scoring_version 2.1.3).** `ToSViolations` (`engine.py`
+  `_compute_governance_factors`, ~599-606) and the `TOS_VIOLATION` gate
+  (`gates.py` `evaluate_tos_violation`, 607-847) both keyed a contribution off
+  the **identical** `{"debugger", "proxy", "nativeMessaging"}` set for a *bare
+  declaration* (no corroborating evidence) — a genuine narrow duplicate.
+  `ToSViolations` no longer adds severity (`tos_severity += 0.5 * ...`) for a
+  bare declaration; it still emits `prohibited_perm:{perm}` in `flags` and
+  `details["violations"]` as evidence/context (unchanged emission shape). The
+  **`TOS_VIOLATION` gate is untouched and is now the sole scored/decision
+  owner**: a bare declaration still WARNs, and an aggravated declaration
+  (`externally_connectable` wildcard, or SAST evidence tied to the specific
+  restricted capability) still BLOCKs — no gate-trigger, threshold, or penalty
+  logic changed. The compound `ToSViolations` use (broad-host **+ VT
+  malicious**) and the **travel-docs/visa-portal heuristic** are both untouched
+  and still contribute severity — only the bare-permission branch was touched.
+  Locked by `test_tos_bare_prohibited_permission_scored_only_by_gate`,
+  `test_tos_gate_still_blocks_aggravated_prohibited_permission`, and
+  `test_tos_broad_host_vt_and_travel_docs_heuristics_unchanged_by_pr_3c`.
+  Verified score/verdict impact (live before/after `calculate_scores()`
+  comparison, not golden snapshots): a bare single prohibited permission with
+  full analyzer coverage moves `governance_score` 49→75 and `overall_score`
+  77→85; the worst case (all three prohibited permissions) moves
+  `governance_score` 23→75 and `overall_score` 63→80 — in every probed case the
+  final `decision` stayed `NEEDS_REVIEW`, because the still-triggered
+  `TOS_VIOLATION` WARN gate forces review via the warning-gates path in
+  `decision.resolve()` independent of score. No verdict flip observed.
 
 - **travel-docs / visa-portal heuristic — OUT OF SCOPE, already tracked.**
   The travel-docs automation signal is represented in three places (the
@@ -200,12 +221,17 @@ analyzer, or golden-snapshot change:
      see §4), now locked by real guardrail tests in
      `tests/scoring/test_no_double_count.py`. `SENSITIVE_EXFIL` is documented and
      tested as structurally WARN-only. No scoring formula changed.
-   - **PR-3c (planned)** — resolve the **ToS bare prohibited-permission**
-     duplicate: `{"debugger", "proxy", "nativeMessaging"}` is scored by both
-     `ToSViolations` and the `TOS_VIOLATION` gate for a bare declaration. Converts
-     the remaining tracker test. If it changes any gate-trigger or scored
-     contribution it bumps `scoring_version` (and `DECISION_VERSION` if precedence
-     or rulepack semantics change), with a golden-snapshot regen.
+   - **PR-3c — DONE (scoring_version 2.1.3)** — ToS bare prohibited-permission
+     counted once (`TOS_VIOLATION` gate owns it). Removed the `ToSViolations`
+     severity contribution (`tos_severity += 0.5 * len(found_prohibited)`) for a
+     bare `debugger`/`proxy`/`nativeMessaging` declaration; kept
+     `prohibited_perm:{perm}` as evidence/context. `gates.py` is byte-unchanged —
+     the `TOS_VIOLATION` gate's WARN (bare) / BLOCK (aggravated) behavior and
+     penalties are identical. Compound ToS use (broad-host + VT malicious) and
+     the travel-docs/visa-portal heuristic are unchanged. `DECISION_VERSION` not
+     bumped (no precedence/rulepack change). Golden snapshots unchanged (read
+     static fixture values). Live before/after scoring comparison showed no
+     verdict flip (see §4).
 3. **PR-4** — optional Security internal rebalance (`weights_version` bump).
 4. **PR-5** — reputation-as-modifier + layer re-weight, gated on a labeled
    benign/malicious/review corpus (`weights_version` + `scoring_version`, golden

--- a/docs/adr/0002-scoring-layer-ownership.md
+++ b/docs/adr/0002-scoring-layer-ownership.md
@@ -106,6 +106,59 @@ tests **before** any recalibration is the OSS-safe order.
   version differs, so a version bump is the migration mechanism; a revert of the
   version constants is the rollback.
 
+### 4. Factor-vs-gate audit outcomes (PR-3b — docs/tests only)
+
+PR-3b is documentation + regression guardrails only. It changes **no** scoring
+formula, weight, gate, threshold, rulepack, or `ScoringEngine.VERSION`. It closes
+two of the three factor-vs-gate items from §2 by proving, at the code level, that
+the factor and the gate consume **disjoint evidence** — a graded soft signal plus
+a hard, corroboration-gated stop — rather than double-penalizing the same input.
+
+- **purpose-mismatch — AUDITED: intentionally layered, not a duplicate.**
+  The `Consistency` factor (`engine.py` `_compute_governance_factors`, ~594-696)
+  fires only on an **indirect aggregate**: a benign purpose claim
+  (theme/color/font/wallpaper/new tab) combined with any security/privacy factor
+  severity `> 0.5`, or an `"offline"` claim plus broad-host. Its only flags are
+  `benign_claim_risky_behavior` and `offline_claim_network_access`; it never
+  inspects SAST behavior. The `PURPOSE_MISMATCH` gate (`gates.py`
+  `evaluate_purpose_mismatch`, 919-1107) BLOCKs only on **direct, SAST-classified
+  behavior** — `remote_code`, `secret_read`+`exfil`, `key_capture`+`exfil`, or a
+  corroborated `standalone_dangerous` behavior — classified by the concrete
+  rule-suffix taxonomy (`_PM_*`, 252-288), never by keywords. The evidence sets
+  are disjoint: a remote-code BLOCK leaves `Consistency` at severity 0 with no
+  SAST-derived flag. Locked by
+  `test_purpose_mismatch_gate_and_consistency_factor_use_disjoint_evidence`.
+
+- **exfiltration — AUDITED: intentionally layered, not a duplicate.**
+  The `NetworkExfil` factor (`normalizers.py` `normalize_network_exfil`,
+  ~825-950) is driven by `NetworkSignalPack` domain/pattern analysis and returns
+  **severity `0.0` whenever `network.enabled` is False** (early return,
+  ~849-865). The `SENSITIVE_EXFIL` gate (`gates.py` `evaluate_sensitive_exfil`,
+  1113-1233) is driven by a **permission count + coarse SAST text-regex +
+  privacy-policy absence** (2+ risk factors → WARN), and is **structurally
+  WARN-only by design**: its `decision` is the literal `"WARN"` (~line 1205) with
+  no `BLOCK` path in the function. The only shared input is the `has_network`
+  boolean; every other input is disjoint. A WARN with network analysis off leaves
+  `NetworkExfil` at severity `0.0`. Locked by
+  `test_sensitive_exfil_gate_and_network_factor_use_disjoint_evidence` and the
+  WARN-only invariant `test_sensitive_exfil_gate_is_structurally_warn_only`.
+
+- **ToS bare prohibited-permission declaration — STILL OPEN, deferred to PR-3c.**
+  `ToSViolations` (`engine.py`) and the `TOS_VIOLATION` gate (`gates.py`) both key
+  a contribution off the **identical** `{"debugger", "proxy", "nativeMessaging"}`
+  set for a *bare declaration* (no corroborating evidence). This is a genuine
+  narrow duplicate and is **not** resolved here — its tracker test (the
+  `("ToSViolations", "TOS_VIOLATION")` case of
+  `test_tracker_concept_represented_by_both_factor_and_gate`) is left
+  **unchanged** so PR-3c converts it deliberately.
+
+- **travel-docs / visa-portal heuristic — OUT OF SCOPE, already tracked.**
+  The travel-docs automation signal is represented in three places (the
+  `ToSViolations` factor heuristic, a `TOS_VIOLATION` gate backstop, and the
+  `PROTECTED_SERVICE_AUTOMATION` rulepack). That triplication and its
+  gate-comment retirement plan are tracked under **ADR 0001** and are **not**
+  touched by PR-3b or PR-3c.
+
 ## Scope of this PR (PR-1)
 
 Hygiene only — **no** score, verdict, weight, threshold, gate, rulepack,
@@ -141,10 +194,18 @@ analyzer, or golden-snapshot change:
    (`PermissionCombos` owns the bare-capability signal). Removed the unconditional
    `Manifest` severity contribution; kept it as manifest context. Compound
    broad-host uses left intentionally separate. Golden snapshots unchanged.
-   - **PR-3b (deferred)** — purpose-mismatch / exfil / ToS factor-vs-gate: these
-     are graduated by design (small soft factor + large corroboration-gated hard
-     gate), **not** naive duplicates. Requires a case-by-case audit and, for any
-     gate-trigger change, a labeled corpus — deferred, not folded into PR-3a.
+   - **PR-3b — DONE (docs/tests only, no version bump)** — factor-vs-gate audit
+     for **purpose-mismatch** and **exfil**: both proven intentionally layered on
+     disjoint evidence (soft aggregate factor vs. hard corroboration-gated gate,
+     see §4), now locked by real guardrail tests in
+     `tests/scoring/test_no_double_count.py`. `SENSITIVE_EXFIL` is documented and
+     tested as structurally WARN-only. No scoring formula changed.
+   - **PR-3c (planned)** — resolve the **ToS bare prohibited-permission**
+     duplicate: `{"debugger", "proxy", "nativeMessaging"}` is scored by both
+     `ToSViolations` and the `TOS_VIOLATION` gate for a bare declaration. Converts
+     the remaining tracker test. If it changes any gate-trigger or scored
+     contribution it bumps `scoring_version` (and `DECISION_VERSION` if precedence
+     or rulepack semantics change), with a golden-snapshot regen.
 3. **PR-4** — optional Security internal rebalance (`weights_version` bump).
 4. **PR-5** — reputation-as-modifier + layer re-weight, gated on a labeled
    benign/malicious/review corpus (`weights_version` + `scoring_version`, golden

--- a/src/extension_shield/scoring/engine.py
+++ b/src/extension_shield/scoring/engine.py
@@ -111,7 +111,14 @@ class ScoringEngine:
     # Privacy/PermissionCombos is now the sole scored owner. Compound broad-host
     # uses (ToSViolations+VT, CaptureSignals, NetworkExfil, DisclosureAlignment)
     # are unchanged. See docs/adr/0002-scoring-layer-ownership.md.
-    VERSION = "2.1.2"
+    # Bumped 2.1.2 -> 2.1.3: bare ToS prohibited-permission declaration
+    # (debugger/proxy/nativeMessaging) is no longer scored by the
+    # Governance/ToSViolations factor (it was a double-count with the
+    # TOS_VIOLATION gate, which is unchanged and remains the sole WARN/BLOCK
+    # authority for this signal); the factor still emits prohibited_perm:{perm}
+    # as evidence/context. Compound ToS use (broad-host + VT malicious) and the
+    # travel-docs/visa heuristic are unchanged. See docs/adr/0002-scoring-layer-ownership.md.
+    VERSION = "2.1.3"
     
     def __init__(
         self,
@@ -596,11 +603,14 @@ class ScoringEngine:
         tos_severity = 0.0
         tos_flags: List[str] = []
         
-        # Check for prohibited permissions (from gate logic)
+        # Check for prohibited permissions (from gate logic). Bare declaration is
+        # evidence/context only here — the TOS_VIOLATION gate (gates.py) is the
+        # sole scored owner of this WARN/BLOCK signal, so this factor must not
+        # double-penalize the same raw permission set. See ADR 0002 (PR-3c,
+        # scoring_version 2.1.3): flags are kept for evidence, severity is not.
         prohibited = {"debugger", "proxy", "nativeMessaging"}
         found_prohibited = prohibited.intersection(set(signal_pack.permissions.api_permissions))
         if found_prohibited:
-            tos_severity += 0.5 * len(found_prohibited)
             tos_flags.extend([f"prohibited_perm:{p}" for p in found_prohibited])
         
         # Check for concerning permission combinations

--- a/tests/scoring/test_no_double_count.py
+++ b/tests/scoring/test_no_double_count.py
@@ -1,31 +1,32 @@
-"""No-double-count guardrails (PR-1 tracking + one hard invariant).
+"""No-double-count guardrails (PR-1 through PR-3c + one hard invariant).
 
-These tests DO NOT change scoring behavior. They pin the *current* state of the
-known duplicate-risk areas surfaced by the backend scoring audit so that the
-future de-duplication PRs (PR-2/PR-3) are forced to update them deliberately,
-and they enforce the one invariant that must hold in every version:
+These tests DO NOT change scoring behavior. They lock in the de-duplication
+outcomes of the backend scoring audit (PR-1 through PR-3c) as permanent
+regression guards, and they enforce the one invariant that must hold in every
+version:
 
     reputation / maintenance context can never, by itself, produce a BLOCK.
 
-Duplicate-risk trackers (documented, not yet fixed — see
-docs/adr/0002-scoring-layer-ownership.md):
+Duplicate-risk areas (see docs/adr/0002-scoring-layer-ownership.md):
 
   * privacy-policy absence is scored in BOTH Security (Webstore) and Governance
     (DisclosureAlignment).
   * broad-host access is counted in BOTH Security (Manifest posture) and Privacy
     (PermissionCombos).
-  * ToS bare prohibited-permission declaration is represented by BOTH a scoring
-    factor (ToSViolations) and a hard gate (TOS_VIOLATION) — the one remaining
-    open duplicate, deferred to PR-3c. (purpose-mismatch and exfil were audited
-    in PR-3b as intentionally layered on DISJOINT evidence — a soft aggregate
-    factor vs. a hard, corroboration-gated gate — and are now locked by the
-    guardrail tests below, not trackers.)
+  * ToS bare prohibited-permission declaration — **RESOLVED in PR-3c
+    (scoring_version 2.1.3).** Was represented by BOTH a scoring factor
+    (ToSViolations) and a hard gate (TOS_VIOLATION) for the identical
+    declaration. TOS_VIOLATION is now the sole scored/decision owner; see
+    `test_tos_bare_prohibited_permission_scored_only_by_gate` below.
+    (purpose-mismatch and exfil were audited in PR-3b as intentionally layered
+    on DISJOINT evidence — a soft aggregate factor vs. a hard,
+    corroboration-gated gate — and are locked by the guardrail tests below,
+    not trackers.)
 
-When a future PR consolidates an owner, the corresponding assertion below will
-flip — that is the intended signal to update the tracker (and the ADR).
+All three duplicate-risk trackers above are now resolved and locked by
+permanent regression tests: if a future PR reintroduces a double-count, the
+corresponding assertion below fails (see docs/adr/0002-scoring-layer-ownership.md).
 """
-
-import pytest
 
 from extension_shield.scoring.engine import ScoringEngine
 from extension_shield.scoring.gates import HardGates
@@ -37,6 +38,7 @@ from extension_shield.governance.signal_pack import (
     PermissionsSignalPack,
     SastSignalPack,
     VirusTotalSignalPack,
+    NetworkSignalPack,
 )
 from tests.scoring.utils import make_min_signal_pack, make_sast_finding
 
@@ -202,25 +204,110 @@ def test_broad_host_compound_uses_unchanged():
 
 # PR-3b audited purpose-mismatch and exfil as intentionally layered on disjoint
 # evidence (see the guardrail tests below and ADR 0002 §4). The ToS bare
-# prohibited-permission case remains a genuine narrow duplicate and stays a
-# tracker until PR-3c converts it — kept EXACTLY as-is here.
-@pytest.mark.parametrize(
-    "factor_name, gate_id",
-    [
-        ("ToSViolations", "TOS_VIOLATION"),   # ToS / policy — open duplicate, PR-3c
-    ],
-)
-def test_tracker_concept_represented_by_both_factor_and_gate(factor_name, gate_id):
-    """TRACKING: each concept is represented by BOTH a scoring factor and a gate.
+# prohibited-permission case was the one remaining genuine narrow duplicate and
+# is now resolved by PR-3c (scoring_version 2.1.3, ADR 0002) — the tracker is
+# converted into the permanent regression test below.
 
-    This is allowed by design (a graded factor + a hard-stop gate), but PR-3
-    must ensure the SAME piece of evidence is not double-penalized (factor
-    severity AND gate penalty) without explicit intent. This test documents the
-    dual representation; refine it when the de-dup design lands.
+
+def test_tos_bare_prohibited_permission_scored_only_by_gate():
+    """PR-3c (DONE): TOS_VIOLATION gate is the SOLE scored owner of a bare
+    debugger/proxy/nativeMessaging declaration (scoring_version 2.1.3, ADR 0002).
+
+    The Governance/ToSViolations factor no longer adds severity for a bare
+    prohibited-permission declaration — it still surfaces
+    ``prohibited_perm:{perm}`` as evidence/context. Permanent regression guard:
+    fails if the ToSViolations double-count is reintroduced, or if the
+    TOS_VIOLATION gate's WARN/BLOCK behavior for this signal changes.
     """
-    result = ScoringEngine().calculate_scores(make_min_signal_pack(), manifest=MV3_MANIFEST)
-    assert factor_name in _all_factor_names(result)
-    assert gate_id in HardGates.GATES
+    def _perms(prohibited):
+        return PermissionsSignalPack(api_permissions=list(prohibited), total_permissions=len(prohibited))
+
+    clean = _perms([])
+    bare = _perms(["debugger"])
+
+    # ToSViolations must NOT score a bare prohibited-permission declaration:
+    # severity is unchanged vs. no prohibited permission at all.
+    pack_clean = make_min_signal_pack()
+    pack_clean.permissions = clean
+    pack_bare = make_min_signal_pack()
+    pack_bare.permissions = bare
+
+    gov_clean = _factors_by_name(
+        ScoringEngine().calculate_scores(pack_clean, manifest=MV3_MANIFEST).governance_layer
+    )
+    gov_bare = _factors_by_name(
+        ScoringEngine().calculate_scores(pack_bare, manifest=MV3_MANIFEST).governance_layer
+    )
+    assert gov_bare["ToSViolations"].severity == gov_clean["ToSViolations"].severity == 0.0, (
+        "Governance/ToSViolations must not add severity for a bare prohibited-"
+        "permission declaration (owned by the TOS_VIOLATION gate)"
+    )
+
+    # ...but the factor keeps prohibited_perm:{perm} as evidence/context (kept intact).
+    assert "prohibited_perm:debugger" in gov_bare["ToSViolations"].flags
+    assert "prohibited_perm:debugger" in gov_bare["ToSViolations"].details.get("violations", [])
+
+    # TOS_VIOLATION gate IS the sole scored owner: bare declaration still WARNs
+    # (unaggravated — no externally_connectable wildcard, no capability evidence).
+    gate = HardGates().evaluate_tos_violation(
+        bare, SastSignalPack(), NetworkSignalPack(enabled=False, confidence=0.0), MV3_MANIFEST
+    )
+    assert gate.triggered is True
+    assert gate.decision == "WARN"
+    assert "debugger" in gate.details.get("prohibited_present", [])
+
+
+def test_tos_gate_still_blocks_aggravated_prohibited_permission():
+    """PR-3c leaves TOS_VIOLATION gate BLOCK escalation for an AGGRAVATED
+    prohibited-permission declaration unchanged — gates.py is untouched.
+
+    Aggravation here: externally_connectable exposes the extension to any
+    website (a web -> extension -> native/privileged bridge), which the gate
+    already treats as sufficient to escalate WARN -> BLOCK for a restricted
+    permission (gates.py, "Aggravator 1").
+    """
+    perms = PermissionsSignalPack(api_permissions=["nativeMessaging"], total_permissions=1)
+    manifest = {
+        **MV3_MANIFEST,
+        "externally_connectable": {"matches": ["<all_urls>"]},
+    }
+    gate = HardGates().evaluate_tos_violation(
+        perms, SastSignalPack(), NetworkSignalPack(enabled=False, confidence=0.0), manifest
+    )
+    assert gate.triggered is True
+    assert gate.decision == "BLOCK"
+
+
+def test_tos_broad_host_vt_and_travel_docs_heuristics_unchanged_by_pr_3c():
+    """PR-3c touches ONLY the bare prohibited-permission severity contribution.
+    The two OTHER ToSViolations severity sources — broad-host + VT malicious,
+    and the travel-docs/visa-portal heuristic — are untouched and still score.
+    """
+    # (1) broad-host + VT malicious detection (engine.py, unchanged compound use).
+    tos_pack = make_min_signal_pack()
+    tos_pack.permissions = _broad_host_perms()
+    tos_pack.virustotal = VirusTotalSignalPack(enabled=True, total_engines=70, malicious_count=3)
+    gov = _factors_by_name(
+        ScoringEngine().calculate_scores(tos_pack, manifest=MV3_MANIFEST).governance_layer
+    )
+    assert "broad_access_with_vt_detection" in gov["ToSViolations"].flags
+    assert gov["ToSViolations"].severity > 0
+
+    # (2) travel-docs / visa-portal automation heuristic (engine.py, unchanged).
+    # Domain must be a real entry in config/protected_services.yaml
+    # (protected_service_domains) for the heuristic to fire.
+    travel_pack = make_min_signal_pack()
+    travel_pack.permissions = PermissionsSignalPack(
+        api_permissions=["scripting"],
+        host_permissions=["https://www.usvisascheduling.com/*"],
+        total_permissions=1,
+    )
+    travel_manifest = {**MV3_MANIFEST, "content_scripts": [{"matches": ["https://www.usvisascheduling.com/*"]}]}
+    gov2 = _factors_by_name(
+        ScoringEngine().calculate_scores(travel_pack, manifest=travel_manifest).governance_layer
+    )
+    assert "travel_docs_tos_automation_risk" in gov2["ToSViolations"].flags
+    assert gov2["ToSViolations"].severity >= 0.9
 
 
 # ---------------------------------------------------------------------------

--- a/tests/scoring/test_no_double_count.py
+++ b/tests/scoring/test_no_double_count.py
@@ -14,8 +14,12 @@ docs/adr/0002-scoring-layer-ownership.md):
     (DisclosureAlignment).
   * broad-host access is counted in BOTH Security (Manifest posture) and Privacy
     (PermissionCombos).
-  * purpose-mismatch / exfil / ToS are each represented by BOTH a scoring factor
-    AND a hard gate.
+  * ToS bare prohibited-permission declaration is represented by BOTH a scoring
+    factor (ToSViolations) and a hard gate (TOS_VIOLATION) — the one remaining
+    open duplicate, deferred to PR-3c. (purpose-mismatch and exfil were audited
+    in PR-3b as intentionally layered on DISJOINT evidence — a soft aggregate
+    factor vs. a hard, corroboration-gated gate — and are now locked by the
+    guardrail tests below, not trackers.)
 
 When a future PR consolidates an owner, the corresponding assertion below will
 flip — that is the intended signal to update the tracker (and the ADR).
@@ -34,7 +38,7 @@ from extension_shield.governance.signal_pack import (
     SastSignalPack,
     VirusTotalSignalPack,
 )
-from tests.scoring.utils import make_min_signal_pack
+from tests.scoring.utils import make_min_signal_pack, make_sast_finding
 
 
 MV3_MANIFEST = {"name": "Test Extension", "description": "a tool", "manifest_version": 3}
@@ -196,12 +200,14 @@ def test_broad_host_compound_uses_unchanged():
     assert "no_privacy_policy_with_network" in gov2["DisclosureAlignment"].flags
 
 
+# PR-3b audited purpose-mismatch and exfil as intentionally layered on disjoint
+# evidence (see the guardrail tests below and ADR 0002 §4). The ToS bare
+# prohibited-permission case remains a genuine narrow duplicate and stays a
+# tracker until PR-3c converts it — kept EXACTLY as-is here.
 @pytest.mark.parametrize(
     "factor_name, gate_id",
     [
-        ("Consistency", "PURPOSE_MISMATCH"),  # purpose-mismatch
-        ("NetworkExfil", "SENSITIVE_EXFIL"),  # exfiltration
-        ("ToSViolations", "TOS_VIOLATION"),   # ToS / policy
+        ("ToSViolations", "TOS_VIOLATION"),   # ToS / policy — open duplicate, PR-3c
     ],
 )
 def test_tracker_concept_represented_by_both_factor_and_gate(factor_name, gate_id):
@@ -215,6 +221,152 @@ def test_tracker_concept_represented_by_both_factor_and_gate(factor_name, gate_i
     result = ScoringEngine().calculate_scores(make_min_signal_pack(), manifest=MV3_MANIFEST)
     assert factor_name in _all_factor_names(result)
     assert gate_id in HardGates.GATES
+
+
+# ---------------------------------------------------------------------------
+# PR-3b: factor-vs-gate audited as intentionally layered (disjoint evidence).
+# These are guardrails, not trackers — they must keep passing. They read only
+# existing FactorScore / GateResult outputs; they change no scoring behavior.
+# ---------------------------------------------------------------------------
+
+def _remote_code_sast_pack():
+    """A SAST finding classified as remote-code loading (concrete PURPOSE_MISMATCH
+    BLOCK evidence), on a non-benign, non-offline manifest with no broad-host — so
+    the Consistency factor's indirect aggregate trigger cannot fire."""
+    pack = make_min_signal_pack()
+    pack.sast = SastSignalPack(
+        deduped_findings=[
+            make_sast_finding(
+                # Behavior suffix `dynamic_script_loading` is in gates._PM_REMOTE_CODE
+                # -> classified as remote-code, a standalone-concrete BLOCK reason.
+                check_id="custom.remote.dynamic_script_loading",
+                file_path="src/loader.js",
+                line_number=42,
+                severity="MEDIUM",
+                message="loads a script element from a remote URL",
+                code_snippet="const s=document.createElement('script');s.src=cfg.remote;document.head.appendChild(s)",
+            )
+        ],
+        files_scanned=5,
+        confidence=0.9,
+    )
+    # A plain sensitive perm, no broad host — unrelated to the SAST classification.
+    pack.permissions = PermissionsSignalPack(api_permissions=["storage"], total_permissions=1)
+    return pack
+
+
+def test_purpose_mismatch_gate_and_consistency_factor_use_disjoint_evidence():
+    """PURPOSE_MISMATCH (gate) and Consistency (factor) read DISJOINT evidence, so
+    they are intentionally layered — not a duplicate.
+
+    * The gate BLOCKS on DIRECT SAST-classified behavior (remote-code loading,
+      gates.py:1006-1007), via the concrete rule-suffix taxonomy.
+    * The Consistency factor (engine.py ~651-695) only fires on an INDIRECT
+      aggregate — a benign purpose claim + a high-severity signal, or an
+      "offline" claim + broad-host — and never inspects SAST behavior.
+
+    With a non-benign manifest the same fixture BLOCKS the gate while leaving
+    Consistency at severity 0 with no flag referencing the SAST evidence.
+    """
+    pack = _remote_code_sast_pack()
+    manifest = {
+        "name": "Data Sync Pro",
+        "description": "syncs your data across devices",
+        "manifest_version": 3,
+    }
+
+    # Gate: DIRECT SAST remote-code behavior -> BLOCK/triggered.
+    gate = HardGates().evaluate_purpose_mismatch(manifest, pack.sast, pack.permissions)
+    assert gate.triggered is True
+    assert gate.decision == "BLOCK"
+    assert "dynamic_script_loading" in gate.details.get("remote_code", [])
+
+    # Factor: INDIRECT aggregate did not fire (non-benign name, no "offline"
+    # claim, no broad-host) -> severity 0 and no SAST-derived flag. This proves
+    # Consistency never consumed the gate's SAST evidence.
+    result = ScoringEngine().calculate_scores(pack, manifest=manifest)
+    consistency = _factors_by_name(result.governance_layer)["Consistency"]
+    assert consistency.severity == 0.0
+    assert not any(
+        ("dynamic_script_loading" in f) or ("remote" in f.lower()) or ("sast" in f.lower())
+        for f in consistency.flags
+    )
+
+
+def test_sensitive_exfil_gate_and_network_factor_use_disjoint_evidence():
+    """SENSITIVE_EXFIL (gate) and NetworkExfil (factor) read DISJOINT evidence.
+
+    * The NetworkExfil factor (normalizers.py:849-865) is driven by
+      NetworkSignalPack domain/pattern analysis and returns severity 0.0 whenever
+      ``network.enabled`` is False.
+    * The SENSITIVE_EXFIL gate (gates.py:1113-1233) WARNs from a permission +
+      disclosure combination (sensitive perm + network perm + no privacy policy)
+      that the factor never reads.
+
+    Their only shared input is the ``has_network`` boolean; with network analysis
+    off the gate still WARNs while the factor stays at 0.0.
+    """
+    from extension_shield.scoring.normalizers import normalize_network_exfil
+    from extension_shield.governance.signal_pack import NetworkSignalPack
+
+    perms = PermissionsSignalPack(
+        api_permissions=["cookies", "webRequest"],  # sensitive perm + network perm
+        total_permissions=2,
+    )
+    webstore = WebstoreStatsSignalPack(has_privacy_policy=False)  # 3rd risk factor
+
+    # Gate: permission + disclosure combination (>= 2 risk factors) -> WARN/triggered.
+    gate = HardGates().evaluate_sensitive_exfil(perms, SastSignalPack(), webstore)
+    assert gate.triggered is True
+    assert gate.decision == "WARN"
+    assert gate.details.get("risk_factors", 0) >= 2
+
+    # Factor: network analysis OFF -> severity 0.0 (a disjoint, analysis-driven signal).
+    net = normalize_network_exfil(NetworkSignalPack(enabled=False, confidence=0.0), perms)
+    assert net.severity == 0.0
+    assert net.details.get("network_analysis_enabled") is False
+
+
+def test_sensitive_exfil_gate_is_structurally_warn_only():
+    """Invariant: SENSITIVE_EXFIL can never BLOCK — it is a capability/disclosure
+    WARNING by design (its decision is the literal "WARN", gates.py ~1205).
+
+    Iterate "worst case" inputs (every sensitive permission + broad-host/network +
+    no privacy policy + SAST network-pattern findings) and assert the gate
+    decision is never BLOCK. Locks the WARN-only structure against a future edit
+    that adds a BLOCK path.
+    """
+    all_sensitive = [
+        "cookies", "webRequest", "webRequestBlocking", "history",
+        "browsingData", "clipboardRead", "tabs",
+    ]
+    network_sast = SastSignalPack(
+        deduped_findings=[
+            make_sast_finding(check_id="net.fetch.external_api",
+                              message="fetch() to a third-party api", severity="HIGH"),
+            make_sast_finding(check_id="net.ws.websocket_connection",
+                              message="opens a websocket to send data", severity="HIGH"),
+        ],
+        files_scanned=5,
+        confidence=0.9,
+    )
+    perm_cases = [
+        PermissionsSignalPack(
+            api_permissions=all_sensitive, host_permissions=["<all_urls>"],
+            has_broad_host_access=True, total_permissions=len(all_sensitive),
+        ),
+        PermissionsSignalPack(api_permissions=all_sensitive, total_permissions=len(all_sensitive)),
+    ]
+    sast_cases = [network_sast, SastSignalPack()]
+
+    for perms in perm_cases:
+        for sast in sast_cases:
+            gate = HardGates().evaluate_sensitive_exfil(
+                perms, sast, WebstoreStatsSignalPack(has_privacy_policy=False)
+            )
+            assert gate.decision != "BLOCK", (
+                "SENSITIVE_EXFIL is structurally WARN-only; it must never BLOCK"
+            )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
PR-3b + PR-3c stacked branch.

Commit 1 documents the factor-vs-gate audit:
- Purpose mismatch is intentionally layered, not duplicate scoring.
- Exfiltration is intentionally layered, not duplicate scoring.
- ToS bare prohibited permissions remain the only safe cleanup target.

Commit 2 removes the ToS bare prohibited-permission double count:
- debugger/proxy/nativeMessaging no longer add ToSViolations factor severity.
- Evidence/context flags remain.
- TOS_VIOLATION gate WARN/BLOCK behavior is unchanged.
- ScoringEngine.VERSION bumped 2.1.2 → 2.1.3.

Not changed:
No gates, weights, decision logic, rulepacks, frontend, normalizers, broad-host, purpose-mismatch, exfil, travel-docs/visa logic, PR-4 weights, or PR-5 reputation work changed.

Remaining / deferred:
- travel-docs/visa heuristic retirement remains deferred to ADR 0001 / future rulepack cleanup.
- PR-4 weight/preset changes are not included.
- PR-5 Reputation modifier / v2 model is not included.
- NetworkExfil reweighting is not included.
- No gate trigger-condition changes are included.
- No rulepack retirement work is included.

Tests:
111 passed, 0 failed.
