### PR TITLE
test(scoring): seed synthetic labeled corpus cases

### DIFF
--- a/docs/scoring/corpus_inventory.md
+++ b/docs/scoring/corpus_inventory.md
@@ -11,24 +11,43 @@ command you can re-run — do not restate numbers without verifying them.
 | --- | --- | --- |
 | `tests/fixtures/scoring_corpus/starter_corpus.json` | 2 entries | `unknown` ×2 (synthetic) |
 | `tests/fixtures/scoring_corpus/template.json` | 1 entry | `unknown` (template) |
+| `tests/fixtures/scoring_corpus/synthetic_labeled_seed.json` | 8 entries | `benign` ×2, `malicious` ×2, `needs_review` ×2, `low_confidence` ×2 (all **synthetic**) |
 | **Real, evidence-backed labeled cases** | **0** | — |
 
 Verify:
 
 ```
-python3 -c "import json,collections; d=json.load(open('tests/fixtures/scoring_corpus/starter_corpus.json')); print(len(d), collections.Counter(e['label'] for e in d))"
-# -> 2 Counter({'unknown': 2})
-git grep -nE '"label"[[:space:]]*:[[:space:]]*"[a-z_]+"' -- '*.json' '*.py'
-# -> every match is value 'unknown' (12 hits). No benign/malicious/needs_review/
-#    low_confidence value exists anywhere in tracked files.
+python3 -c "import json,collections; d=json.load(open('tests/fixtures/scoring_corpus/synthetic_labeled_seed.json')); print(len(d), collections.Counter(e['label'] for e in d))"
+# -> 8 Counter({'benign': 2, 'malicious': 2, 'needs_review': 2, 'low_confidence': 2})
 ```
 
-(The schema rejection test in `tests/scoring/test_scoring_corpus_schema.py` uses a
-deliberately invalid label `"definitely-not-a-label"`; its hyphens fall outside
-`[a-z_]+`, so it does not appear in the grep above — it is not a real label.)
+**The synthetic seed does not change the real labeled count — it is still 0.** The
+seed's entries are fully synthetic calibration scaffolding (see below), not real
+extensions. The starter/template entries remain `unknown` and self-identify as
+synthetic.
 
-The starter entries self-identify as synthetic (`tags: ["synthetic", …]`, and
-`rationale` says "NOT a real-world labeled case").
+## Synthetic labeled seed (calibration scaffolding, not real data)
+
+`synthetic_labeled_seed.json` is a small, **fully synthetic, PII-free** set that
+exercises the harness across the four scored classes. Every entry is generated
+from a constructed `SignalPack` (`model_dump(mode="json")`), uses only
+`synthetic-*` ids/names and `example.*` domains, and carries **no** real
+extension id, brand, developer name, email, URL, or CRX data. Each `label` is
+justified by concrete synthetic signal values in the entry's `rationale` (e.g.
+`virustotal.malicious_count=8`, `sast.counts_by_severity.CRITICAL=1`,
+`sast.files_scanned=0`).
+
+`expected_verdict` is `null` for every entry: `label` is the intended
+ground-truth class, not the engine's output. Each entry's `notes` records the
+**observed current engine behavior (non-authoritative)** so future weight work
+can diff against it. Where the observed verdict differs from the label intent
+(e.g. `low_confidence` entries currently score `NEEDS_REVIEW` via the coverage
+cap), that mismatch is intended calibration evidence — not a bug and not asserted
+by any test.
+
+This seed is for **harness coverage and calibration scaffolding only**. It is not
+evidence of real-world model quality, and it does not substitute for a real
+labeled corpus.
 
 ## Golden fixtures are OUTPUTS, not inputs
 

