### PR TITLE
chore(scoring): source ScoringResult scoring_version default from engine

### DIFF
--- a/src/extension_shield/scoring/explain.py
+++ b/src/extension_shield/scoring/explain.py
@@ -133,7 +133,7 @@ class ExplanationPayload:
             "gates_checked": ["VT_MALWARE", ...],
             "results": [...]
         },
-        "scoring_version": "v2",
+        "scoring_version": "2.1.3",  # semver, resolves from ScoringEngine.VERSION
         "weights_version": "v1"
     }
     """

--- a/src/extension_shield/scoring/models.py
+++ b/src/extension_shield/scoring/models.py
@@ -12,6 +12,23 @@ from typing import Any, Dict, List, Optional
 from pydantic import BaseModel, Field, computed_field
 
 
+def _current_scoring_version() -> str:
+    """Single source of truth for a ``ScoringResult``'s default ``scoring_version``.
+
+    The canonical version lives on ``ScoringEngine.VERSION``. It is imported
+    lazily (inside the function body, not at module scope) because ``engine.py``
+    imports this module at load time — a module-level ``from ...engine import
+    ScoringEngine`` here would create a circular import. ``explain.py`` also
+    imports this module, so we deliberately do not reuse its helper either.
+    Resolving at instantiation time is safe: the engine module is always fully
+    loaded before any ``ScoringResult`` is built. This keeps the default from
+    drifting behind the engine version (it used to be a hardcoded ``"2.0.0"``).
+    """
+    from extension_shield.scoring.engine import ScoringEngine
+
+    return ScoringEngine.VERSION
+
+
 class RiskLevel(str, Enum):
     """Risk level classification based on score thresholds."""
     
@@ -325,8 +342,8 @@ class ScoringResult(BaseModel):
         description="Timestamp when this result was created"
     )
     scoring_version: str = Field(
-        default="2.0.0",
-        description="Version of the scoring engine used"
+        default_factory=_current_scoring_version,
+        description="Version of the scoring engine used (defaults to ScoringEngine.VERSION)"
     )
     # Explicit gate/override breakdown for QA and enterprise audits (overall_score = final_overall)
     base_overall: Optional[int] = Field(

--- a/tests/scoring/test_no_double_count.py
+++ b/tests/scoring/test_no_double_count.py
@@ -59,7 +59,10 @@ def _all_factor_names(result):
 
 
 # ---------------------------------------------------------------------------
-# Duplicate-risk trackers (current state; flip when a single owner is chosen)
+# Single-owner guardrails (PERMANENT). Privacy-policy, broad-host, and ToS
+# bare prohibited-permission ownership are resolved: each is scored by exactly
+# one owner. These are not trackers awaiting a decision — they are regression
+# guards that fail if a future PR reintroduces a double-count.
 # ---------------------------------------------------------------------------
 
 def test_privacy_policy_scored_only_by_governance_disclosure():

--- a/tests/scoring/test_scoring_version_consistency.py
+++ b/tests/scoring/test_scoring_version_consistency.py
@@ -19,6 +19,11 @@ from extension_shield.scoring.explain import (
     build_explanation,
     _current_scoring_version,
 )
+from extension_shield.scoring.models import (
+    Decision,
+    ScoringResult,
+    _current_scoring_version as _models_current_scoring_version,
+)
 
 
 def _minimal_explanation_dict():
@@ -80,3 +85,58 @@ def _make_min_pack():
     from tests.scoring.utils import make_min_signal_pack
 
     return make_min_signal_pack()
+
+
+# ---------------------------------------------------------------------------
+# models.ScoringResult default coverage.
+#
+# ``ScoringResult`` used to hardcode ``scoring_version="2.0.0"``. The engine
+# always overrode it (scoring_version=self.VERSION), so it was latent rather
+# than live — but any ScoringResult built without an explicit version (tests,
+# helpers, future callers) would emit stale metadata. The default now resolves
+# from ScoringEngine.VERSION via a local lazy helper. These guards fail if the
+# stale hardcode returns.
+# ---------------------------------------------------------------------------
+
+def _make_min_result():
+    """A minimal ScoringResult built WITHOUT passing scoring_version."""
+    return ScoringResult(
+        scan_id="s",
+        extension_id="e",
+        security_score=100,
+        privacy_score=100,
+        governance_score=100,
+        overall_score=100,
+        decision=Decision.ALLOW,
+    )
+
+
+def test_models_helper_resolves_to_engine_version():
+    assert _models_current_scoring_version() == ScoringEngine.VERSION
+
+
+def test_scoring_result_default_scoring_version_tracks_engine():
+    # The stale hardcode ("2.0.0") must not come back as a default.
+    result = _make_min_result()
+    assert result.scoring_version == ScoringEngine.VERSION
+    assert result.scoring_version != "2.0.0"
+
+
+def test_scoring_result_emitted_metadata_matches_engine_version():
+    assert _make_min_result().model_dump_for_api()["scoring_version"] == ScoringEngine.VERSION
+
+
+def test_scoring_result_explicit_version_override_is_still_honored():
+    # The engine passes scoring_version=self.VERSION explicitly; that path must
+    # remain unaffected by the default_factory change.
+    result = ScoringResult(
+        scan_id="s",
+        extension_id="e",
+        security_score=100,
+        privacy_score=100,
+        governance_score=100,
+        overall_score=100,
+        decision=Decision.ALLOW,
+        scoring_version="9.9.9",
+    )
+    assert result.scoring_version == "9.9.9"


### PR DESCRIPTION
Small cleanup after the scoring dedup work.

This removes the stale `ScoringResult` default `scoring_version="2.0.0"` and makes it resolve from `ScoringEngine.VERSION` through a local lazy helper. It also adds tests so this cannot drift again.

Also cleaned up two stale docs/comments:
- no-double-count tracker wording now reflects the resolved guardrails
- `explain.py` example now shows the current semver-style scoring version

No scoring, verdict, weights, gates, rulepacks, frontend, or version constants changed.

Tests:
- `uv run pytest tests/scoring/test_scoring_version_consistency.py`
- `uv run pytest tests/scoring/test_no_double_count.py`
- `uv run pytest tests/scoring/`
- `uv run pytest tests/test_golden_snapshots.py`