### PR TITLE
feat(scoring): offline corpus schema + before/after diff harness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -271,6 +271,9 @@ railway.toml
 playwright-report/
 test-results/
 
+# Generated scoring corpus diff reports (never committed)
+scoring_reports/
+
 # Local-only cloud/Supabase tooling
 supabase/
 scripts/cloud_only/

--- a/docs/scoring/corpus.md
+++ b/docs/scoring/corpus.md
@@ -1,0 +1,107 @@
+# Scoring calibration corpus + before/after harness
+
+This document describes the offline corpus and the before/after scoring
+comparison harness that together form the prerequisite for any future weight or
+layer change (PR-4 conservative weights, PR-5 reputation modifier / v2 model).
+
+**Why this exists.** Weight/layer changes move scores and verdicts. We cannot
+prove a change is safe from intuition — every authoritative source (NIST, OWASP,
+CVSS) calibrates risk weights against data. The golden snapshots
+(`tests/test_golden_snapshots.py`) are frozen *outputs* of a handful of pinned
+fixtures; they pin stability but cannot be recomputed under a new model, so they
+are not a calibration corpus. This corpus stores scoring **inputs** so any future
+model can be re-run against it and diffed.
+
+## Corpus format
+
+A corpus file is a JSON array of entries (an object with an `entries` array is
+also accepted). Each entry:
+
+| Field | Required | Type | Meaning |
+| --- | --- | --- | --- |
+| `id` | yes | string | Unique id within the corpus. |
+| `name` | yes | string | Human-readable name. |
+| `label` | yes | enum | Human ground-truth: `benign`, `malicious`, `needs_review`, `low_confidence`, `unknown`. **Advisory only** — never asserted against engine output. |
+| `inputs` | yes | object | The scoring inputs (see below). Must contain `signal_pack`. |
+| `expected_verdict` | no | enum/null | `ALLOW`, `NEEDS_REVIEW`, `BLOCK`, or null. Advisory ground-truth; not asserted. |
+| `confidence` | no | number/null | Reviewer confidence in the label `[0,1]` or null. |
+| `rationale` | no | string | Why the label was assigned; cite evidence. |
+| `tags` | no | string[] | Free-form tags (e.g. `broad-host`, `synthetic`). |
+| `known_signals` | no | string[] | Notable signals present, for reviewer context. |
+| `notes` | no | string | Anything else. |
+
+### `inputs` — SignalPack-shaped inputs, not outputs
+
+`inputs` mirrors the arguments to `ScoringEngine.calculate_scores`:
+
+| Key | Required | Meaning |
+| --- | --- | --- |
+| `signal_pack` | yes | A JSON object that deserializes via `SignalPack.model_validate(...)`. May be minimal — omitted sub-packs fall back to their model defaults. |
+| `manifest` | no | Optional manifest dict passed to the engine (or null). |
+| `user_count` | no | Optional install count for popularity-based confidence (or null). |
+| `permissions_analysis` | no | Optional raw permissions-analysis dict (or null). |
+
+Store **inputs, never a pre-scored `ScoringResult`.** Outputs cannot be recomputed
+under a different weight model, which defeats the purpose of the corpus.
+
+To serialize a real `SignalPack` into an entry, use
+`pack.model_dump(mode="json")`. Set a fixed `created_at` (e.g.
+`"2024-01-01T00:00:00+00:00"`) so committed fixtures are stable and never embed a
+wall-clock time.
+
+## Adding a labeled case
+
+1. Copy an entry from `tests/fixtures/scoring_corpus/template.json`.
+2. Fill `inputs.signal_pack` with real (offline) SignalPack data. Do **not**
+   include CRX binaries, secrets, API-derived payloads, or private scan
+   artifacts.
+3. Assign `label` / `expected_verdict` **only** when a real human review backs
+   the claim. If unsure, leave `label: "unknown"` and `expected_verdict: null`.
+   Do not invent labels.
+4. Keep `id` unique.
+
+## Running the harness
+
+Fully offline — it imports only the local `ScoringEngine` and `SignalPack` and
+reads local JSON. No network, scans, or database access.
+
+```
+uv run python -m scripts.scoring.compare_scoring_corpus \
+  --corpus tests/fixtures/scoring_corpus/starter_corpus.json \
+  --baseline v1 --candidate v1 --format md
+```
+
+- `--baseline` / `--candidate` are `weights_version` presets. Today only `v1`
+  exists, so the default is **identity mode** (`v1` vs `v1`) and the report shows
+  a zero diff — that is the machinery self-check. When a future preset lands
+  (e.g. `v1.1`), pass `--candidate v1.1` to see the real before/after.
+- Reports are written to the git-ignored `scoring_reports/` directory by default
+  (override with `--out`). **Generated reports are not committed.**
+
+## Reading the report
+
+Each row reports: baseline and candidate score/verdict, the score delta, the
+verdict-flip type, per-layer score deltas, and per-factor contribution deltas.
+
+Flip types: `ALLOW<->NEEDS_REVIEW`, `NEEDS_REVIEW<->BLOCK`, `ALLOW<->BLOCK`.
+
+## Sign-off rules for future weight/model changes
+
+The harness measures movement; humans decide if it is acceptable. Before shipping
+a weight/model change:
+
+- **`ALLOW<->BLOCK` flips require explicit human review.** The report flags them.
+- **Every verdict flip must list its driver** — the layer/factor deltas in the
+  report identify it; record it in the PR.
+- **Reputation-only changes must never create a `BLOCK`.** Reputation/maintenance
+  is a bounded, downward-biased context/confidence modifier, not a verdict driver.
+- **Low-confidence cases stay conservative** — a change should not turn a
+  low-confidence case into a stronger verdict without cause.
+- **Version bumps are mandatory:** any weight/formula change requires a
+  `weights_version` bump **and** a `ScoringEngine.VERSION` bump (which drives the
+  emitted `scoring_version`); any decision-precedence or rulepack-verdict change
+  requires a `DECISION_VERSION` bump. Recompute-on-read then refreshes cached rows.
+
+This harness introduces **no** scoring change: it only reads inputs and runs the
+existing engine. It never edits weights, gates, rulepacks, thresholds, or version
+constants.