--- a/tests/fixtures/scoring_corpus/synthetic_labeled_seed.json
+++ b/tests/fixtures/scoring_corpus/synthetic_labeled_seed.json
@@ -1,0 +1,1060 @@
+[
+  {
+    "id": "synthetic-benign-001",
+    "name": "Synthetic Benign Extension",
+    "label": "benign",
+    "expected_verdict": null,
+    "confidence": null,
+    "source_type": "synthetic",
+    "rationale": "vt.malicious_count=0, sast findings=0, entropy overall_risk=low, permissions.total=1 (storage) -> no risk signals",
+    "tags": [
+      "synthetic",
+      "benign"
+    ],
+    "notes": "Fully synthetic, PII-free. observed current engine behavior (non-authoritative): decision=ALLOW overall=99",
+    "inputs": {
+      "signal_pack": {
+        "scan_id": "synthetic-benign-001",
+        "extension_id": "synthetic-benign-001",
+        "sast": {
+          "raw_findings": {},
+          "deduped_findings": [],
+          "counts_by_severity": {
+            "CRITICAL": 0,
+            "ERROR": 0,
+            "WARNING": 0,
+            "INFO": 0
+          },
+          "confidence": 1.0,
+          "files_scanned": 1,
+          "files_with_findings": 0,
+          "scan_error": false
+        },
+        "virustotal": {
+          "malicious_count": 0,
+          "suspicious_count": 0,
+          "harmless_count": 0,
+          "undetected_count": 0,
+          "total_engines": 70,
+          "vendor_hits": [],
+          "malware_families": [],
+          "ratios": {},
+          "files_analyzed": 0,
+          "enabled": true,
+          "timestamp": null
+        },
+        "entropy": {
+          "file_entropy_map": {},
+          "suspected_obfuscation_files": [],
+          "minified_files": [],
+          "high_risk_patterns": {},
+          "thresholds_used": {
+            "normal_max": 5.5,
+            "suspicious_min": 6.5,
+            "high_risk_min": 7.5
+          },
+          "files_analyzed": 3,
+          "obfuscated_count": 0,
+          "suspicious_count": 0,
+          "overall_risk": "low"
+        },
+        "webstore_stats": {
+          "installs": 1000,
+          "rating_avg": 4.5,
+          "rating_count": null,
+          "last_updated": null,
+          "developer": null,
+          "developer_email": null,
+          "developer_website": null,
+          "developer_profile": {},
+          "category": null,
+          "is_featured": false,
+          "follows_best_practices": false,
+          "has_privacy_policy": true
+        },
+        "webstore_reviews": {
+          "sampled_reviews": [],
+          "complaint_clusters": [],
+          "keyword_hits": {},
+          "time_trend": {},
+          "manipulation_flags": [],
+          "total_reviews_sampled": 0,
+          "negative_review_ratio": 0.0
+        },
+        "permissions": {
+          "api_permissions": [
+            "storage"
+          ],
+          "host_permissions": [],
+          "optional_permissions": [],
+          "permission_analysis": [],
+          "unreasonable_permissions": [],
+          "high_risk_permissions": [],
+          "has_broad_host_access": false,
+          "broad_host_patterns": [],
+          "total_permissions": 1
+        },
+        "chromestats": {
+          "enabled": false,
+          "risk_indicators": [],
+          "total_risk_score": 0,
+          "overall_risk_level": "low",
+          "install_trends": {},
+          "rating_patterns": {},
+          "developer_reputation": {}
+        },
+        "network": {
+          "enabled": false,
+          "domains": [],
+          "has_runtime_url_construction": false,
+          "suspicious_flags": {
+            "http_unencrypted": false,
+            "base64_encoded_urls": false,
+            "high_entropy_payload": false,
+            "dynamic_url_construction": false,
+            "credential_exfil_pattern": false,
+            "data_harvest_pattern": false
+          },
+          "external_request_count": 0,
+          "data_sending_patterns": [],
+          "confidence": 0.0
+        },
+        "evidence": [],
+        "created_at": "2024-01-01T00:00:00Z"
+      },
+      "manifest": null,
+      "user_count": null,
+      "permissions_analysis": null
+    }
+  },
+  {
+    "id": "synthetic-benign-002",
+    "name": "Synthetic Minimal Permissions Extension",
+    "label": "benign",
+    "expected_verdict": null,
+    "confidence": null,
+    "source_type": "synthetic",
+    "rationale": "permissions.total=1 (storage only), has_broad_host_access=false, host=[], vt.malicious_count=0, sast findings=0 -> minimal attack surface",
+    "tags": [
+      "synthetic",
+      "benign"
+    ],
+    "notes": "Fully synthetic, PII-free. observed current engine behavior (non-authoritative): decision=ALLOW overall=99",
+    "inputs": {
+      "signal_pack": {
+        "scan_id": "synthetic-benign-002",
+        "extension_id": "synthetic-benign-002",
+        "sast": {
+          "raw_findings": {},
+          "deduped_findings": [],
+          "counts_by_severity": {
+            "CRITICAL": 0,
+            "ERROR": 0,
+            "WARNING": 0,
+            "INFO": 0
+          },
+          "confidence": 1.0,
+          "files_scanned": 1,
+          "files_with_findings": 0,
+          "scan_error": false
+        },
+        "virustotal": {
+          "malicious_count": 0,
+          "suspicious_count": 0,
+          "harmless_count": 0,
+          "undetected_count": 0,
+          "total_engines": 70,
+          "vendor_hits": [],
+          "malware_families": [],
+          "ratios": {},
+          "files_analyzed": 0,
+          "enabled": true,
+          "timestamp": null
+        },
+        "entropy": {
+          "file_entropy_map": {},
+          "suspected_obfuscation_files": [],
+          "minified_files": [],
+          "high_risk_patterns": {},
+          "thresholds_used": {
+            "normal_max": 5.5,
+            "suspicious_min": 6.5,
+            "high_risk_min": 7.5
+          },
+          "files_analyzed": 3,
+          "obfuscated_count": 0,
+          "suspicious_count": 0,
+          "overall_risk": "low"
+        },
+        "webstore_stats": {
+          "installs": 1000,
+          "rating_avg": 4.5,
+          "rating_count": null,
+          "last_updated": null,
+          "developer": null,
+          "developer_email": null,
+          "developer_website": null,
+          "developer_profile": {},
+          "category": null,
+          "is_featured": false,
+          "follows_best_practices": false,
+          "has_privacy_policy": true
+        },
+        "webstore_reviews": {
+          "sampled_reviews": [],
+          "complaint_clusters": [],
+          "keyword_hits": {},
+          "time_trend": {},
+          "manipulation_flags": [],
+          "total_reviews_sampled": 0,
+          "negative_review_ratio": 0.0
+        },
+        "permissions": {
+          "api_permissions": [
+            "storage"
+          ],
+          "host_permissions": [],
+          "optional_permissions": [],
+          "permission_analysis": [],
+          "unreasonable_permissions": [],
+          "high_risk_permissions": [],
+          "has_broad_host_access": false,
+          "broad_host_patterns": [],
+          "total_permissions": 1
+        },
+        "chromestats": {
+          "enabled": false,
+          "risk_indicators": [],
+          "total_risk_score": 0,
+          "overall_risk_level": "low",
+          "install_trends": {},
+          "rating_patterns": {},
+          "developer_reputation": {}
+        },
+        "network": {
+          "enabled": false,
+          "domains": [],
+          "has_runtime_url_construction": false,
+          "suspicious_flags": {
+            "http_unencrypted": false,
+            "base64_encoded_urls": false,
+            "high_entropy_payload": false,
+            "dynamic_url_construction": false,
+            "credential_exfil_pattern": false,
+            "data_harvest_pattern": false
+          },
+          "external_request_count": 0,
+          "data_sending_patterns": [],
+          "confidence": 0.0
+        },
+        "evidence": [],
+        "created_at": "2024-01-01T00:00:00Z"
+      },
+      "manifest": null,
+      "user_count": null,
+      "permissions_analysis": null
+    }
+  },
+  {
+    "id": "synthetic-malicious-001",
+    "name": "Synthetic VT Malware Extension",
+    "label": "malicious",
+    "expected_verdict": null,
+    "confidence": null,
+    "source_type": "synthetic",
+    "rationale": "virustotal.malicious_count=8 (>=5 VT_MALWARE block threshold), enabled=true, malware_families set -> confirmed malware detections",
+    "tags": [
+      "synthetic",
+      "malicious"
+    ],
+    "notes": "Fully synthetic, PII-free. observed current engine behavior (non-authoritative): decision=BLOCK overall=78",
+    "inputs": {
+      "signal_pack": {
+        "scan_id": "synthetic-malicious-001",
+        "extension_id": "synthetic-malicious-001",
+        "sast": {
+          "raw_findings": {},
+          "deduped_findings": [],
+          "counts_by_severity": {
+            "CRITICAL": 0,
+            "ERROR": 0,
+            "WARNING": 0,
+            "INFO": 0
+          },
+          "confidence": 1.0,
+          "files_scanned": 1,
+          "files_with_findings": 0,
+          "scan_error": false
+        },
+        "virustotal": {
+          "malicious_count": 8,
+          "suspicious_count": 0,
+          "harmless_count": 60,
+          "undetected_count": 0,
+          "total_engines": 70,
+          "vendor_hits": [
+            {
+              "vendor_name": "SyntheticAV",
+              "result": "Trojan.Synthetic",
+              "category": "malicious"
+            }
+          ],
+          "malware_families": [
+            "synthetic.trojan.gen"
+          ],
+          "ratios": {},
+          "files_analyzed": 0,
+          "enabled": true,
+          "timestamp": null
+        },
+        "entropy": {
+          "file_entropy_map": {},
+          "suspected_obfuscation_files": [],
+          "minified_files": [],
+          "high_risk_patterns": {},
+          "thresholds_used": {
+            "normal_max": 5.5,
+            "suspicious_min": 6.5,
+            "high_risk_min": 7.5
+          },
+          "files_analyzed": 3,
+          "obfuscated_count": 0,
+          "suspicious_count": 0,
+          "overall_risk": "low"
+        },
+        "webstore_stats": {
+          "installs": 1000,
+          "rating_avg": 4.5,
+          "rating_count": null,
+          "last_updated": null,
+          "developer": null,
+          "developer_email": null,
+          "developer_website": null,
+          "developer_profile": {},
+          "category": null,
+          "is_featured": false,
+          "follows_best_practices": false,
+          "has_privacy_policy": true
+        },
+        "webstore_reviews": {
+          "sampled_reviews": [],
+          "complaint_clusters": [],
+          "keyword_hits": {},
+          "time_trend": {},
+          "manipulation_flags": [],
+          "total_reviews_sampled": 0,
+          "negative_review_ratio": 0.0
+        },
+        "permissions": {
+          "api_permissions": [
+            "storage"
+          ],
+          "host_permissions": [],
+          "optional_permissions": [],
+          "permission_analysis": [],
+          "unreasonable_permissions": [],
+          "high_risk_permissions": [],
+          "has_broad_host_access": false,
+          "broad_host_patterns": [],
+          "total_permissions": 1
+        },
+        "chromestats": {
+          "enabled": false,
+          "risk_indicators": [],
+          "total_risk_score": 0,
+          "overall_risk_level": "low",
+          "install_trends": {},
+          "rating_patterns": {},
+          "developer_reputation": {}
+        },
+        "network": {
+          "enabled": false,
+          "domains": [],
+          "has_runtime_url_construction": false,
+          "suspicious_flags": {
+            "http_unencrypted": false,
+            "base64_encoded_urls": false,
+            "high_entropy_payload": false,
+            "dynamic_url_construction": false,
+            "credential_exfil_pattern": false,
+            "data_harvest_pattern": false
+          },
+          "external_request_count": 0,
+          "data_sending_patterns": [],
+          "confidence": 0.0
+        },
+        "evidence": [],
+        "created_at": "2024-01-01T00:00:00Z"
+      },
+      "manifest": null,
+      "user_count": null,
+      "permissions_analysis": null
+    }
+  },
+  {
+    "id": "synthetic-malicious-002",
+    "name": "Synthetic Critical SAST Extension",
+    "label": "malicious",
+    "expected_verdict": null,
+    "confidence": null,
+    "source_type": "synthetic",
+    "rationale": "sast.counts_by_severity.CRITICAL=1 (remote-code eval finding) >= sast_critical_block_count -> CRITICAL_SAST",
+    "tags": [
+      "synthetic",
+      "malicious"
+    ],
+    "notes": "Fully synthetic, PII-free. observed current engine behavior (non-authoritative): decision=BLOCK overall=71",
+    "inputs": {
+      "signal_pack": {
+        "scan_id": "synthetic-malicious-002",
+        "extension_id": "synthetic-malicious-002",
+        "sast": {
+          "raw_findings": {
+            "background.js": 1
+          },
+          "deduped_findings": [
+            {
+              "check_id": "synthetic.remote-code-exec",
+              "file_path": "background.js",
+              "line_number": 1,
+              "severity": "CRITICAL",
+              "message": "Synthetic: eval() of remote-fetched code",
+              "category": "remote_code",
+              "code_snippet": null
+            }
+          ],
+          "counts_by_severity": {
+            "CRITICAL": 1,
+            "ERROR": 0,
+            "WARNING": 0,
+            "INFO": 0
+          },
+          "confidence": 1.0,
+          "files_scanned": 4,
+          "files_with_findings": 1,
+          "scan_error": false
+        },
+        "virustotal": {
+          "malicious_count": 0,
+          "suspicious_count": 0,
+          "harmless_count": 0,
+          "undetected_count": 0,
+          "total_engines": 70,
+          "vendor_hits": [],
+          "malware_families": [],
+          "ratios": {},
+          "files_analyzed": 0,
+          "enabled": true,
+          "timestamp": null
+        },
+        "entropy": {
+          "file_entropy_map": {},
+          "suspected_obfuscation_files": [],
+          "minified_files": [],
+          "high_risk_patterns": {},
+          "thresholds_used": {
+            "normal_max": 5.5,
+            "suspicious_min": 6.5,
+            "high_risk_min": 7.5
+          },
+          "files_analyzed": 3,
+          "obfuscated_count": 0,
+          "suspicious_count": 0,
+          "overall_risk": "low"
+        },
+        "webstore_stats": {
+          "installs": 1000,
+          "rating_avg": 4.5,
+          "rating_count": null,
+          "last_updated": null,
+          "developer": null,
+          "developer_email": null,
+          "developer_website": null,
+          "developer_profile": {},
+          "category": null,
+          "is_featured": false,
+          "follows_best_practices": false,
+          "has_privacy_policy": true
+        },
+        "webstore_reviews": {
+          "sampled_reviews": [],
+          "complaint_clusters": [],
+          "keyword_hits": {},
+          "time_trend": {},
+          "manipulation_flags": [],
+          "total_reviews_sampled": 0,
+          "negative_review_ratio": 0.0
+        },
+        "permissions": {
+          "api_permissions": [
+            "storage"
+          ],
+          "host_permissions": [],
+          "optional_permissions": [],
+          "permission_analysis": [],
+          "unreasonable_permissions": [],
+          "high_risk_permissions": [],
+          "has_broad_host_access": false,
+          "broad_host_patterns": [],
+          "total_permissions": 1
+        },
+        "chromestats": {
+          "enabled": false,
+          "risk_indicators": [],
+          "total_risk_score": 0,
+          "overall_risk_level": "low",
+          "install_trends": {},
+          "rating_patterns": {},
+          "developer_reputation": {}
+        },
+        "network": {
+          "enabled": false,
+          "domains": [],
+          "has_runtime_url_construction": false,
+          "suspicious_flags": {
+            "http_unencrypted": false,
+            "base64_encoded_urls": false,
+            "high_entropy_payload": false,
+            "dynamic_url_construction": false,
+            "credential_exfil_pattern": false,
+            "data_harvest_pattern": false
+          },
+          "external_request_count": 0,
+          "data_sending_patterns": [],
+          "confidence": 0.0
+        },
+        "evidence": [],
+        "created_at": "2024-01-01T00:00:00Z"
+      },
+      "manifest": null,
+      "user_count": null,
+      "permissions_analysis": null
+    }
+  },
+  {
+    "id": "synthetic-needsreview-001",
+    "name": "Synthetic Sensitive Combo Extension",
+    "label": "needs_review",
+    "expected_verdict": null,
+    "confidence": null,
+    "source_type": "synthetic",
+    "rationale": "sensitive permission combo: cookies + has_broad_host_access(<all_urls>) + scripting, but vt.malicious_count=0 and 0 SAST findings -> capability worth review, no malicious evidence",
+    "tags": [
+      "synthetic",
+      "needs_review"
+    ],
+    "notes": "Fully synthetic, PII-free. observed current engine behavior (non-authoritative): decision=NEEDS_REVIEW overall=84",
+    "inputs": {
+      "signal_pack": {
+        "scan_id": "synthetic-needsreview-001",
+        "extension_id": "synthetic-needsreview-001",
+        "sast": {
+          "raw_findings": {},
+          "deduped_findings": [],
+          "counts_by_severity": {
+            "CRITICAL": 0,
+            "ERROR": 0,
+            "WARNING": 0,
+            "INFO": 0
+          },
+          "confidence": 1.0,
+          "files_scanned": 1,
+          "files_with_findings": 0,
+          "scan_error": false
+        },
+        "virustotal": {
+          "malicious_count": 0,
+          "suspicious_count": 0,
+          "harmless_count": 0,
+          "undetected_count": 0,
+          "total_engines": 70,
+          "vendor_hits": [],
+          "malware_families": [],
+          "ratios": {},
+          "files_analyzed": 0,
+          "enabled": true,
+          "timestamp": null
+        },
+        "entropy": {
+          "file_entropy_map": {},
+          "suspected_obfuscation_files": [],
+          "minified_files": [],
+          "high_risk_patterns": {},
+          "thresholds_used": {
+            "normal_max": 5.5,
+            "suspicious_min": 6.5,
+            "high_risk_min": 7.5
+          },
+          "files_analyzed": 3,
+          "obfuscated_count": 0,
+          "suspicious_count": 0,
+          "overall_risk": "low"
+        },
+        "webstore_stats": {
+          "installs": 1000,
+          "rating_avg": 4.5,
+          "rating_count": null,
+          "last_updated": null,
+          "developer": null,
+          "developer_email": null,
+          "developer_website": null,
+          "developer_profile": {},
+          "category": null,
+          "is_featured": false,
+          "follows_best_practices": false,
+          "has_privacy_policy": true
+        },
+        "webstore_reviews": {
+          "sampled_reviews": [],
+          "complaint_clusters": [],
+          "keyword_hits": {},
+          "time_trend": {},
+          "manipulation_flags": [],
+          "total_reviews_sampled": 0,
+          "negative_review_ratio": 0.0
+        },
+        "permissions": {
+          "api_permissions": [
+            "cookies",
+            "scripting",
+            "tabs",
+            "storage"
+          ],
+          "host_permissions": [
+            "<all_urls>"
+          ],
+          "optional_permissions": [],
+          "permission_analysis": [],
+          "unreasonable_permissions": [],
+          "high_risk_permissions": [
+            "cookies"
+          ],
+          "has_broad_host_access": true,
+          "broad_host_patterns": [
+            "<all_urls>"
+          ],
+          "total_permissions": 4
+        },
+        "chromestats": {
+          "enabled": false,
+          "risk_indicators": [],
+          "total_risk_score": 0,
+          "overall_risk_level": "low",
+          "install_trends": {},
+          "rating_patterns": {},
+          "developer_reputation": {}
+        },
+        "network": {
+          "enabled": false,
+          "domains": [],
+          "has_runtime_url_construction": false,
+          "suspicious_flags": {
+            "http_unencrypted": false,
+            "base64_encoded_urls": false,
+            "high_entropy_payload": false,
+            "dynamic_url_construction": false,
+            "credential_exfil_pattern": false,
+            "data_harvest_pattern": false
+          },
+          "external_request_count": 0,
+          "data_sending_patterns": [],
+          "confidence": 0.0
+        },
+        "evidence": [],
+        "created_at": "2024-01-01T00:00:00Z"
+      },
+      "manifest": null,
+      "user_count": null,
+      "permissions_analysis": null
+    }
+  },
+  {
+    "id": "synthetic-needsreview-002",
+    "name": "Synthetic No Privacy Policy Extension",
+    "label": "needs_review",
+    "expected_verdict": null,
+    "confidence": null,
+    "source_type": "synthetic",
+    "rationale": "webstore_stats.has_privacy_policy=false with broad host access -> governance/disclosure gap; no malware/critical-SAST",
+    "tags": [
+      "synthetic",
+      "needs_review"
+    ],
+    "notes": "Fully synthetic, PII-free. observed current engine behavior (non-authoritative): decision=NEEDS_REVIEW overall=85",
+    "inputs": {
+      "signal_pack": {
+        "scan_id": "synthetic-needsreview-002",
+        "extension_id": "synthetic-needsreview-002",
+        "sast": {
+          "raw_findings": {},
+          "deduped_findings": [],
+          "counts_by_severity": {
+            "CRITICAL": 0,
+            "ERROR": 0,
+            "WARNING": 0,
+            "INFO": 0
+          },
+          "confidence": 1.0,
+          "files_scanned": 1,
+          "files_with_findings": 0,
+          "scan_error": false
+        },
+        "virustotal": {
+          "malicious_count": 0,
+          "suspicious_count": 0,
+          "harmless_count": 0,
+          "undetected_count": 0,
+          "total_engines": 70,
+          "vendor_hits": [],
+          "malware_families": [],
+          "ratios": {},
+          "files_analyzed": 0,
+          "enabled": true,
+          "timestamp": null
+        },
+        "entropy": {
+          "file_entropy_map": {},
+          "suspected_obfuscation_files": [],
+          "minified_files": [],
+          "high_risk_patterns": {},
+          "thresholds_used": {
+            "normal_max": 5.5,
+            "suspicious_min": 6.5,
+            "high_risk_min": 7.5
+          },
+          "files_analyzed": 3,
+          "obfuscated_count": 0,
+          "suspicious_count": 0,
+          "overall_risk": "low"
+        },
+        "webstore_stats": {
+          "installs": 1000,
+          "rating_avg": 4.5,
+          "rating_count": null,
+          "last_updated": null,
+          "developer": null,
+          "developer_email": null,
+          "developer_website": null,
+          "developer_profile": {},
+          "category": null,
+          "is_featured": false,
+          "follows_best_practices": false,
+          "has_privacy_policy": false
+        },
+        "webstore_reviews": {
+          "sampled_reviews": [],
+          "complaint_clusters": [],
+          "keyword_hits": {},
+          "time_trend": {},
+          "manipulation_flags": [],
+          "total_reviews_sampled": 0,
+          "negative_review_ratio": 0.0
+        },
+        "permissions": {
+          "api_permissions": [
+            "tabs",
+            "storage"
+          ],
+          "host_permissions": [
+            "<all_urls>"
+          ],
+          "optional_permissions": [],
+          "permission_analysis": [],
+          "unreasonable_permissions": [],
+          "high_risk_permissions": [],
+          "has_broad_host_access": true,
+          "broad_host_patterns": [
+            "<all_urls>"
+          ],
+          "total_permissions": 2
+        },
+        "chromestats": {
+          "enabled": false,
+          "risk_indicators": [],
+          "total_risk_score": 0,
+          "overall_risk_level": "low",
+          "install_trends": {},
+          "rating_patterns": {},
+          "developer_reputation": {}
+        },
+        "network": {
+          "enabled": false,
+          "domains": [],
+          "has_runtime_url_construction": false,
+          "suspicious_flags": {
+            "http_unencrypted": false,
+            "base64_encoded_urls": false,
+            "high_entropy_payload": false,
+            "dynamic_url_construction": false,
+            "credential_exfil_pattern": false,
+            "data_harvest_pattern": false
+          },
+          "external_request_count": 0,
+          "data_sending_patterns": [],
+          "confidence": 0.0
+        },
+        "evidence": [],
+        "created_at": "2024-01-01T00:00:00Z"
+      },
+      "manifest": null,
+      "user_count": null,
+      "permissions_analysis": null
+    }
+  },
+  {
+    "id": "synthetic-lowconf-001",
+    "name": "Synthetic No SAST Coverage Extension",
+    "label": "low_confidence",
+    "expected_verdict": null,
+    "confidence": null,
+    "source_type": "synthetic",
+    "rationale": "sast.files_scanned=0 (analyzer produced no coverage) -> cannot confirm code safety; other signals thin",
+    "tags": [
+      "synthetic",
+      "low_confidence"
+    ],
+    "notes": "Fully synthetic, PII-free. observed current engine behavior (non-authoritative): decision=NEEDS_REVIEW overall=80",
+    "inputs": {
+      "signal_pack": {
+        "scan_id": "synthetic-lowconf-001",
+        "extension_id": "synthetic-lowconf-001",
+        "sast": {
+          "raw_findings": {},
+          "deduped_findings": [],
+          "counts_by_severity": {
+            "CRITICAL": 0,
+            "ERROR": 0,
+            "WARNING": 0,
+            "INFO": 0
+          },
+          "confidence": 1.0,
+          "files_scanned": 0,
+          "files_with_findings": 0,
+          "scan_error": false
+        },
+        "virustotal": {
+          "malicious_count": 0,
+          "suspicious_count": 0,
+          "harmless_count": 0,
+          "undetected_count": 0,
+          "total_engines": 70,
+          "vendor_hits": [],
+          "malware_families": [],
+          "ratios": {},
+          "files_analyzed": 0,
+          "enabled": true,
+          "timestamp": null
+        },
+        "entropy": {
+          "file_entropy_map": {},
+          "suspected_obfuscation_files": [],
+          "minified_files": [],
+          "high_risk_patterns": {},
+          "thresholds_used": {
+            "normal_max": 5.5,
+            "suspicious_min": 6.5,
+            "high_risk_min": 7.5
+          },
+          "files_analyzed": 0,
+          "obfuscated_count": 0,
+          "suspicious_count": 0,
+          "overall_risk": "low"
+        },
+        "webstore_stats": {
+          "installs": 1000,
+          "rating_avg": 4.5,
+          "rating_count": null,
+          "last_updated": null,
+          "developer": null,
+          "developer_email": null,
+          "developer_website": null,
+          "developer_profile": {},
+          "category": null,
+          "is_featured": false,
+          "follows_best_practices": false,
+          "has_privacy_policy": true
+        },
+        "webstore_reviews": {
+          "sampled_reviews": [],
+          "complaint_clusters": [],
+          "keyword_hits": {},
+          "time_trend": {},
+          "manipulation_flags": [],
+          "total_reviews_sampled": 0,
+          "negative_review_ratio": 0.0
+        },
+        "permissions": {
+          "api_permissions": [
+            "storage"
+          ],
+          "host_permissions": [],
+          "optional_permissions": [],
+          "permission_analysis": [],
+          "unreasonable_permissions": [],
+          "high_risk_permissions": [],
+          "has_broad_host_access": false,
+          "broad_host_patterns": [],
+          "total_permissions": 1
+        },
+        "chromestats": {
+          "enabled": false,
+          "risk_indicators": [],
+          "total_risk_score": 0,
+          "overall_risk_level": "low",
+          "install_trends": {},
+          "rating_patterns": {},
+          "developer_reputation": {}
+        },
+        "network": {
+          "enabled": false,
+          "domains": [],
+          "has_runtime_url_construction": false,
+          "suspicious_flags": {
+            "http_unencrypted": false,
+            "base64_encoded_urls": false,
+            "high_entropy_payload": false,
+            "dynamic_url_construction": false,
+            "credential_exfil_pattern": false,
+            "data_harvest_pattern": false
+          },
+          "external_request_count": 0,
+          "data_sending_patterns": [],
+          "confidence": 0.0
+        },
+        "evidence": [],
+        "created_at": "2024-01-01T00:00:00Z"
+      },
+      "manifest": null,
+      "user_count": null,
+      "permissions_analysis": null
+    }
+  },
+  {
+    "id": "synthetic-lowconf-002",
+    "name": "Synthetic Coverage Gap With Weak Signals Extension",
+    "label": "low_confidence",
+    "expected_verdict": null,
+    "confidence": null,
+    "source_type": "synthetic",
+    "rationale": "sast.files_scanned=0 (no static coverage) while entropy.obfuscated_count=2 (medium) -> flagged obfuscation with no analyzer to confirm behavior",
+    "tags": [
+      "synthetic",
+      "low_confidence"
+    ],
+    "notes": "Fully synthetic, PII-free. observed current engine behavior (non-authoritative): decision=NEEDS_REVIEW overall=80",
+    "inputs": {
+      "signal_pack": {
+        "scan_id": "synthetic-lowconf-002",
+        "extension_id": "synthetic-lowconf-002",
+        "sast": {
+          "raw_findings": {},
+          "deduped_findings": [],
+          "counts_by_severity": {
+            "CRITICAL": 0,
+            "ERROR": 0,
+            "WARNING": 0,
+            "INFO": 0
+          },
+          "confidence": 1.0,
+          "files_scanned": 0,
+          "files_with_findings": 0,
+          "scan_error": false
+        },
+        "virustotal": {
+          "malicious_count": 0,
+          "suspicious_count": 0,
+          "harmless_count": 0,
+          "undetected_count": 0,
+          "total_engines": 70,
+          "vendor_hits": [],
+          "malware_families": [],
+          "ratios": {},
+          "files_analyzed": 0,
+          "enabled": true,
+          "timestamp": null
+        },
+        "entropy": {
+          "file_entropy_map": {},
+          "suspected_obfuscation_files": [],
+          "minified_files": [],
+          "high_risk_patterns": {},
+          "thresholds_used": {
+            "normal_max": 5.5,
+            "suspicious_min": 6.5,
+            "high_risk_min": 7.5
+          },
+          "files_analyzed": 4,
+          "obfuscated_count": 2,
+          "suspicious_count": 2,
+          "overall_risk": "medium"
+        },
+        "webstore_stats": {
+          "installs": 1000,
+          "rating_avg": 4.5,
+          "rating_count": null,
+          "last_updated": null,
+          "developer": null,
+          "developer_email": null,
+          "developer_website": null,
+          "developer_profile": {},
+          "category": null,
+          "is_featured": false,
+          "follows_best_practices": false,
+          "has_privacy_policy": true
+        },
+        "webstore_reviews": {
+          "sampled_reviews": [],
+          "complaint_clusters": [],
+          "keyword_hits": {},
+          "time_trend": {},
+          "manipulation_flags": [],
+          "total_reviews_sampled": 0,
+          "negative_review_ratio": 0.0
+        },
+        "permissions": {
+          "api_permissions": [
+            "storage"
+          ],
+          "host_permissions": [],
+          "optional_permissions": [],
+          "permission_analysis": [],
+          "unreasonable_permissions": [],
+          "high_risk_permissions": [],
+          "has_broad_host_access": false,
+          "broad_host_patterns": [],
+          "total_permissions": 1
+        },
+        "chromestats": {
+          "enabled": false,
+          "risk_indicators": [],
+          "total_risk_score": 0,
+          "overall_risk_level": "low",
+          "install_trends": {},
+          "rating_patterns": {},
+          "developer_reputation": {}
+        },
+        "network": {
+          "enabled": false,
+          "domains": [],
+          "has_runtime_url_construction": false,
+          "suspicious_flags": {
+            "http_unencrypted": false,
+            "base64_encoded_urls": false,
+            "high_entropy_payload": false,
+            "dynamic_url_construction": false,
+            "credential_exfil_pattern": false,
+            "data_harvest_pattern": false
+          },
+          "external_request_count": 0,
+          "data_sending_patterns": [],
+          "confidence": 0.0
+        },
+        "evidence": [],
+        "created_at": "2024-01-01T00:00:00Z"
+      },
+      "manifest": null,
+      "user_count": null,
+      "permissions_analysis": null
+    }
+  }
+]

