### PR TITLE
feat(scoring): signal-pack extraction utility for corpus labeling

### DIFF
--- a/docs/scoring/corpus_inventory.md
+++ b/docs/scoring/corpus_inventory.md
@@ -1,0 +1,117 @@
+# Scoring corpus inventory & labeling guide
+
+Companion to [`corpus.md`](corpus.md) (the #274 schema + harness). This file
+records **what labeled data exists**, how to grow it safely, and how the
+golden-fixture extraction utility fits in. Every count below is backed by a
+command you can re-run — do not restate numbers without verifying them.
+
+## Current inventory (verified)
+
+| Source | Count | Labels |
+| --- | --- | --- |
+| `tests/fixtures/scoring_corpus/starter_corpus.json` | 2 entries | `unknown` ×2 (synthetic) |
+| `tests/fixtures/scoring_corpus/template.json` | 1 entry | `unknown` (template) |
+| **Real, evidence-backed labeled cases** | **0** | — |
+
+Verify:
+
+```
+python3 -c "import json,collections; d=json.load(open('tests/fixtures/scoring_corpus/starter_corpus.json')); print(len(d), collections.Counter(e['label'] for e in d))"
+# -> 2 Counter({'unknown': 2})
+git grep -nE '"label"[[:space:]]*:[[:space:]]*"[a-z_]+"' -- '*.json' '*.py'
+# -> every match is value 'unknown' (12 hits). No benign/malicious/needs_review/
+#    low_confidence value exists anywhere in tracked files.
+```
+
+(The schema rejection test in `tests/scoring/test_scoring_corpus_schema.py` uses a
+deliberately invalid label `"definitely-not-a-label"`; its hyphens fall outside
+`[a-z_]+`, so it does not appear in the grep above — it is not a real label.)
+
+The starter entries self-identify as synthetic (`tags: ["synthetic", …]`, and
+`rationale` says "NOT a real-world labeled case").
+
+## Golden fixtures are OUTPUTS, not inputs
+
+`tests/fixtures/*_results.json` are **5 pre-scored scan-output payloads** for real
+named extensions (e.g. "Equalizer for Chrome browser", "Session Buddy"). They
+carry engine outputs (`governance_verdict`, `overall_security_score`, …) and have
+**no** top-level `signal_pack`. A raw `SignalPack.model_validate` on one **fails**
+(missing `scan_id`), and their analyzer sections are shaped differently from the
+SignalPack sub-packs — so they need conversion, not a direct load.
+
+Verify (representative):
+
+```
+python3 -c "import json; d=json.load(open('tests/fixtures/abikfbojmghmfjdjlbagiamkinbmbaic_results.json')); print('signal_pack' in d, 'governance_verdict' in d)"
+# -> False True   (output payload, not an input)
+```
+
+## The extraction utility (`scripts/scoring/extract_signal_pack.py`)
+
+Converts a golden fixture into a corpus entry by **reusing the production
+`SignalPackBuilder`** (`extension_shield.governance.tool_adapters`) — the same
+builder the real scan pipeline uses (`report_view_model.py`, `governance_nodes.py`,
+`payload_helpers.py`, `api/main.py`). It reconstructs the `analysis_results` dict
+from the fixture sections (identity for most; `sast_results` → `javascript_analysis`,
+the key `SastAdapter` reads), builds the pack, and serializes it with
+`model_dump(mode="json")` into `inputs.signal_pack`.
+
+```
+# dry-run to stdout (offline):
+uv run python -m scripts.scoring.extract_signal_pack tests/fixtures/abikfbojmghmfjdjlbagiamkinbmbaic_results.json
+# write to an uncommitted path (never into tests/fixtures/scoring_corpus/):
+uv run python -m scripts.scoring.extract_signal_pack tests/fixtures/*_results.json --output /tmp/extracted_corpus.json
+```
+
+- Fully offline: `SignalPackBuilder.build()` is a pure dict→SignalPack transform
+  (no scans/network/DB).
+- `label` is always `unknown`; `expected_verdict` is `null` unless a human passes
+  `--expected-verdict`. The fixture's `governance_verdict`/`overall_*` are recorded
+  only under a non-authoritative `extraction.engine_outputs_not_ground_truth` field
+  and are **never** used as a label.
+- **No silent data loss:** it warns (stderr) when a fixture section had data but
+  the built sub-pack came back empty (a key mismatch), rather than dropping it.
+
+### Fidelity caveat
+
+Extracted packs are **best-effort reconstructions for labeling**, not a
+score-reproduction guarantee. Re-scoring one may not reproduce the fixture's
+stored `overall_security_score`/`governance_verdict`: the fixtures may predate the
+current engine/normalizer, and the persisted results view is not guaranteed
+identical to the raw `analysis_results` the builder originally consumed. The
+harness's job is before/after comparison of a *fixed* input under two models — not
+matching a historical score.
+
+## Labeling rules (for the future data-population PR)
+
+- Default to `label: "unknown"`; assign a real label only when the fixture signals
+  provide **evidence-backed** support. Do not infer labels from filenames.
+- `malicious` requires the **strongest** evidence and an explicit rationale.
+- **Never** treat `governance_verdict`/`overall_risk` as ground truth — they are
+  engine outputs, not human labels.
+- Real extension IDs/names carry accuracy/reputation risk: **anonymize or
+  evidence-gate** them before committing labeled real-extension corpus data.
+- **Do not commit** CRX binaries, `extensions_storage/`, `local_rescan_reports/`,
+  `EXTENSIONSHIELD_ENGINE_STATE.md`, or any private/user data. This utility ships
+  the tool only — it does not commit extracted real-extension entries.
+
+## Minimum viable corpus (proposed target)
+
+A defensible first-pass calibration target (a starting proposal, to refine — per
+OWASP, "not necessary to be over-precise"):
+
+| Label | Target | Have (real) | Shortfall |
+| --- | --- | ---: | ---: |
+| benign | 15 | 0 | 15 |
+| malicious | 15 | 0 | 15 |
+| needs_review | 10 | 0 | 10 |
+| low_confidence / coverage-limited | 10 | 0 | 10 |
+| **Total** | **~50** | **0** | **~50** |
+
+## Blocker status
+
+- **PR-4 (v1.1 weights): BLOCKED** — 0 real labeled cases vs the ~50 target; churn
+  cannot be proven without a labeled before/after corpus.
+- **PR-5 (v2 reputation modifier): BLOCKED** — machinery exists, corpus data does
+  not. The extraction utility (this PR) is a prerequisite step toward the data,
+  not the data itself.

--- a/scripts/scoring/extract_signal_pack.py
+++ b/scripts/scoring/extract_signal_pack.py
@@ -1,0 +1,285 @@
+"""Golden-fixture → SignalPack extraction utility for corpus labeling.
+
+Converts existing ``tests/fixtures/*_results.json`` scan-OUTPUT payloads into
+corpus-compatible ``inputs.signal_pack`` entries (the PR #274 schema), so real
+scans can seed a labeled corpus. See ``docs/scoring/corpus_inventory.md``.
+
+Design contract
+---------------
+* **Reuse production assembly, do not hand-roll.** The SignalPack is built by the
+  same ``SignalPackBuilder`` the real pipeline uses
+  (``extension_shield.governance.tool_adapters``), fed a reconstructed
+  ``analysis_results`` dict. We do NOT re-implement the analyzer→sub-pack mapping,
+  so the extracted pack matches what production would build. The only fixups are
+  key names the adapters expect: identity for most sections, plus
+  ``sast_results`` → ``javascript_analysis`` (what ``SastAdapter`` reads).
+* **Fully offline.** ``build()`` is a pure dict→SignalPack transform — no scans,
+  network, or DB. This module only reads local JSON and imports local code.
+* **Never invents labels.** ``label`` defaults to ``"unknown"`` and
+  ``expected_verdict`` to ``null`` unless a human passes one explicitly. The
+  fixture's ``governance_verdict``/``overall_*`` are ENGINE OUTPUTS, never treated
+  as ground truth (recorded only under a clearly-marked, non-authoritative field).
+* **Best-effort reconstruction.** Re-scoring an extracted pack may NOT reproduce
+  the fixture's stored score (fixtures may predate the current engine/normalizer;
+  the persisted results view is not guaranteed identical to the raw
+  ``analysis_results``). These entries are for LABELING, not score reproduction.
+* **Tool-only PR.** This utility does not commit extracted real-extension corpus
+  entries — output defaults to stdout; ``--output`` writes to a caller-specified
+  path and refuses to write into the committed corpus dir. Committing labeled
+  real-extension data is a separate, human-reviewed step.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+from extension_shield.governance.signal_pack import SignalPack
+from extension_shield.governance.tool_adapters import SignalPackBuilder
+from scripts.scoring.compare_scoring_corpus import CorpusError, validate_entry
+
+# Fixture analyzer-section keys that the adapters read from ``analysis_results``
+# under the SAME name (identity mapping).
+_IDENTITY_KEYS: Tuple[str, ...] = (
+    "virustotal_analysis",
+    "entropy_analysis",
+    "webstore_analysis",
+    "permissions_analysis",
+    "chromestats_analysis",
+    "network_analysis",
+)
+# Fixture key -> analysis_results key the adapter expects (non-identity fixups).
+# SAST is persisted as ``sast_results`` but ``SastAdapter`` reads
+# ``javascript_analysis`` (verified in tool_adapters.py:SastAdapter.adapt).
+_REMAP: Dict[str, str] = {"sast_results": "javascript_analysis"}
+
+# Engine OUTPUT fields that must NEVER be used as a human label. Recorded (some
+# of them) only under entry["extraction"]["engine_outputs_not_ground_truth"].
+_OUTPUT_ONLY_FIELDS: Tuple[str, ...] = (
+    "governance_verdict",
+    "governance_bundle",
+    "governance_report",
+    "overall_risk",
+    "overall_security_score",
+    "risk_distribution",
+    "total_risk_score",
+    "summary",
+)
+
+
+def reconstruct_analysis_results(
+    fixture: Dict[str, Any],
+) -> Tuple[Dict[str, Any], List[str]]:
+    """Rebuild the ``analysis_results`` dict the adapters consume from a fixture.
+
+    Returns (analysis_results, used_keys) where used_keys records what was mapped
+    (for the extraction audit trail).
+    """
+    analysis_results: Dict[str, Any] = {}
+    used: List[str] = []
+    for key in _IDENTITY_KEYS:
+        if fixture.get(key) is not None:
+            analysis_results[key] = fixture[key]
+            used.append(key)
+    for src, dst in _REMAP.items():
+        if fixture.get(src) is not None:
+            analysis_results[dst] = fixture[src]
+            used.append(f"{src}->{dst}")
+    return analysis_results, used
+
+
+def _coverage_warnings(fixture: Dict[str, Any], pack: SignalPack) -> List[str]:
+    """Flag sections where the fixture HAD data but the built sub-pack is empty.
+
+    A warning means the reconstruction likely lost data (a key mismatch) — the
+    opposite of silent loss. Sections the fixture simply lacks are not warned.
+    """
+    warns: List[str] = []
+
+    sast_findings = (fixture.get("sast_results") or {}).get("sast_findings") or {}
+    had_sast = (
+        any(bool(v) for v in sast_findings.values())
+        if isinstance(sast_findings, dict)
+        else bool(sast_findings)
+    )
+    if had_sast and not pack.sast.deduped_findings and not pack.sast.raw_findings:
+        warns.append("sast: fixture had findings but built SAST pack is empty")
+
+    if fixture.get("virustotal_analysis") and not pack.virustotal.enabled:
+        warns.append("virustotal: fixture had data but built VT pack is disabled")
+
+    if fixture.get("entropy_analysis") and pack.entropy.files_analyzed == 0:
+        warns.append("entropy: fixture had data but files_analyzed=0")
+
+    if fixture.get("permissions_analysis") and (
+        pack.permissions.total_permissions == 0
+        and not pack.permissions.api_permissions
+        and not pack.permissions.host_permissions
+    ):
+        warns.append("permissions: fixture had data but built permissions pack is empty")
+
+    return warns
+
+
+def extract_entry(
+    fixture: Dict[str, Any],
+    *,
+    source_path: str = "",
+    expected_verdict: Optional[str] = None,
+) -> Tuple[Dict[str, Any], List[str]]:
+    """Build one corpus entry from a golden fixture. Returns (entry, warnings).
+
+    Raises CorpusError if the fixture lacks an extension_id or the produced entry
+    fails schema/SignalPack validation.
+    """
+    ext_id = fixture.get("extension_id")
+    if not ext_id or not isinstance(ext_id, str):
+        raise CorpusError(f"fixture {source_path or '<unknown>'} has no usable extension_id")
+
+    analysis_results, used_keys = reconstruct_analysis_results(fixture)
+    pack = SignalPackBuilder().build(
+        scan_id=ext_id,
+        analysis_results=analysis_results,
+        metadata=fixture.get("metadata") or {},
+        manifest=fixture.get("manifest") or {},
+        extension_id=ext_id,
+    )
+    warns = _coverage_warnings(fixture, pack)
+
+    metadata = fixture.get("metadata") or {}
+    user_count = metadata.get("user_count") or metadata.get("users")
+
+    entry: Dict[str, Any] = {
+        "id": f"golden-{ext_id}",
+        "name": fixture.get("extension_name") or ext_id,
+        "label": "unknown",  # never inferred from engine output
+        "expected_verdict": expected_verdict,  # None unless a human passed one
+        "confidence": None,
+        "source_type": "real_scan",
+        "rationale": (
+            "Extracted from a committed golden scan-output fixture via the "
+            "production SignalPackBuilder. Best-effort reconstruction for future "
+            "human labeling; NOT evidence-backed and NOT a score-reproduction guarantee."
+        ),
+        "tags": ["extracted", "real_scan", "needs_labeling"],
+        "known_signals": [],
+        "notes": (
+            "Auto-extracted; label='unknown' until a human reviews the evidence. "
+            "engine outputs are recorded under 'extraction' but are NOT ground truth."
+        ),
+        "extraction": {
+            "source_fixture": source_path,
+            "reconstruction_used_keys": used_keys,
+            "coverage_warnings": warns,
+            "engine_outputs_not_ground_truth": {
+                k: fixture[k] for k in ("governance_verdict",) if k in fixture
+            },
+        },
+        "inputs": {
+            "signal_pack": pack.model_dump(mode="json"),
+            "manifest": fixture.get("manifest"),
+            "user_count": user_count,
+            "permissions_analysis": None,
+        },
+    }
+
+    # Validate against the #274 schema and the SignalPack model before emitting.
+    validate_entry(entry)
+    SignalPack.model_validate(entry["inputs"]["signal_pack"])
+    return entry, warns
+
+
+def extract_entries(
+    fixture_paths: List[str],
+    *,
+    expected_verdict: Optional[str] = None,
+) -> Tuple[List[Dict[str, Any]], List[str]]:
+    """Extract entries for multiple fixture paths. Returns (entries, all_warnings)."""
+    entries: List[Dict[str, Any]] = []
+    all_warns: List[str] = []
+    for path in fixture_paths:
+        fixture = json.loads(Path(path).read_text(encoding="utf-8"))
+        entry, warns = extract_entry(fixture, source_path=path, expected_verdict=expected_verdict)
+        entries.append(entry)
+        all_warns.extend(f"[{path}] {w}" for w in warns)
+    return entries, all_warns
+
+
+_CORPUS_DIR_GUARD = "tests/fixtures/scoring_corpus"
+
+
+def _is_within_corpus_dir(out: Path) -> bool:
+    """True if ``out`` resolves inside the committed corpus dir.
+
+    Uses the RESOLVED, absolute path so cwd-relative paths, ``..`` traversal, and
+    symlinks cannot slip a write into ``tests/fixtures/scoring_corpus/`` (a plain
+    substring check on the raw path is bypassable — e.g. ``--output out.json`` run
+    from inside that directory).
+    """
+    resolved = out.resolve()
+    try:
+        repo_root = Path(__file__).resolve().parents[2]
+        corpus_dir = (repo_root / _CORPUS_DIR_GUARD).resolve()
+        if resolved == corpus_dir or resolved.is_relative_to(corpus_dir):
+            return True
+    except (IndexError, OSError, ValueError):
+        pass
+    # Fallback: substring on the normalized/absolute path (still catches the dir
+    # even if the repo layout differs from the expected scripts/scoring/ anchor).
+    return _CORPUS_DIR_GUARD in resolved.as_posix()
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Extract corpus signal_pack entries from golden scan-output fixtures "
+            "(fully offline; reuses the production SignalPackBuilder). Defaults to "
+            "stdout dry-run; does not commit real-extension corpus data."
+        )
+    )
+    parser.add_argument("fixtures", nargs="+", help="Path(s) to *_results.json golden fixtures.")
+    parser.add_argument(
+        "--output",
+        default=None,
+        help=(
+            "Write the corpus JSON array to this path. Default: stdout (dry-run). "
+            f"Refuses to write into {_CORPUS_DIR_GUARD}/ (committing real-extension "
+            "corpus is a separate, human-reviewed step)."
+        ),
+    )
+    parser.add_argument(
+        "--expected-verdict",
+        default=None,
+        choices=("ALLOW", "NEEDS_REVIEW", "BLOCK"),
+        help="Optional human-provided expected_verdict for all entries (default: null).",
+    )
+    return parser
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    args = _build_parser().parse_args(argv)
+    entries, warns = extract_entries(args.fixtures, expected_verdict=args.expected_verdict)
+    for w in warns:
+        print(f"WARN {w}", file=sys.stderr)
+    payload = json.dumps(entries, indent=2)
+    if args.output:
+        out = Path(args.output)
+        if _is_within_corpus_dir(out):
+            raise SystemExit(
+                f"Refusing to write into {_CORPUS_DIR_GUARD}/ — committing extracted "
+                "real-extension corpus entries is deferred to a human-reviewed labeling PR."
+            )
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(payload, encoding="utf-8")
+        print(f"Wrote {len(entries)} entrie(s) to {out}", file=sys.stderr)
+    else:
+        print(payload)
+    print(f"extracted={len(entries)} warnings={len(warns)}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scoring/test_extract_signal_pack.py
+++ b/tests/scoring/test_extract_signal_pack.py
@@ -1,0 +1,197 @@
+"""Tests for the golden-fixture → signal_pack extraction utility.
+
+These verify the extractor reuses the production SignalPackBuilder to produce
+valid, schema-conforming corpus entries with default 'unknown' labels, surfaces
+coverage warnings instead of silently losing data, and stays fully offline.
+
+Deliberately absent: any assertion that a re-scored extracted pack reproduces the
+fixture's stored overall_security_score/governance_verdict. Extracted entries are
+best-effort reconstructions for labeling, not score-reproduction guarantees.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from extension_shield.governance.signal_pack import SignalPack
+from scripts.scoring.compare_scoring_corpus import CorpusError, validate_entry
+from scripts.scoring.extract_signal_pack import (
+    _CORPUS_DIR_GUARD,
+    _coverage_warnings,
+    _is_within_corpus_dir,
+    extract_entries,
+    extract_entry,
+    main,
+    reconstruct_analysis_results,
+)
+
+FIXTURE_DIR = Path(__file__).parent.parent / "fixtures"
+GOLDEN = sorted(FIXTURE_DIR.glob("*_results.json"))
+
+
+def _load(path):
+    return json.loads(Path(path).read_text(encoding="utf-8"))
+
+
+def test_golden_fixtures_present():
+    # Guard: the extractor is meaningless if the fixtures moved.
+    assert len(GOLDEN) >= 1, "expected at least one tests/fixtures/*_results.json"
+
+
+@pytest.mark.parametrize("path", GOLDEN, ids=lambda p: p.name)
+def test_every_golden_fixture_extracts_to_valid_entry(path):
+    entry, warns = extract_entry(_load(path), source_path=str(path))
+    # validate_entry is also called inside extract_entry, but assert explicitly.
+    validate_entry(entry)
+    SignalPack.model_validate(entry["inputs"]["signal_pack"])
+    assert entry["label"] == "unknown"
+    assert entry["expected_verdict"] is None
+    assert entry["source_type"] == "real_scan"
+    assert entry["id"].startswith("golden-")
+
+
+def test_reuse_populates_signal_pack_where_fixture_had_data():
+    # The whole point of reusing SignalPackBuilder: real data must flow through,
+    # not silently vanish. Every golden fixture carries entropy + permissions +
+    # webstore installs, so the built pack must reflect at least one of them.
+    for path in GOLDEN:
+        entry, _ = extract_entry(_load(path), source_path=str(path))
+        sp = entry["inputs"]["signal_pack"]
+        entropy_files = sp["entropy"]["files_analyzed"]
+        total_perms = sp["permissions"]["total_permissions"]
+        installs = sp["webstore_stats"]["installs"]
+        assert (entropy_files > 0) or (total_perms > 0) or (installs not in (None, 0)), (
+            f"{path.name}: built pack lost all analyzer data -> silent-loss regression"
+        )
+
+
+def test_sast_remap_maps_findings_for_a_fixture_with_sast():
+    # Pinterest fixture is known (verified) to have a SAST finding; the
+    # sast_results->javascript_analysis remap must carry it into the pack.
+    target = next((p for p in GOLDEN if p.name.startswith("nkabool")), None)
+    if target is None:
+        pytest.skip("expected SAST-bearing fixture not present")
+    entry, _ = extract_entry(_load(target), source_path=str(target))
+    sast = entry["inputs"]["signal_pack"]["sast"]
+    assert sast["files_scanned"] > 0
+    # This fixture has a finding; the remap must not drop it.
+    assert len(sast["deduped_findings"]) >= 1
+
+
+def test_governance_verdict_is_never_used_as_label():
+    path = GOLDEN[0]
+    fixture = _load(path)
+    entry, _ = extract_entry(fixture, source_path=str(path))
+    assert entry["label"] == "unknown"
+    assert entry["expected_verdict"] is None
+    # If the fixture carries an engine verdict, it may be recorded ONLY under the
+    # clearly-marked non-authoritative field — never as label/expected_verdict.
+    recorded = entry["extraction"]["engine_outputs_not_ground_truth"]
+    if "governance_verdict" in fixture:
+        assert recorded.get("governance_verdict") == fixture["governance_verdict"]
+    assert entry["label"] != fixture.get("governance_verdict")
+
+
+def test_real_extension_name_and_id_carried_safely():
+    path = GOLDEN[0]
+    fixture = _load(path)
+    entry, _ = extract_entry(fixture, source_path=str(path))
+    assert entry["name"] == (fixture.get("extension_name") or fixture["extension_id"])
+    assert fixture["extension_id"] in entry["id"]
+
+
+def test_human_expected_verdict_is_honored_when_passed():
+    path = GOLDEN[0]
+    entry, _ = extract_entry(_load(path), source_path=str(path), expected_verdict="NEEDS_REVIEW")
+    assert entry["expected_verdict"] == "NEEDS_REVIEW"
+
+
+def test_missing_extension_id_fails_loudly():
+    with pytest.raises(CorpusError):
+        extract_entry({"extension_name": "no id here"}, source_path="synthetic")
+
+
+def test_coverage_warning_when_fixture_data_does_not_map():
+    # Unit-test the warning path directly: a fixture that HAS sast findings paired
+    # with an empty built pack must warn (not silently drop).
+    fake_fixture = {"sast_results": {"sast_findings": {"a.js": [{"check_id": "x"}]}}}
+    empty_pack = SignalPack.model_validate({"scan_id": "s"})
+    warns = _coverage_warnings(fake_fixture, empty_pack)
+    assert any("sast" in w for w in warns)
+
+
+def test_no_warnings_for_a_clean_extraction():
+    # Real golden fixtures reconstruct cleanly; none should warn (regression guard
+    # on the remap staying correct).
+    _, warns = extract_entries([str(p) for p in GOLDEN])
+    assert warns == [], f"unexpected coverage warnings: {warns}"
+
+
+def test_reconstruct_remaps_sast_key():
+    fixture = _load(GOLDEN[0])
+    ar, used = reconstruct_analysis_results(fixture)
+    if fixture.get("sast_results") is not None:
+        assert "javascript_analysis" in ar
+        assert "sast_results->javascript_analysis" in used
+
+
+def test_cli_dry_run_prints_json_array(capsys):
+    rc = main([str(GOLDEN[0])])
+    assert rc == 0
+    out = capsys.readouterr().out
+    parsed = json.loads(out)
+    assert isinstance(parsed, list) and len(parsed) == 1
+    assert parsed[0]["label"] == "unknown"
+
+
+def test_cli_refuses_to_write_into_committed_corpus_dir(tmp_path):
+    bad = f"{_CORPUS_DIR_GUARD}/should_not_write.json"
+    with pytest.raises(SystemExit):
+        main([str(GOLDEN[0]), "--output", bad])
+
+
+def test_corpus_dir_guard_resolves_paths():
+    # Direct path into the corpus dir -> blocked.
+    assert _is_within_corpus_dir(Path(f"{_CORPUS_DIR_GUARD}/x.json")) is True
+    # `..` traversal that resolves into the corpus dir -> blocked.
+    assert _is_within_corpus_dir(
+        Path(f"tests/fixtures/../fixtures/scoring_corpus/x.json")
+    ) is True
+    # An absolute path landing in the corpus dir -> blocked.
+    repo_root = Path(__file__).resolve().parents[2]
+    assert _is_within_corpus_dir(repo_root / _CORPUS_DIR_GUARD / "x.json") is True
+
+
+def test_corpus_dir_guard_allows_paths_outside(tmp_path):
+    assert _is_within_corpus_dir(tmp_path / "extracted.json") is False
+
+
+def test_cli_refuses_cwd_relative_bypass(tmp_path, monkeypatch):
+    # Regression for the substring-guard bypass: run from inside the corpus dir
+    # with a cwd-relative --output; the resolved path is inside the dir -> refuse.
+    corpus_dir = Path(__file__).resolve().parents[2] / _CORPUS_DIR_GUARD
+    monkeypatch.chdir(corpus_dir)
+    with pytest.raises(SystemExit):
+        main([str(GOLDEN[0]), "--output", "sneaked_in.json"])
+    assert not (corpus_dir / "sneaked_in.json").exists()
+
+
+def test_cli_output_writes_to_allowed_path(tmp_path):
+    out = tmp_path / "extracted.json"
+    rc = main([str(GOLDEN[0]), "--output", str(out)])
+    assert rc == 0 and out.exists()
+    data = json.loads(out.read_text(encoding="utf-8"))
+    assert isinstance(data, list) and data[0]["label"] == "unknown"
+
+
+def test_extraction_is_offline(monkeypatch):
+    # Prove no network: make socket construction explode, then extract anyway.
+    import socket
+
+    def _boom(*a, **k):
+        raise AssertionError("network access attempted during offline extraction")
+
+    monkeypatch.setattr(socket, "socket", _boom)
+    entry, _ = extract_entry(_load(GOLDEN[0]), source_path=str(GOLDEN[0]))
+    assert entry["label"] == "unknown"


### PR DESCRIPTION
Converts the committed golden scan-output fixtures into corpus-compatible `inputs.signal_pack` entries so real scans can seed a labeled calibration corpus. This is the data-unblocker identified by the corpus audit — **no scoring behavior changes**.

## Why
The #274 corpus schema + before/after harness exist, but there are **0 real labeled cases** (starter corpus is 2 synthetic `unknown`). The 5 `tests/fixtures/*_results.json` are pre-scored *output* payloads, not `inputs.signal_pack` — a direct `SignalPack.model_validate` fails and their analyzer sections don't match the sub-pack shapes. This utility bridges that gap.

## What
- **`scripts/scoring/extract_signal_pack.py`** — reuses the **production `SignalPackBuilder`** (`governance/tool_adapters`), the same builder the real pipeline uses, rather than hand-rolling a mapping. It reconstructs `analysis_results` from the fixture sections (identity keys + `sast_results → javascript_analysis`, the key `SastAdapter` reads) and serializes with `model_dump(mode="json")`.
  - Fully offline (pure dict→SignalPack transform; no scans/network/DB).
  - **Never invents labels:** `label` defaults to `unknown`, `expected_verdict` to `null`; `governance_verdict`/`overall_*` are recorded only as non-authoritative context, never used as ground truth.
  - **No silent data loss:** warns when a fixture section had data but the built sub-pack came back empty.
  - **Tool-only:** defaults to stdout; `--output` refuses (resolved-path check) to write into the committed corpus dir. Committing labeled real-extension data is a separate, human-reviewed step.
- **`tests/scoring/test_extract_signal_pack.py`** — 22 tests: valid-entry extraction for all 5 fixtures, SAST-remap fidelity, offline guarantee, label-safety, the write-guard (incl. cwd-relative bypass regression), and coverage-warning behavior. No test asserts re-scored packs reproduce stored scores (best-effort reconstruction).
- **`docs/scoring/corpus_inventory.md`** — verified inventory (0 real labeled cases), labeling/anonymization rules, MVP corpus target, and PR-4/PR-5 blocked status.

## Fidelity caveat
Extracted packs are best-effort reconstructions for **labeling**, not score-reproduction guarantees — fixtures may predate the current engine/normalizer.

## Reviewer notes
- No protected files touched (`git diff master --name-only` = these 3 new files only). No weights/gates/rulepacks/engine/tool_adapters/frontend/version changes.
- Does **not** commit any extracted real-extension corpus entry.
- Tests: `tests/scoring/` (152) and `tests/test_golden_snapshots.py` (21) pass; golden snapshots unchanged.
- Reviewed by an adversarial verification pass; two findings (a bypassable write-guard, a doc grep inaccuracy) were fixed before submission.