--- a/scripts/scoring/__init__.py
+++ b/scripts/scoring/__init__.py
@@ -1,0 +1,6 @@
+"""Offline scoring tooling (calibration corpus + before/after diff harness).
+
+These modules import only local scoring code and read local JSON. They never
+call external APIs, trigger scans, or touch any database. See
+``compare_scoring_corpus`` and ``docs/scoring/corpus.md``.
+"""

--- a/scripts/scoring/compare_scoring_corpus.py
+++ b/scripts/scoring/compare_scoring_corpus.py
@@ -1,0 +1,516 @@
+"""Offline before/after scoring comparison harness.
+
+Purpose
+-------
+Unblock future weight/layer work (PR-4/PR-5) by providing a way to measure how a
+scoring change moves scores and verdicts across a labeled corpus, *before* it
+ships. It loads a corpus of SignalPack-shaped INPUTS, recomputes scores under a
+baseline and a candidate weight preset, and emits a diff report.
+
+Design contract
+---------------
+* **Inputs, not outputs.** Each corpus entry stores the inputs to
+  ``ScoringEngine.calculate_scores`` (a ``signal_pack`` plus optional
+  ``manifest`` / ``user_count`` / ``permissions_analysis``), never a pre-scored
+  ``ScoringResult``. This is what lets us recompute under a *different* model.
+  Golden snapshots are frozen outputs and cannot serve this role.
+* **Fully offline.** Only local imports (``ScoringEngine``, ``SignalPack``) and
+  local JSON reads. No network, no scans, no database, no external services.
+* **Deterministic diff.** Non-deterministic result fields (``created_at`` and
+  anything else that varies per run) are excluded, so an identity comparison
+  (same preset on both sides) yields an exact zero diff.
+* **No labels asserted.** The corpus ``label`` / ``expected_verdict`` fields are
+  advisory human ground-truth for future calibration. This harness only reports
+  the delta between two engine runs; it never asserts the engine agrees with a
+  label.
+
+This module is import-safe (pure functions) and runnable as a CLI. It must not
+import from ``tests/``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import io
+import json
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+from extension_shield.governance.signal_pack import SignalPack
+from extension_shield.scoring.engine import ScoringEngine
+from extension_shield.scoring.models import ScoringResult
+
+# --- schema -----------------------------------------------------------------
+
+REQUIRED_FIELDS: Tuple[str, ...] = ("id", "name", "label", "inputs")
+VALID_LABELS = {"benign", "malicious", "needs_review", "low_confidence", "unknown"}
+VALID_VERDICTS = {"ALLOW", "NEEDS_REVIEW", "BLOCK"}
+
+# Result fields intentionally excluded from the diff because they vary per run.
+# Keeping this list explicit is what makes identity-mode a true zero diff.
+NON_DETERMINISTIC_FIELDS: Tuple[str, ...] = ("created_at",)
+
+DEFAULT_OUTPUT_DIR = "scoring_reports"  # git-ignored; generated reports are not committed
+DEFAULT_BASELINE = "v1"
+DEFAULT_CANDIDATE = "v1"
+
+# Verdict flips that always require explicit human sign-off before shipping.
+REVIEW_REQUIRED_FLIPS = {"ALLOW<->BLOCK"}
+
+
+class CorpusError(ValueError):
+    """Raised when a corpus file or entry is malformed."""
+
+
+# --- loading & validation ---------------------------------------------------
+
+
+def load_corpus(path: Any) -> List[Dict[str, Any]]:
+    """Load and validate a corpus JSON file.
+
+    Accepts either a top-level JSON array of entries or an object with an
+    ``entries`` array. Raises ``CorpusError`` on any structural problem.
+    """
+    p = Path(path)
+    with p.open("r", encoding="utf-8") as f:
+        data = json.load(f)
+    if isinstance(data, dict):
+        data = data.get("entries", data)
+    if not isinstance(data, list):
+        raise CorpusError(
+            f"Corpus at {p} must be a JSON array or an object with an 'entries' array."
+        )
+    validate_corpus(data)
+    return data
+
+
+def validate_entry(entry: Any, index: Optional[int] = None) -> None:
+    """Validate a single corpus entry, including that its signal_pack parses."""
+    where = f"entry[{index}]" if index is not None else "entry"
+    if not isinstance(entry, dict):
+        raise CorpusError(f"{where} must be a JSON object.")
+    for field in REQUIRED_FIELDS:
+        if field not in entry:
+            raise CorpusError(f"{where} is missing required field '{field}'.")
+    if not isinstance(entry["id"], str) or not entry["id"]:
+        raise CorpusError(f"{where} 'id' must be a non-empty string.")
+    if not isinstance(entry["name"], str):
+        raise CorpusError(f"{where} 'name' must be a string.")
+    label = entry["label"]
+    if label not in VALID_LABELS:
+        raise CorpusError(
+            f"{where} has invalid label {label!r}; expected one of {sorted(VALID_LABELS)}."
+        )
+    expected = entry.get("expected_verdict")
+    if expected is not None and expected not in VALID_VERDICTS:
+        raise CorpusError(
+            f"{where} has invalid expected_verdict {expected!r}; "
+            f"expected one of {sorted(VALID_VERDICTS)} or null."
+        )
+    inputs = entry["inputs"]
+    if not isinstance(inputs, dict) or "signal_pack" not in inputs:
+        raise CorpusError(f"{where} 'inputs' must be an object containing 'signal_pack'.")
+    # Confirm the signal_pack input actually deserializes into a SignalPack.
+    build_inputs(entry)
+
+
+def validate_corpus(corpus: Any) -> None:
+    """Validate an entire corpus: each entry, plus id uniqueness."""
+    if not isinstance(corpus, list):
+        raise CorpusError("Corpus must be a list of entries.")
+    seen_ids: set = set()
+    for i, entry in enumerate(corpus):
+        validate_entry(entry, i)
+        entry_id = entry["id"]
+        if entry_id in seen_ids:
+            raise CorpusError(f"Duplicate entry id {entry_id!r}.")
+        seen_ids.add(entry_id)
+
+
+def build_inputs(
+    entry: Dict[str, Any],
+) -> Tuple[SignalPack, Optional[Dict[str, Any]], Optional[int], Optional[Dict[str, Any]]]:
+    """Deserialize a corpus entry's ``inputs`` into calculate_scores arguments."""
+    inputs = entry["inputs"]
+    try:
+        pack = SignalPack.model_validate(inputs["signal_pack"])
+    except Exception as exc:  # pydantic ValidationError or malformed dict
+        raise CorpusError(
+            f"entry {entry.get('id')!r} signal_pack failed SignalPack validation: {exc}"
+        ) from exc
+    manifest = inputs.get("manifest")
+    user_count = inputs.get("user_count")
+    permissions_analysis = inputs.get("permissions_analysis")
+    return pack, manifest, user_count, permissions_analysis
+
+
+# --- scoring & diffing ------------------------------------------------------
+
+
+def _score_snapshot(result: ScoringResult) -> Dict[str, Any]:
+    """Project a ScoringResult into a deterministic dict for diffing.
+
+    Excludes ``created_at`` (and anything else in NON_DETERMINISTIC_FIELDS by
+    construction: only the fields listed below are read).
+    """
+
+    def layer(layer_score: Any) -> Optional[Dict[str, Any]]:
+        if layer_score is None:
+            return None
+        return {
+            "score": layer_score.score,
+            "factors": {
+                f.name: {
+                    "severity": round(f.severity, 6),
+                    "weight": round(f.weight, 6),
+                    "confidence": round(f.confidence, 6),
+                    "contribution": round(f.contribution, 6),
+                }
+                for f in layer_score.factors
+            },
+        }
+
+    return {
+        "overall_score": result.overall_score,
+        "security_score": result.security_score,
+        "privacy_score": result.privacy_score,
+        "governance_score": result.governance_score,
+        "verdict": result.decision.value,
+        "layers": {
+            "security": layer(result.security_layer),
+            "privacy": layer(result.privacy_layer),
+            "governance": layer(result.governance_layer),
+        },
+    }
+
+
+def score_entry(entry: Dict[str, Any], weights_version: str = DEFAULT_BASELINE) -> Dict[str, Any]:
+    """Recompute scores for one corpus entry under ``weights_version`` (offline)."""
+    pack, manifest, user_count, permissions_analysis = build_inputs(entry)
+    engine = ScoringEngine(weights_version=weights_version)
+    result = engine.calculate_scores(
+        pack,
+        manifest=manifest,
+        user_count=user_count,
+        permissions_analysis=permissions_analysis,
+    )
+    return _score_snapshot(result)
+
+
+def flip_type(baseline_verdict: str, candidate_verdict: str) -> Optional[str]:
+    """Classify a verdict change; None if unchanged."""
+    if baseline_verdict == candidate_verdict:
+        return None
+    pair = {baseline_verdict, candidate_verdict}
+    if pair == {"ALLOW", "BLOCK"}:
+        return "ALLOW<->BLOCK"
+    if pair == {"ALLOW", "NEEDS_REVIEW"}:
+        return "ALLOW<->NEEDS_REVIEW"
+    if pair == {"NEEDS_REVIEW", "BLOCK"}:
+        return "NEEDS_REVIEW<->BLOCK"
+    # Fallback for any non-standard verdict values.
+    return f"{baseline_verdict}->{candidate_verdict}"
+
+
+def _layer_deltas(base_layers: Dict[str, Any], cand_layers: Dict[str, Any]) -> Dict[str, int]:
+    out: Dict[str, int] = {}
+    for name in ("security", "privacy", "governance"):
+        base = base_layers.get(name)
+        cand = cand_layers.get(name)
+        if base and cand and base["score"] != cand["score"]:
+            out[name] = cand["score"] - base["score"]
+    return out
+
+
+def _factor_deltas(
+    base_layers: Dict[str, Any], cand_layers: Dict[str, Any]
+) -> List[Dict[str, Any]]:
+    deltas: List[Dict[str, Any]] = []
+    for name in ("security", "privacy", "governance"):
+        base = base_layers.get(name)
+        cand = cand_layers.get(name)
+        if not base or not cand:
+            continue
+        base_factors = base["factors"]
+        cand_factors = cand["factors"]
+        for fname in sorted(set(base_factors) | set(cand_factors)):
+            base_contrib = base_factors.get(fname, {}).get("contribution")
+            cand_contrib = cand_factors.get(fname, {}).get("contribution")
+            if base_contrib != cand_contrib:
+                deltas.append(
+                    {
+                        "layer": name,
+                        "factor": fname,
+                        "baseline_contribution": base_contrib,
+                        "candidate_contribution": cand_contrib,
+                    }
+                )
+    return deltas
+
+
+def diff_entry(
+    entry: Dict[str, Any],
+    baseline_wv: str = DEFAULT_BASELINE,
+    candidate_wv: str = DEFAULT_CANDIDATE,
+) -> Dict[str, Any]:
+    """Score one entry under both presets and return a diff row."""
+    base = score_entry(entry, baseline_wv)
+    cand = score_entry(entry, candidate_wv)
+    ft = flip_type(base["verdict"], cand["verdict"])
+    return {
+        "id": entry["id"],
+        "name": entry.get("name", ""),
+        "label": entry.get("label", "unknown"),
+        "expected_verdict": entry.get("expected_verdict"),
+        "baseline_score": base["overall_score"],
+        "candidate_score": cand["overall_score"],
+        "score_delta": cand["overall_score"] - base["overall_score"],
+        "baseline_verdict": base["verdict"],
+        "candidate_verdict": cand["verdict"],
+        "verdict_flip": ft or "",
+        "review_required": ft in REVIEW_REQUIRED_FLIPS,
+        "layer_deltas": _layer_deltas(base["layers"], cand["layers"]),
+        "factor_deltas": _factor_deltas(base["layers"], cand["layers"]),
+    }
+
+
+def compare_corpus(
+    corpus: List[Dict[str, Any]],
+    baseline_wv: str = DEFAULT_BASELINE,
+    candidate_wv: str = DEFAULT_CANDIDATE,
+) -> List[Dict[str, Any]]:
+    """Diff every entry in a corpus. Returns one row per entry."""
+    return [diff_entry(entry, baseline_wv, candidate_wv) for entry in corpus]
+
+
+def row_has_diff(row: Dict[str, Any]) -> bool:
+    """True if a row shows any score/verdict/layer/factor movement."""
+    return bool(
+        row["score_delta"] != 0
+        or row["verdict_flip"]
+        or row["layer_deltas"]
+        or row["factor_deltas"]
+    )
+
+
+def has_any_diff(rows: List[Dict[str, Any]]) -> bool:
+    """True if any row in the report shows movement (False => identity/zero diff)."""
+    return any(row_has_diff(row) for row in rows)
+
+
+# --- rendering --------------------------------------------------------------
+
+
+def _summarize(rows: List[Dict[str, Any]]) -> Dict[str, Any]:
+    flips: Dict[str, int] = {}
+    review_required = 0
+    changed = 0
+    for row in rows:
+        if row_has_diff(row):
+            changed += 1
+        if row["verdict_flip"]:
+            flips[row["verdict_flip"]] = flips.get(row["verdict_flip"], 0) + 1
+        if row["review_required"]:
+            review_required += 1
+    return {
+        "total": len(rows),
+        "changed": changed,
+        "flips": flips,
+        "review_required": review_required,
+    }
+
+
+def _md_cell(value: Any) -> str:
+    """Escape a value for safe inclusion in a Markdown table cell.
+
+    A raw '|' would start a new column and a newline would break the row, so a
+    corpus id/name containing either would corrupt the table. Escape pipes and
+    flatten newlines.
+    """
+    return str(value).replace("|", "\\|").replace("\r", " ").replace("\n", " ")
+
+
+def render_markdown(
+    rows: List[Dict[str, Any]],
+    baseline_wv: str = DEFAULT_BASELINE,
+    candidate_wv: str = DEFAULT_CANDIDATE,
+) -> str:
+    """Render a Markdown diff report."""
+    summary = _summarize(rows)
+    lines: List[str] = []
+    lines.append("# Scoring corpus before/after diff")
+    lines.append("")
+    lines.append(f"- Baseline weights: `{baseline_wv}`")
+    lines.append(f"- Candidate weights: `{candidate_wv}`")
+    lines.append(f"- Entries: {summary['total']}")
+    lines.append(f"- Entries changed: {summary['changed']}")
+    if summary["flips"]:
+        flip_str = ", ".join(f"{k}: {v}" for k, v in sorted(summary["flips"].items()))
+        lines.append(f"- Verdict flips: {flip_str}")
+    else:
+        lines.append("- Verdict flips: none")
+    if summary["review_required"]:
+        lines.append(
+            f"- **REVIEW REQUIRED: {summary['review_required']} ALLOW<->BLOCK flip(s) "
+            "need explicit human sign-off before shipping.**"
+        )
+    if summary["changed"] == 0:
+        lines.append("")
+        lines.append("_No differences: identity comparison (candidate == baseline)._")
+    lines.append("")
+    lines.append(
+        "| id | label | base score | cand score | Δscore | base verdict | "
+        "cand verdict | flip | layer Δ |"
+    )
+    lines.append("| --- | --- | ---: | ---: | ---: | --- | --- | --- | --- |")
+    for row in rows:
+        layer_delta = (
+            ", ".join(f"{k}{v:+d}" for k, v in row["layer_deltas"].items())
+            if row["layer_deltas"]
+            else ""
+        )
+        flip = row["verdict_flip"]
+        if row["review_required"]:
+            flip = f"⚠️ {flip}"
+        lines.append(
+            f"| {_md_cell(row['id'])} | {_md_cell(row['label'])} | {row['baseline_score']} | "
+            f"{row['candidate_score']} | {row['score_delta']:+d} | "
+            f"{row['baseline_verdict']} | {row['candidate_verdict']} | {_md_cell(flip)} | {layer_delta} |"
+        )
+    # Factor-level detail for rows that moved.
+    detailed = [r for r in rows if r["factor_deltas"]]
+    if detailed:
+        lines.append("")
+        lines.append("## Factor-level changes")
+        for row in detailed:
+            lines.append("")
+            lines.append(f"### {_md_cell(row['id'])} ({_md_cell(row['name'])})")
+            lines.append("")
+            lines.append("| layer | factor | base contribution | cand contribution |")
+            lines.append("| --- | --- | ---: | ---: |")
+            for fd in row["factor_deltas"]:
+                lines.append(
+                    f"| {_md_cell(fd['layer'])} | {_md_cell(fd['factor'])} | "
+                    f"{fd['baseline_contribution']} | {fd['candidate_contribution']} |"
+                )
+    lines.append("")
+    return "\n".join(lines)
+
+
+def render_csv(rows: List[Dict[str, Any]]) -> str:
+    """Render a flat CSV diff report (one row per entry)."""
+    buffer = io.StringIO()
+    fieldnames = [
+        "id",
+        "name",
+        "label",
+        "expected_verdict",
+        "baseline_score",
+        "candidate_score",
+        "score_delta",
+        "baseline_verdict",
+        "candidate_verdict",
+        "verdict_flip",
+        "review_required",
+        "layer_deltas",
+        "factor_deltas",
+    ]
+    writer = csv.DictWriter(buffer, fieldnames=fieldnames)
+    writer.writeheader()
+    for row in rows:
+        flat = dict(row)
+        flat["layer_deltas"] = json.dumps(row["layer_deltas"], sort_keys=True)
+        flat["factor_deltas"] = json.dumps(row["factor_deltas"], sort_keys=True)
+        writer.writerow(flat)
+    return buffer.getvalue()
+
+
+def render_report(
+    rows: List[Dict[str, Any]],
+    fmt: str,
+    baseline_wv: str,
+    candidate_wv: str,
+) -> str:
+    if fmt == "md":
+        return render_markdown(rows, baseline_wv, candidate_wv)
+    if fmt == "csv":
+        return render_csv(rows)
+    raise ValueError(f"Unknown format {fmt!r}; expected 'md' or 'csv'.")
+
+
+def write_report(
+    rows: List[Dict[str, Any]],
+    out_path: Any,
+    fmt: str,
+    baseline_wv: str = DEFAULT_BASELINE,
+    candidate_wv: str = DEFAULT_CANDIDATE,
+) -> Path:
+    """Render and write a report to ``out_path``; returns the Path written."""
+    out = Path(out_path)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(render_report(rows, fmt, baseline_wv, candidate_wv), encoding="utf-8")
+    return out
+
+
+# --- CLI --------------------------------------------------------------------
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Offline before/after scoring diff over a labeled corpus of "
+            "SignalPack inputs. Fully offline; no APIs, scans, or DB access."
+        )
+    )
+    parser.add_argument("--corpus", required=True, help="Path to a corpus JSON file.")
+    parser.add_argument(
+        "--baseline",
+        default=DEFAULT_BASELINE,
+        help=f"Baseline weights_version (default: {DEFAULT_BASELINE}).",
+    )
+    parser.add_argument(
+        "--candidate",
+        default=DEFAULT_CANDIDATE,
+        help=(
+            f"Candidate weights_version (default: {DEFAULT_CANDIDATE}). With the "
+            "default, this is identity mode and the report shows zero diff."
+        ),
+    )
+    parser.add_argument(
+        "--format",
+        choices=("md", "csv"),
+        default="md",
+        help="Report format (default: md).",
+    )
+    parser.add_argument(
+        "--out",
+        default=None,
+        help=(
+            f"Output path. Defaults to {DEFAULT_OUTPUT_DIR}/corpus_diff.<ext> "
+            "(git-ignored; generated reports are not committed)."
+        ),
+    )
+    return parser
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    args = _build_parser().parse_args(argv)
+    corpus = load_corpus(args.corpus)
+    rows = compare_corpus(corpus, args.baseline, args.candidate)
+    ext = "md" if args.format == "md" else "csv"
+    out_path = args.out or f"{DEFAULT_OUTPUT_DIR}/corpus_diff.{ext}"
+    written = write_report(rows, out_path, args.format, args.baseline, args.candidate)
+    summary = _summarize(rows)
+    print(f"Wrote {args.format} report to {written}")
+    print(
+        f"entries={summary['total']} changed={summary['changed']} "
+        f"review_required={summary['review_required']}"
+    )
+    if summary["flips"]:
+        print("flips: " + ", ".join(f"{k}={v}" for k, v in sorted(summary["flips"].items())))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/fixtures/scoring_corpus/README.md
+++ b/tests/fixtures/scoring_corpus/README.md
@@ -1,0 +1,22 @@
+# Scoring corpus fixtures
+
+Offline, committed corpus fixtures for the before/after scoring harness.
+
+- `starter_corpus.json` — a tiny **synthetic** starter set (all `label: "unknown"`).
+  It exists to exercise the harness, not to assert any real-world labels.
+- `template.json` — a single template entry to copy when adding a real case.
+
+Each entry stores **SignalPack-shaped inputs**, never a pre-scored result, so the
+harness can recompute scores under a different weight model. Full field docs, how
+to add labeled cases, and how to read verdict flips are in
+[`docs/scoring/corpus.md`](../../../docs/scoring/corpus.md).
+
+Run the harness (identity mode, zero diff) with:
+
+```
+uv run python -m scripts.scoring.compare_scoring_corpus \
+  --corpus tests/fixtures/scoring_corpus/starter_corpus.json
+```
+
+Generated reports are written under the git-ignored `scoring_reports/` directory
+and must not be committed.