--- a/tests/scoring/test_scoring_corpus_compare.py
+++ b/tests/scoring/test_scoring_corpus_compare.py
@@ -59,11 +59,26 @@ def _synthetic_row(**overrides):
 
 FIXTURES = Path(__file__).parent.parent / "fixtures" / "scoring_corpus"
 STARTER = FIXTURES / "starter_corpus.json"
+SYNTHETIC = FIXTURES / "synthetic_labeled_seed.json"
 
 
 @pytest.fixture()
 def starter():
     return load_corpus(STARTER)
+
+
+def test_synthetic_seed_loads_and_scores_zero_diff_identity():
+    # The harness must load the synthetic seed and, in identity mode (v1 vs v1),
+    # score every entry with no diff. This proves the synthetic packs are
+    # engine-loadable and the harness handles the new file.
+    corpus = load_corpus(SYNTHETIC)
+    rows = compare_corpus(corpus, DEFAULT_BASELINE, DEFAULT_BASELINE)
+    assert len(rows) == len(corpus) and len(rows) >= 6
+    assert has_any_diff(rows) is False
+    for row in rows:
+        assert row["score_delta"] == 0 and row["verdict_flip"] == ""
+        # every synthetic entry produces a real verdict (no crash / empty)
+        assert row["baseline_verdict"] in ("ALLOW", "NEEDS_REVIEW", "BLOCK")
 
 
 # --- identity mode ----------------------------------------------------------