--- a/tests/fixtures/scoring_corpus/starter_corpus.json
+++ b/tests/fixtures/scoring_corpus/starter_corpus.json
@@ -1,0 +1,51 @@
+[
+  {
+    "id": "syn-001",
+    "name": "minimal-empty-pack",
+    "label": "unknown",
+    "expected_verdict": null,
+    "confidence": null,
+    "rationale": "Synthetic offline fixture with no findings and all analyzers at defaults. Exists only to exercise the harness; it is NOT a real-world labeled case. The engine caps overall at the insufficient-data coverage cap for an empty pack.",
+    "tags": ["synthetic", "coverage-cap", "template"],
+    "known_signals": [],
+    "notes": "Replace synthetic entries with real SignalPack inputs and human labels to build a calibration corpus. See docs/scoring/corpus.md.",
+    "inputs": {
+      "signal_pack": {
+        "scan_id": "syn-001",
+        "extension_id": "synminimalaaaaaaaaaaaaaaaaaaaaaa",
+        "created_at": "2024-01-01T00:00:00+00:00"
+      },
+      "manifest": null,
+      "user_count": null,
+      "permissions_analysis": null
+    }
+  },
+  {
+    "id": "syn-002",
+    "name": "broad-host-permissions",
+    "label": "unknown",
+    "expected_verdict": null,
+    "confidence": null,
+    "rationale": "Synthetic offline fixture declaring broad host access (<all_urls>). Exists to demonstrate layer/factor deltas (broad host lowers the privacy layer). NOT a real-world labeled case; no maliciousness is asserted from capability alone.",
+    "tags": ["synthetic", "broad-host", "privacy"],
+    "known_signals": ["has_broad_host_access"],
+    "notes": "Capability (declared permission) is not abuse. This entry is illustrative input only.",
+    "inputs": {
+      "signal_pack": {
+        "scan_id": "syn-002",
+        "extension_id": "synbroadhostaaaaaaaaaaaaaaaaaaaa",
+        "created_at": "2024-01-01T00:00:00+00:00",
+        "permissions": {
+          "api_permissions": ["tabs"],
+          "host_permissions": ["<all_urls>"],
+          "has_broad_host_access": true,
+          "broad_host_patterns": ["<all_urls>"],
+          "total_permissions": 2
+        }
+      },
+      "manifest": null,
+      "user_count": null,
+      "permissions_analysis": null
+    }
+  }
+]

--- a/tests/fixtures/scoring_corpus/template.json
+++ b/tests/fixtures/scoring_corpus/template.json
@@ -1,0 +1,23 @@
+[
+  {
+    "id": "REPLACE-unique-id",
+    "name": "human-readable-name",
+    "label": "unknown",
+    "expected_verdict": null,
+    "confidence": null,
+    "rationale": "Why this case is labeled as it is. Cite evidence. Leave label 'unknown' and expected_verdict null until a real human review backs a claim.",
+    "tags": ["example"],
+    "known_signals": [],
+    "notes": "This is a TEMPLATE entry, not a scored case. JSON has no comments; field docs live in docs/scoring/corpus.md. Do NOT invent labels.",
+    "inputs": {
+      "signal_pack": {
+        "scan_id": "REPLACE-unique-id",
+        "extension_id": "REPLACE-32-char-extension-id----",
+        "created_at": "2024-01-01T00:00:00+00:00"
+      },
+      "manifest": null,
+      "user_count": null,
+      "permissions_analysis": null
+    }
+  }
+]

--- a/tests/scoring/test_scoring_corpus_compare.py
+++ b/tests/scoring/test_scoring_corpus_compare.py
@@ -1,0 +1,233 @@
+"""Diff-harness tests for the offline scoring corpus comparison.
+
+Covers: identity-mode (v1 vs v1) produces an exact zero diff, the diff excludes
+non-deterministic fields (created_at), verdict-flip classification, and report
+generation to a tmp path. Fully offline: no APIs, scans, or database access.
+
+These tests intentionally do NOT assert engine output equals a corpus label.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from scripts.scoring.compare_scoring_corpus import (
+    DEFAULT_BASELINE,
+    NON_DETERMINISTIC_FIELDS,
+    REVIEW_REQUIRED_FLIPS,
+    _factor_deltas,
+    _layer_deltas,
+    compare_corpus,
+    diff_entry,
+    flip_type,
+    has_any_diff,
+    load_corpus,
+    render_csv,
+    render_markdown,
+    row_has_diff,
+    score_entry,
+    write_report,
+)
+
+
+def _synthetic_row(**overrides):
+    """A diff row shaped exactly like diff_entry() output, for renderer tests."""
+    row = {
+        "id": "syn-flip",
+        "name": "forced-flip",
+        "label": "unknown",
+        "expected_verdict": None,
+        "baseline_score": 80,
+        "candidate_score": 20,
+        "score_delta": -60,
+        "baseline_verdict": "ALLOW",
+        "candidate_verdict": "BLOCK",
+        "verdict_flip": "ALLOW<->BLOCK",
+        "review_required": True,
+        "layer_deltas": {"security": -60},
+        "factor_deltas": [
+            {
+                "layer": "security",
+                "factor": "SAST",
+                "baseline_contribution": 0.1,
+                "candidate_contribution": 0.7,
+            }
+        ],
+    }
+    row.update(overrides)
+    return row
+
+FIXTURES = Path(__file__).parent.parent / "fixtures" / "scoring_corpus"
+STARTER = FIXTURES / "starter_corpus.json"
+
+
+@pytest.fixture()
+def starter():
+    return load_corpus(STARTER)
+
+
+# --- identity mode ----------------------------------------------------------
+
+
+def test_identity_mode_produces_zero_diff(starter):
+    rows = compare_corpus(starter, DEFAULT_BASELINE, DEFAULT_BASELINE)
+    assert len(rows) == len(starter)
+    for row in rows:
+        assert row["score_delta"] == 0, row
+        assert row["verdict_flip"] == "", row
+        assert row["layer_deltas"] == {}, row
+        assert row["factor_deltas"] == [], row
+        assert row["baseline_verdict"] == row["candidate_verdict"]
+    assert has_any_diff(rows) is False
+    assert all(not row_has_diff(row) for row in rows)
+
+
+def test_scoring_is_deterministic_across_runs(starter):
+    # Same entry, same preset, scored twice → identical snapshot (created_at excluded).
+    for entry in starter:
+        a = score_entry(entry, DEFAULT_BASELINE)
+        b = score_entry(entry, DEFAULT_BASELINE)
+        assert a == b
+
+
+def test_snapshot_excludes_non_deterministic_fields(starter):
+    # The diff snapshot must not carry created_at (or any listed volatile field).
+    snap = score_entry(starter[0], DEFAULT_BASELINE)
+    for field in NON_DETERMINISTIC_FIELDS:
+        assert field not in snap
+    assert "created_at" not in snap
+
+
+# --- flip classification ----------------------------------------------------
+
+
+def test_flip_type_none_when_unchanged():
+    assert flip_type("ALLOW", "ALLOW") is None
+    assert flip_type("BLOCK", "BLOCK") is None
+
+
+def test_flip_type_classifies_each_pair():
+    assert flip_type("ALLOW", "NEEDS_REVIEW") == "ALLOW<->NEEDS_REVIEW"
+    assert flip_type("NEEDS_REVIEW", "ALLOW") == "ALLOW<->NEEDS_REVIEW"
+    assert flip_type("NEEDS_REVIEW", "BLOCK") == "NEEDS_REVIEW<->BLOCK"
+    assert flip_type("ALLOW", "BLOCK") == "ALLOW<->BLOCK"
+    assert flip_type("BLOCK", "ALLOW") == "ALLOW<->BLOCK"
+
+
+def test_allow_block_flip_constant_membership():
+    assert "ALLOW<->BLOCK" in REVIEW_REQUIRED_FLIPS
+    assert flip_type("ALLOW", "BLOCK") in REVIEW_REQUIRED_FLIPS
+
+
+# --- non-empty diff path (exercised with synthetic snapshots/rows, no invented weights) ---
+
+
+def test_layer_deltas_reports_changed_layers_only():
+    base = {
+        "security": {"score": 90, "factors": {}},
+        "privacy": {"score": 100, "factors": {}},
+        "governance": {"score": 100, "factors": {}},
+    }
+    cand = {
+        "security": {"score": 40, "factors": {}},
+        "privacy": {"score": 100, "factors": {}},
+        "governance": {"score": 100, "factors": {}},
+    }
+    assert _layer_deltas(base, cand) == {"security": -50}
+
+
+def test_factor_deltas_reports_changed_contributions_only():
+    base = {
+        "security": {"score": 90, "factors": {"SAST": {"contribution": 0.1}, "VT": {"contribution": 0.2}}},
+        "privacy": {"score": 100, "factors": {}},
+        "governance": {"score": 100, "factors": {}},
+    }
+    cand = {
+        "security": {"score": 40, "factors": {"SAST": {"contribution": 0.6}, "VT": {"contribution": 0.2}}},
+        "privacy": {"score": 100, "factors": {}},
+        "governance": {"score": 100, "factors": {}},
+    }
+    deltas = _factor_deltas(base, cand)
+    assert deltas == [
+        {"layer": "security", "factor": "SAST", "baseline_contribution": 0.1, "candidate_contribution": 0.6}
+    ]
+
+
+def test_markdown_renders_non_empty_diff_with_review_marker():
+    text = render_markdown([_synthetic_row()], "v1", "v2")
+    assert "REVIEW REQUIRED" in text          # summary callout
+    assert "⚠️ ALLOW<->BLOCK" in text          # flagged flip in the table
+    assert "Factor-level changes" in text      # factor detail section rendered
+    assert "SAST" in text
+    assert "security-60" in text               # layer delta cell
+
+
+def test_markdown_escapes_pipe_and_newline_in_cells():
+    row = _synthetic_row(id="syn|evil", name="line1\nline2")
+    text = render_markdown([row], "v1", "v2")
+    # A raw pipe/newline would corrupt the table; they must be escaped/flattened.
+    assert "syn\\|evil" in text
+    assert "syn|evil |" not in text  # unescaped pipe would create a phantom column
+    # the factor-detail heading uses id/name too
+    assert "line1 line2" in text
+
+
+def test_csv_renders_non_empty_diff_row():
+    text = render_csv([_synthetic_row()])
+    body = text.splitlines()[1]
+    assert "ALLOW<->BLOCK" in body
+    assert "-60" in body
+
+
+# --- report generation ------------------------------------------------------
+
+
+def test_markdown_report_generates(starter, tmp_path):
+    rows = compare_corpus(starter, DEFAULT_BASELINE, DEFAULT_BASELINE)
+    out = write_report(rows, tmp_path / "diff.md", "md", DEFAULT_BASELINE, DEFAULT_BASELINE)
+    assert out.exists()
+    text = out.read_text(encoding="utf-8")
+    assert "Scoring corpus before/after diff" in text
+    # Identity mode should announce zero differences.
+    assert "identity comparison" in text
+    for entry in starter:
+        assert entry["id"] in text
+
+
+def test_csv_report_generates(starter, tmp_path):
+    rows = compare_corpus(starter, DEFAULT_BASELINE, DEFAULT_BASELINE)
+    out = write_report(rows, tmp_path / "diff.csv", "csv", DEFAULT_BASELINE, DEFAULT_BASELINE)
+    assert out.exists()
+    text = out.read_text(encoding="utf-8")
+    header = text.splitlines()[0]
+    for col in ("id", "score_delta", "verdict_flip", "layer_deltas", "factor_deltas"):
+        assert col in header
+
+
+def test_render_functions_return_strings(starter):
+    rows = compare_corpus(starter, DEFAULT_BASELINE, DEFAULT_BASELINE)
+    assert isinstance(render_markdown(rows, "v1", "v1"), str)
+    assert isinstance(render_csv(rows), str)
+
+
+def test_diff_entry_shape(starter):
+    row = diff_entry(starter[0], DEFAULT_BASELINE, DEFAULT_BASELINE)
+    for key in (
+        "id",
+        "baseline_score",
+        "candidate_score",
+        "score_delta",
+        "baseline_verdict",
+        "candidate_verdict",
+        "verdict_flip",
+        "review_required",
+        "layer_deltas",
+        "factor_deltas",
+    ):
+        assert key in row
+
+
+def test_unknown_weights_version_raises(starter):
+    # A candidate preset that does not exist must fail loudly, not silently pass.
+    with pytest.raises(Exception):
+        score_entry(starter[0], "does-not-exist")

--- a/tests/scoring/test_scoring_corpus_schema.py
+++ b/tests/scoring/test_scoring_corpus_schema.py
@@ -1,0 +1,136 @@
+"""Schema tests for the offline scoring corpus.
+
+These validate the corpus *structure* and that each entry's SignalPack input
+deserializes. They deliberately do NOT assert engine output against corpus
+labels — labels are advisory human ground-truth for future calibration, not a
+current-engine golden assertion (that is what test_golden_snapshots.py is for).
+
+Fully offline: no APIs, scans, or database access.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from extension_shield.governance.signal_pack import SignalPack
+from scripts.scoring.compare_scoring_corpus import (
+    CorpusError,
+    REQUIRED_FIELDS,
+    VALID_LABELS,
+    VALID_VERDICTS,
+    build_inputs,
+    load_corpus,
+    validate_corpus,
+    validate_entry,
+)
+
+FIXTURES = Path(__file__).parent.parent / "fixtures" / "scoring_corpus"
+STARTER = FIXTURES / "starter_corpus.json"
+TEMPLATE = FIXTURES / "template.json"
+
+
+def test_starter_corpus_loads_and_validates():
+    corpus = load_corpus(STARTER)
+    assert isinstance(corpus, list) and len(corpus) >= 1
+
+
+def test_template_corpus_loads_and_validates():
+    corpus = load_corpus(TEMPLATE)
+    assert isinstance(corpus, list) and len(corpus) >= 1
+
+
+def test_every_entry_has_required_fields():
+    for entry in load_corpus(STARTER):
+        for field in REQUIRED_FIELDS:
+            assert field in entry, f"{entry.get('id')} missing {field}"
+
+
+def test_labels_and_verdicts_are_valid():
+    for entry in load_corpus(STARTER):
+        assert entry["label"] in VALID_LABELS
+        expected = entry.get("expected_verdict")
+        assert expected is None or expected in VALID_VERDICTS
+
+
+def test_every_signal_pack_input_validates_to_signalpack():
+    for entry in load_corpus(STARTER):
+        pack, manifest, user_count, permissions_analysis = build_inputs(entry)
+        assert isinstance(pack, SignalPack)
+        # optional inputs are either None or their expected container types
+        assert manifest is None or isinstance(manifest, dict)
+        assert user_count is None or isinstance(user_count, int)
+        assert permissions_analysis is None or isinstance(permissions_analysis, dict)
+
+
+def test_missing_required_field_is_rejected():
+    bad = {"id": "x", "name": "x", "label": "unknown"}  # no 'inputs'
+    with pytest.raises(CorpusError):
+        validate_entry(bad, 0)
+
+
+def test_invalid_label_is_rejected():
+    bad = {
+        "id": "x",
+        "name": "x",
+        "label": "definitely-not-a-label",
+        "inputs": {"signal_pack": {"scan_id": "x"}},
+    }
+    with pytest.raises(CorpusError):
+        validate_entry(bad, 0)
+
+
+def test_invalid_expected_verdict_is_rejected():
+    bad = {
+        "id": "x",
+        "name": "x",
+        "label": "unknown",
+        "expected_verdict": "MAYBE",
+        "inputs": {"signal_pack": {"scan_id": "x"}},
+    }
+    with pytest.raises(CorpusError):
+        validate_entry(bad, 0)
+
+
+def test_inputs_without_signal_pack_is_rejected():
+    bad = {"id": "x", "name": "x", "label": "unknown", "inputs": {"manifest": None}}
+    with pytest.raises(CorpusError):
+        validate_entry(bad, 0)
+
+
+def test_malformed_signal_pack_is_rejected():
+    bad = {
+        "id": "x",
+        "name": "x",
+        "label": "unknown",
+        # scan_id is required by SignalPack; omitting it must fail validation.
+        "inputs": {"signal_pack": {"extension_id": "e"}},
+    }
+    with pytest.raises(CorpusError):
+        validate_entry(bad, 0)
+
+
+def test_non_string_id_is_rejected_with_corpus_error():
+    # A list/dict id must raise CorpusError (not a bare unhashable TypeError).
+    bad = {
+        "id": ["not", "a", "string"],
+        "name": "x",
+        "label": "unknown",
+        "inputs": {"signal_pack": {"scan_id": "x"}},
+    }
+    with pytest.raises(CorpusError):
+        validate_entry(bad, 0)
+
+
+def test_empty_id_is_rejected():
+    bad = {"id": "", "name": "x", "label": "unknown", "inputs": {"signal_pack": {"scan_id": "x"}}}
+    with pytest.raises(CorpusError):
+        validate_entry(bad, 0)
+
+
+def test_duplicate_ids_are_rejected():
+    dup = [
+        {"id": "same", "name": "a", "label": "unknown", "inputs": {"signal_pack": {"scan_id": "a"}}},
+        {"id": "same", "name": "b", "label": "unknown", "inputs": {"signal_pack": {"scan_id": "b"}}},
+    ]
+    with pytest.raises(CorpusError):
+        validate_corpus(dup)