--- a/tests/scoring/test_scoring_corpus_schema.py
+++ b/tests/scoring/test_scoring_corpus_schema.py
@@ -27,6 +27,7 @@ from scripts.scoring.compare_scoring_corpus import (
 FIXTURES = Path(__file__).parent.parent / "fixtures" / "scoring_corpus"
 STARTER = FIXTURES / "starter_corpus.json"
 TEMPLATE = FIXTURES / "template.json"
+SYNTHETIC = FIXTURES / "synthetic_labeled_seed.json"
 
 
 def test_starter_corpus_loads_and_validates():
@@ -134,3 +135,59 @@ def test_duplicate_ids_are_rejected():
     ]
     with pytest.raises(CorpusError):
         validate_corpus(dup)
+
+
+# ---------------------------------------------------------------------------
+# Synthetic labeled seed (fully synthetic, PII-free calibration scaffolding).
+# These are NOT real labeled cases; the real evidence-backed count stays 0.
+# ---------------------------------------------------------------------------
+
+import json  # noqa: E402  (local to the synthetic-seed section)
+import re  # noqa: E402
+
+# Allowed non-'unknown' labels for the synthetic seed.
+_SEED_LABELS = {"benign", "malicious", "needs_review", "low_confidence"}
+
+
+def test_synthetic_seed_loads_and_validates():
+    corpus = load_corpus(SYNTHETIC)  # runs validate_corpus internally
+    assert isinstance(corpus, list) and len(corpus) >= 6
+    for entry in corpus:
+        validate_entry(entry)
+        SignalPack.model_validate(entry["inputs"]["signal_pack"])
+
+
+def test_synthetic_seed_labels_are_from_allowed_set():
+    for entry in load_corpus(SYNTHETIC):
+        assert entry["label"] in _SEED_LABELS, entry["id"]
+        assert entry["label"] in VALID_LABELS
+        # These are intended ground-truth labels; expected_verdict stays advisory/null.
+        assert entry.get("expected_verdict") is None
+
+
+def test_synthetic_seed_covers_each_class():
+    labels = {e["label"] for e in load_corpus(SYNTHETIC)}
+    assert _SEED_LABELS.issubset(labels), f"seed missing classes: {_SEED_LABELS - labels}"
+
+
+def test_synthetic_seed_has_no_real_identifiers():
+    # PII/identifier leak guard: no real CWS extension id (32 chars a-p), no email,
+    # no http(s) URL, and any real-TLD domain must be an example.* domain.
+    blob = json.dumps(load_corpus(SYNTHETIC))
+    assert not re.search(r"[a-p]{32}", blob), "looks like a real 32-char CWS extension id"
+    assert not re.search(r"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}", blob), "email present"
+    assert not re.search(r"https?://", blob), "http(s) URL present"
+    # Only match tokens ending in a real TLD (avoids false positives on file
+    # extensions like background.js and dotted identifiers like a.b_c). Any such
+    # domain must be an example.* domain.
+    real_tlds = r"(?:com|net|org|io|co|dev|app|edu|gov|info|xyz|me|us|ai)"
+    for host in re.findall(rf"\b[a-z0-9-]+\.{real_tlds}\b", blob):
+        assert host.startswith("example."), f"non-example domain present: {host}"
+
+
+def test_synthetic_seed_ids_are_synthetic_prefixed():
+    for entry in load_corpus(SYNTHETIC):
+        assert entry["id"].startswith("synthetic-"), entry["id"]
+        # the real-id also must not leak into the in-pack identifiers
+        sp = entry["inputs"]["signal_pack"]
+        assert sp["scan_id"].startswith("synthetic-")


### PR DESCRIPTION
Add a small synthetic corpus seed for the offline scoring harness. The seed
covers all four scored labels with fully synthetic SignalPack inputs:

- benign x2
- malicious x2
- needs_review x2
- low_confidence x2

Each case uses only synthetic ids/names and no real extension data, brands,
emails, URLs, CRX artifacts, or developer information. Labels are grounded in
explicit synthetic signal values such as VT detections, critical SAST findings,
sensitive permission combinations, missing privacy policy signals, and SAST
coverage gaps.

This does not change scoring behavior. It only adds calibration scaffolding for
the corpus harness. The real evidence-backed labeled count remains 0, and PR-4 /
PR-5 remain blocked until a diverse real labeled corpus exists.

Also wires the new fixture into corpus validation and compare tests, adds a
leak guard for real identifiers, and updates the corpus inventory docs.