### PR DESCRIPTION
Adds the offline foundation required before any future scoring weight/layer change (PR-4 conservative weights, PR-5 reputation modifier). It introduces **no scoring behavior change** — it only reads inputs and runs the existing engine.

## Why
Weight/layer changes move scores and verdicts and must be calibrated against data, not intuition. The golden snapshots are frozen *outputs* of a few pinned fixtures — they pin stability but can't be recomputed under a new model, so they aren't a calibration corpus. This PR stores scoring **inputs** so any future model can be re-run against them and diffed.

## What
- **Corpus schema** — entries store SignalPack-shaped inputs (`signal_pack` + optional `manifest`/`user_count`/`permissions_analysis`), never pre-scored `ScoringResult`. Advisory `label`/`expected_verdict` are human ground-truth for future calibration.
- **Harness** (`scripts/scoring/compare_scoring_corpus.py`) — recomputes offline via `ScoringEngine(weights_version).calculate_scores(...)` and emits a Markdown/CSV diff: score delta, verdict-flip type (ALLOW↔NEEDS_REVIEW / NEEDS_REVIEW↔BLOCK / ALLOW↔BLOCK), layer deltas, factor deltas. Non-deterministic fields (`created_at`) are excluded, so identity mode (v1 vs v1) is an exact zero diff. Fully offline — no APIs, scans, or DB access.
- **Starter corpus** is synthetic (`label: "unknown"`); real labels are left to a documented template. Generated reports write to the git-ignored `scoring_reports/`.
- **Docs** (`docs/scoring/corpus.md`) — schema, how to add cases, how to read flips, and version-bump sign-off rules.
- **Tests** — schema validation, SignalPack round-trip, identity zero-diff, flip classification, and report rendering (incl. the non-empty/factor-delta path and markdown-cell escaping). No test asserts engine output against a corpus label.

## Run it
```
uv run python -m scripts.scoring.compare_scoring_corpus \
  --corpus tests/fixtures/scoring_corpus/starter_corpus.json \
  --baseline v1 --candidate v1
```
Today only `v1` exists, so the default is identity mode (zero diff — the machinery self-check). When a future preset lands, `--candidate v1.1` shows the real before/after.

## Reviewer notes
- No weights/gates/rulepacks/thresholds/frontend or version constants touched; only `.gitignore` is modified among existing files (adds `scoring_reports/`).
- Tests: `tests/scoring/` (130) and `tests/test_golden_snapshots.py` (21) pass; golden snapshots unchanged.