### PR TITLE
chore(scoring): anonymize extracted corpus entries

### DIFF
--- a/docs/scoring/corpus_inventory.md
+++ b/docs/scoring/corpus_inventory.md
@@ -109,7 +109,22 @@ matching a historical score.
 - **Never** treat `governance_verdict`/`overall_risk` as ground truth — they are
   engine outputs, not human labels.
 - Real extension IDs/names carry accuracy/reputation risk: **anonymize or
-  evidence-gate** them before committing labeled real-extension corpus data.
+  evidence-gate** them before committing labeled real-extension corpus data. The
+  extractor's `--anonymize` (with `--anonymization-salt`, `--redact-name`) scrubs
+  identifiers/PII across the **entire** entry — id, `extraction.source_fixture`,
+  `signal_pack.scan_id`/`extension_id`, `webstore_stats.developer*`, and manifest
+  name/author/homepage — not just the header. Score/verdict are unchanged **by
+  construction**: scoring-relevant value fields (host permissions, network
+  domains, `content_scripts` matches) are preserved verbatim, and scored
+  free-text (permission justifications, manifest name/description) is redacted
+  with a **keyword-preserving** scheme so the permission-abuse and
+  capture-signal keywords the normalizers key on survive. Consequences: preserved
+  host patterns may **retain brand hints** (domains are not generalized here), and
+  a redacted name may retain a generic capture keyword (e.g. `"[redacted]
+  screenshot"`) — acceptable, not PII. Hashing an already-public id is weak
+  privacy; its value is breaking the direct name→label association. Full
+  leak-freedom requires `--redact-name`. The real labeled corpus count remains 0;
+  PR-4/PR-5 remain blocked (this ships the tool, not the data).
 - **Do not commit** CRX binaries, `extensions_storage/`, `local_rescan_reports/`,
   `EXTENSIONSHIELD_ENGINE_STATE.md`, or any private/user data. This utility ships
   the tool only — it does not commit extracted real-extension entries.

--- a/scripts/scoring/extract_signal_pack.py
+++ b/scripts/scoring/extract_signal_pack.py
@@ -32,6 +32,9 @@ Design contract
 from __future__ import annotations
 
 import argparse
+import copy
+import hashlib
+import hmac
 import json
 import sys
 from pathlib import Path
@@ -129,11 +132,15 @@ def extract_entry(
     *,
     source_path: str = "",
     expected_verdict: Optional[str] = None,
+    anonymize: bool = False,
+    salt: Optional[str] = None,
+    redact_name: bool = False,
 ) -> Tuple[Dict[str, Any], List[str]]:
     """Build one corpus entry from a golden fixture. Returns (entry, warnings).
 
     Raises CorpusError if the fixture lacks an extension_id or the produced entry
-    fails schema/SignalPack validation.
+    fails schema/SignalPack validation. When ``anonymize`` is set, the returned
+    entry is fully anonymized (a non-empty ``salt`` is required).
     """
     ext_id = fixture.get("extension_id")
     if not ext_id or not isinstance(ext_id, str):
@@ -186,7 +193,11 @@ def extract_entry(
         },
     }
 
-    # Validate against the #274 schema and the SignalPack model before emitting.
+    if anonymize:
+        entry = anonymize_entry(entry, salt=salt or "", redact_name=redact_name)
+
+    # Validate the FINAL (possibly anonymized) entry against the #274 schema and
+    # the SignalPack model before emitting.
     validate_entry(entry)
     SignalPack.model_validate(entry["inputs"]["signal_pack"])
     return entry, warns
@@ -196,16 +207,216 @@ def extract_entries(
     fixture_paths: List[str],
     *,
     expected_verdict: Optional[str] = None,
+    anonymize: bool = False,
+    salt: Optional[str] = None,
+    redact_name: bool = False,
 ) -> Tuple[List[Dict[str, Any]], List[str]]:
     """Extract entries for multiple fixture paths. Returns (entries, all_warnings)."""
     entries: List[Dict[str, Any]] = []
     all_warns: List[str] = []
     for path in fixture_paths:
         fixture = json.loads(Path(path).read_text(encoding="utf-8"))
-        entry, warns = extract_entry(fixture, source_path=path, expected_verdict=expected_verdict)
+        entry, warns = extract_entry(
+            fixture,
+            source_path=path,
+            expected_verdict=expected_verdict,
+            anonymize=anonymize,
+            salt=salt,
+            redact_name=redact_name,
+        )
         entries.append(entry)
         all_warns.extend(f"[{path}] {w}" for w in warns)
     return entries, all_warns
+
+
+# --- anonymization ----------------------------------------------------------
+#
+# Anonymization scrubs identifiers/PII across the ENTIRE entry (not just the
+# header) via a TARGETED field allowlist plus a residual exact-token sweep. It
+# deliberately PRESERVES scoring-relevant fields (host permissions, network
+# domains, content_scripts matches, SAST findings) so the score/verdict are
+# unchanged — proven by a neutrality test. Domains are NOT generalized here
+# (deferred), so preserved host patterns may retain brand hints; that is the
+# accepted trade-off for trivially-provable scoring neutrality. Hashing an
+# already-public extension id is weak privacy; its value is breaking the direct
+# name -> label association in a committed corpus.
+
+# Scoring-relevant LEAF fields whose string values (host patterns / domains) may
+# contain brand substrings that ARE scoring inputs; the residual token sweep must
+# NOT touch these, so scoring neutrality holds. Everything else (developer
+# metadata, chromestats/virustotal/entropy corners, evidence, notes) IS swept so
+# brand names/ids/emails cannot hide there. manifest.name is handled separately by
+# the targeted scrub (it is read by the capture-signals heuristic).
+_SCORING_SUBTREE_KEYS = frozenset(
+    {
+        "host_permissions",
+        "broad_host_patterns",
+        "content_scripts",
+        "domains",
+    }
+)
+# Manifest metadata fields that carry identifiers/PII (scrubbed where present).
+_MANIFEST_PII_KEYS = ("name", "description", "author", "homepage_url", "update_url")
+_REDACTED = "[redacted]"
+
+# Scored free-text keywords that must survive redaction so anonymization stays
+# score-neutral by construction. Keep in sync with their normalizer sources:
+#   - abusive/malicious/covert: permission justification, normalizers.py:755
+#     (normalize_permissions_baseline applies a x2.0 weight on a match)
+#   - screenshot/capture/snap/screen grab/screen shot: manifest name/description,
+#     normalizers.py:1008 (normalize_capture_signals: x0.3 if matched as a
+#     disclosed screenshot tool, else x1.5 as covert capture)
+# A justification/name/description can legitimately contain the extension or
+# developer name, so it must be swept for leak-freedom; preserving the scored
+# keywords a removed token contained means scrubbing PII can never add or drop a
+# multiplier.
+_SCORED_FREETEXT_KEYWORDS = (
+    "abusive",
+    "malicious",
+    "covert",
+    "screenshot",
+    "capture",
+    "snap",
+    "screen grab",
+    "screen shot",
+)
+
+
+def _redaction_for(token: str) -> str:
+    """Placeholder for a scrubbed PII token, preserving any scored free-text
+    keyword the token contained (so free-text scoring signals are unchanged)."""
+    lowered = token.lower()
+    kept = [k for k in _SCORED_FREETEXT_KEYWORDS if k in lowered]
+    return _REDACTED + ((" " + " ".join(kept)) if kept else "")
+
+
+def _pseudonym(salt: str, real_id: str) -> str:
+    """Deterministic, salted pseudonym for a real id. Stable per salt; different
+    salt -> different pseudonym; never contains the original id."""
+    digest = hmac.new(salt.encode("utf-8"), (real_id or "").encode("utf-8"), hashlib.sha256).hexdigest()
+    return f"anon-{digest[:16]}"
+
+
+def _collect_pii_tokens(entry: Dict[str, Any], *, redact_name: bool) -> List[str]:
+    """Collect the exact real-PII strings to purge from free-text/metadata.
+
+    Returns them longest-first so substring replacement is stable. These are
+    identifiers; a keyword-preserving redaction (``_redaction_for``) keeps any
+    scored threat keyword a token contained, so replacing them is score-neutral.
+    """
+    tokens: set = set()
+    sp = (entry.get("inputs") or {}).get("signal_pack") or {}
+    ext_id = sp.get("extension_id") or sp.get("scan_id")
+    if isinstance(ext_id, str) and ext_id:
+        tokens.add(ext_id)
+    ws = sp.get("webstore_stats") or {}
+    for k in ("developer", "developer_email", "developer_website"):
+        v = ws.get(k)
+        if isinstance(v, str) and v:
+            tokens.add(v)
+    prof = ws.get("developer_profile") or {}
+    if isinstance(prof, dict):
+        for k in ("name", "email", "website"):
+            v = prof.get(k)
+            if isinstance(v, str) and v:
+                tokens.add(v)
+    mani = (entry.get("inputs") or {}).get("manifest") or {}
+    for k in ("author", "homepage_url"):
+        v = mani.get(k)
+        if isinstance(v, str) and v:
+            tokens.add(v)
+    if redact_name:
+        for v in (entry.get("name"), mani.get("name")):
+            if isinstance(v, str) and v:
+                tokens.add(v)
+    return sorted((t for t in tokens if t), key=len, reverse=True)
+
+
+def _scrub_tokens(obj: Any, tokens: List[str]) -> Any:
+    """Recursively replace exact PII token substrings in string leaves.
+
+    Scoring-VALUE fields (host patterns / domains) are skipped so they are never
+    altered. Scored free-text (e.g. permission ``justification``) IS swept — it
+    can name the extension/developer — but via a keyword-preserving redaction, so
+    the permissions-baseline threat-keyword multiplier is unchanged. Result:
+    scoring neutrality holds by construction, not only on the sample fixtures.
+    """
+    if isinstance(obj, dict):
+        return {
+            k: (v if k in _SCORING_SUBTREE_KEYS else _scrub_tokens(v, tokens))
+            for k, v in obj.items()
+        }
+    if isinstance(obj, list):
+        return [_scrub_tokens(v, tokens) for v in obj]
+    if isinstance(obj, str):
+        s = obj
+        for t in tokens:
+            if t and t in s:
+                s = s.replace(t, _redaction_for(t))
+        return s
+    return obj
+
+
+def anonymize_entry(
+    entry: Dict[str, Any],
+    *,
+    salt: str,
+    redact_name: bool = False,
+) -> Dict[str, Any]:
+    """Return a deep-copied, anonymized copy of a corpus entry.
+
+    Scrubs the full entry (targeted fields + residual token sweep) while leaving
+    scoring-relevant fields intact. Raises CorpusError if ``salt`` is empty.
+    """
+    if not salt:
+        raise CorpusError("anonymization requires a non-empty --anonymization-salt")
+    entry = copy.deepcopy(entry)
+
+    inputs = entry.get("inputs") or {}
+    sp = inputs.get("signal_pack") or {}
+    real_id = sp.get("extension_id") or sp.get("scan_id") or ""
+    if not real_id and isinstance(entry.get("id"), str):
+        real_id = entry["id"].split("golden-", 1)[-1]
+    pseudo = _pseudonym(salt, real_id)
+
+    tokens = _collect_pii_tokens(entry, redact_name=redact_name)
+
+    # --- targeted scrub (explicit identifier/PII fields) ---
+    entry["id"] = pseudo
+    if isinstance(entry.get("extraction"), dict):
+        entry["extraction"]["source_fixture"] = f"anonymized:{pseudo}"
+    if isinstance(sp, dict):
+        if "scan_id" in sp:
+            sp["scan_id"] = pseudo
+        if "extension_id" in sp:
+            sp["extension_id"] = pseudo
+        ws = sp.get("webstore_stats")
+        if isinstance(ws, dict):
+            for k in ("developer", "developer_email", "developer_website"):
+                if k in ws:
+                    ws[k] = ""  # empty (not None): some scoring paths call str ops
+            if "developer_profile" in ws:
+                ws["developer_profile"] = {}  # non-optional Dict field -> empty, not None
+    mani = inputs.get("manifest")
+    if isinstance(mani, dict):
+        # manifest.name and .description are scored free-text (the capture-signals
+        # heuristic, normalizers.py:1006-1019, keyword-matches them). Redact via
+        # the keyword-preserving _redaction_for so the brand is removed but any
+        # capture keyword survives -> score-neutral by construction. Only redact
+        # NON-EMPTY values so an already-empty field is not flipped to a truthy
+        # placeholder.
+        for k in _MANIFEST_PII_KEYS:
+            v = mani.get(k)
+            if isinstance(v, str) and v:
+                mani[k] = _redaction_for(v)
+    if redact_name:
+        entry["name"] = f"Real Extension {pseudo[len('anon-'):][:8]}"
+    if isinstance(entry.get("tags"), list) and "anonymized" not in entry["tags"]:
+        entry["tags"] = list(entry["tags"]) + ["anonymized"]
+
+    # --- residual exact-token sweep over non-scoring subtrees (defense in depth) ---
+    entry = _scrub_tokens(entry, tokens)
+    return entry
 
 
 _CORPUS_DIR_GUARD = "tests/fixtures/scoring_corpus"
@@ -256,12 +467,40 @@ def _build_parser() -> argparse.ArgumentParser:
         choices=("ALLOW", "NEEDS_REVIEW", "BLOCK"),
         help="Optional human-provided expected_verdict for all entries (default: null).",
     )
+    parser.add_argument(
+        "--anonymize",
+        action="store_true",
+        help=(
+            "Scrub identifiers/PII across the entire entry (ids, developer metadata, "
+            "manifest name/author/homepage, source path). Requires --anonymization-salt. "
+            "Preserves scoring-relevant fields (host permissions, etc.) so the score is "
+            "unchanged; those may retain brand hints. Off by default."
+        ),
+    )
+    parser.add_argument(
+        "--anonymization-salt",
+        default=None,
+        help="Salt for deterministic pseudonymous ids. Required with --anonymize.",
+    )
+    parser.add_argument(
+        "--redact-name",
+        action="store_true",
+        help="Also replace the extension name with a generic placeholder (with --anonymize).",
+    )
     return parser
 
 
 def main(argv: Optional[List[str]] = None) -> int:
     args = _build_parser().parse_args(argv)
-    entries, warns = extract_entries(args.fixtures, expected_verdict=args.expected_verdict)
+    if args.anonymize and not args.anonymization_salt:
+        raise SystemExit("--anonymize requires --anonymization-salt <value>.")
+    entries, warns = extract_entries(
+        args.fixtures,
+        expected_verdict=args.expected_verdict,
+        anonymize=args.anonymize,
+        salt=args.anonymization_salt,
+        redact_name=args.redact_name,
+    )
     for w in warns:
         print(f"WARN {w}", file=sys.stderr)
     payload = json.dumps(entries, indent=2)

--- a/tests/scoring/test_extract_signal_pack.py
+++ b/tests/scoring/test_extract_signal_pack.py
@@ -15,11 +15,14 @@ from pathlib import Path
 import pytest
 
 from extension_shield.governance.signal_pack import SignalPack
+from extension_shield.scoring.engine import ScoringEngine
 from scripts.scoring.compare_scoring_corpus import CorpusError, validate_entry
 from scripts.scoring.extract_signal_pack import (
     _CORPUS_DIR_GUARD,
     _coverage_warnings,
     _is_within_corpus_dir,
+    _redaction_for,
+    anonymize_entry,
     extract_entries,
     extract_entry,
     main,
@@ -32,6 +35,32 @@ GOLDEN = sorted(FIXTURE_DIR.glob("*_results.json"))
 
 def _load(path):
     return json.loads(Path(path).read_text(encoding="utf-8"))
+
+
+def _pii_needles(fixture, entry):
+    """The real-PII strings that must NOT survive anonymization — derived at
+    runtime from the fixture/original entry, never hardcoded."""
+    sp = entry["inputs"]["signal_pack"]
+    ws = sp["webstore_stats"]
+    mani = entry["inputs"].get("manifest") or {}
+    needles = []
+    for v in (fixture.get("extension_id"), fixture.get("extension_name")):
+        if v:
+            needles.append(v)
+    for k in ("developer", "developer_email", "developer_website"):
+        if ws.get(k):
+            needles.append(ws[k])
+    for k in ("author", "homepage_url"):
+        if mani.get(k):
+            needles.append(mani[k])
+    return needles
+
+
+def _score(sp_dict, manifest, user_count):
+    r = ScoringEngine(weights_version="v1").calculate_scores(
+        SignalPack.model_validate(sp_dict), manifest=manifest, user_count=user_count
+    )
+    return (r.overall_score, r.decision.value)
 
 
 def test_golden_fixtures_present():
@@ -195,3 +224,224 @@ def test_extraction_is_offline(monkeypatch):
     monkeypatch.setattr(socket, "socket", _boom)
     entry, _ = extract_entry(_load(GOLDEN[0]), source_path=str(GOLDEN[0]))
     assert entry["label"] == "unknown"
+
+
+# --- anonymization (ADR 0003 §5): full-entry scrub, leak-free, score-neutral ---
+
+_SALT = "unit-test-salt"
+
+
+@pytest.mark.parametrize("path", GOLDEN, ids=lambda p: p.name)
+def test_anonymized_entry_validates(path):
+    entry, _ = extract_entry(
+        _load(path), source_path=str(path), anonymize=True, salt=_SALT, redact_name=True
+    )
+    validate_entry(entry)
+    SignalPack.model_validate(entry["inputs"]["signal_pack"])
+    assert entry["label"] == "unknown"
+    assert entry["expected_verdict"] is None
+    # pseudonymous id must not carry the real id or the golden- prefix
+    assert entry["id"].startswith("anon-")
+    assert entry["inputs"]["signal_pack"]["scan_id"] == entry["inputs"]["signal_pack"]["extension_id"]
+
+
+@pytest.mark.parametrize("path", GOLDEN, ids=lambda p: p.name)
+def test_full_entry_leak_test_runtime_needles(path):
+    fixture = _load(path)
+    original, _ = extract_entry(fixture, source_path=str(path))
+    needles = _pii_needles(fixture, original)  # derived at runtime, not hardcoded
+    anon, _ = extract_entry(
+        fixture, source_path=str(path), anonymize=True, salt=_SALT, redact_name=True
+    )
+    blob = json.dumps(anon)  # entire serialized entry, recursively
+    for needle in needles:
+        assert needle not in blob, f"PII leaked in {path.name}: {needle!r}"
+    # the real id must be gone from the source_fixture pointer too
+    assert fixture["extension_id"] not in anon["extraction"]["source_fixture"]
+
+
+@pytest.mark.parametrize("path", GOLDEN, ids=lambda p: p.name)
+def test_score_and_verdict_neutrality(path):
+    fixture = _load(path)
+    original, _ = extract_entry(fixture, source_path=str(path))
+    anon, _ = extract_entry(
+        fixture, source_path=str(path), anonymize=True, salt=_SALT, redact_name=True
+    )
+    o = original["inputs"]
+    a = anon["inputs"]
+    # each side scores with ITS OWN (original vs anonymized) auxiliary inputs, so
+    # manifest anonymization is included in the neutrality proof.
+    assert _score(o["signal_pack"], o["manifest"], o["user_count"]) == _score(
+        a["signal_pack"], a["manifest"], a["user_count"]
+    )
+
+
+def test_scoring_relevant_host_patterns_preserved():
+    # Pinterest fixture has a brand-bearing host pattern that IS a scoring input;
+    # it must be preserved (brand-hint retained) for neutrality, not scrubbed.
+    target = next((p for p in GOLDEN if p.name.startswith("nkabool")), None)
+    if target is None:
+        pytest.skip("expected broad-host fixture not present")
+    orig, _ = extract_entry(_load(target), source_path=str(target))
+    anon, _ = extract_entry(
+        _load(target), source_path=str(target), anonymize=True, salt=_SALT, redact_name=True
+    )
+    assert (
+        anon["inputs"]["signal_pack"]["permissions"]["host_permissions"]
+        == orig["inputs"]["signal_pack"]["permissions"]["host_permissions"]
+    )
+
+
+def test_anonymization_stable_with_same_salt_and_differs_with_different_salt():
+    fixture = _load(GOLDEN[0])
+    a1 = extract_entry(fixture, anonymize=True, salt="A", redact_name=True)[0]
+    a1b = extract_entry(fixture, anonymize=True, salt="A", redact_name=True)[0]
+    a2 = extract_entry(fixture, anonymize=True, salt="B", redact_name=True)[0]
+    assert a1["id"] == a1b["id"]
+    assert a1["inputs"]["signal_pack"]["scan_id"] == a1b["inputs"]["signal_pack"]["scan_id"]
+    assert a1["id"] != a2["id"]
+
+
+def test_redact_name_replaces_original_name():
+    fixture = _load(GOLDEN[0])
+    real_name = fixture["extension_name"]
+    with_redact = extract_entry(fixture, anonymize=True, salt=_SALT, redact_name=True)[0]
+    assert with_redact["name"] != real_name
+    assert real_name not in json.dumps(with_redact)
+    # Without --redact-name the entry is NOT leak-free (name retained) — documents
+    # that full leak-freedom requires --redact-name.
+    without = extract_entry(fixture, anonymize=True, salt=_SALT, redact_name=False)[0]
+    assert without["name"] == real_name
+
+
+def test_anonymize_requires_salt():
+    with pytest.raises(CorpusError):
+        anonymize_entry({"inputs": {"signal_pack": {"scan_id": "x"}}}, salt="")
+    # CLI path: --anonymize without a salt must error.
+    with pytest.raises(SystemExit):
+        main([str(GOLDEN[0]), "--anonymize"])
+
+
+def test_default_non_anonymized_behavior_unchanged():
+    # No anonymization by default: real id/name still present, id keeps golden- prefix.
+    fixture = _load(GOLDEN[0])
+    entry, _ = extract_entry(fixture, source_path=str(GOLDEN[0]))
+    assert entry["id"].startswith("golden-")
+    assert fixture["extension_id"] in entry["id"]
+    assert entry["name"] == fixture["extension_name"]
+
+
+def test_redaction_preserves_scored_threat_keywords():
+    # A PII token that itself contains a scored keyword ('abusive'/'malicious'/
+    # 'covert') must keep that keyword in the redaction, so scrubbing it cannot
+    # drop the permissions-baseline x2.0 multiplier.
+    assert _redaction_for("Google Analytics") == "[redacted]"
+    r = _redaction_for("CovertGrab")
+    assert "covert" in r and "CovertGrab" not in r
+
+
+def test_anonymization_neutral_when_pii_token_contains_threat_keyword():
+    # Regression for the latent gap: a developer name containing 'covert' that is
+    # echoed inside a scored permission justification. Anonymization must remove
+    # the PII but keep the keyword, leaving the abuse signal intact.
+    entry = {
+        "id": "golden-covertgrabextensionaaaaaaaaaaaa",
+        "name": "CovertGrab",
+        "label": "unknown",
+        "expected_verdict": None,
+        "tags": ["extracted"],
+        "extraction": {"source_fixture": "x"},
+        "inputs": {
+            "signal_pack": {
+                "scan_id": "covertgrabextensionaaaaaaaaaaaa",
+                "extension_id": "covertgrabextensionaaaaaaaaaaaa",
+                "webstore_stats": {"developer": "CovertGrab"},
+                "permissions": {
+                    "permission_analysis": [
+                        {"justification": "the tabs permission requested by CovertGrab is covert"}
+                    ]
+                },
+            },
+            "manifest": None,
+        },
+    }
+    anon = anonymize_entry(entry, salt="s", redact_name=True)
+    just = anon["inputs"]["signal_pack"]["permissions"]["permission_analysis"][0]["justification"]
+    assert "CovertGrab" not in just              # PII gone
+    assert "covert" in just.lower()              # scored keyword preserved -> score-neutral
+    assert "CovertGrab" not in json.dumps(anon)  # gone everywhere
+
+
+def _capture_factor_severity(entry):
+    inp = entry["inputs"]
+    r = ScoringEngine(weights_version="v1").calculate_scores(
+        SignalPack.model_validate(inp["signal_pack"]),
+        manifest=inp["manifest"],
+        user_count=inp["user_count"],
+    )
+    factors = r.privacy_layer.factors if r.privacy_layer else []
+    sev = next((f.severity for f in factors if f.name == "CaptureSignals"), None)
+    return (r.overall_score, r.decision.value, round(sev, 4) if sev is not None else None)
+
+
+def test_manifest_capture_keyword_redaction_is_score_neutral():
+    # Regression for the MEDIUM gap: manifest.name/description are scored by the
+    # capture-signals heuristic. A capture signal is present (tabCapture + broad
+    # host) so the branch is actually exercised; anonymization must remove the
+    # brand token but preserve the capture keyword -> capture severity unchanged.
+    from extension_shield.governance.signal_pack import PermissionsSignalPack
+    from tests.scoring.utils import make_min_signal_pack
+
+    pack = make_min_signal_pack(
+        scan_id="synbrandaaaaaaaaaaaaaaaaaaaaaaaa", extension_id="synbrandaaaaaaaaaaaaaaaaaaaaaaaa"
+    )
+    pack.permissions = PermissionsSignalPack(
+        api_permissions=["tabCapture"],
+        host_permissions=["<all_urls>"],
+        has_broad_host_access=True,
+        broad_host_patterns=["<all_urls>"],
+        total_permissions=2,
+    )
+    entry = {
+        "id": "golden-synbrandaaaaaaaaaaaaaaaaaaaaaaaa",
+        "name": "BrandCam Screenshot Tool",
+        "label": "unknown",
+        "expected_verdict": None,
+        "tags": ["extracted"],
+        "extraction": {"source_fixture": "x"},
+        "inputs": {
+            "signal_pack": pack.model_dump(mode="json"),
+            "manifest": {
+                "name": "BrandCam Screenshot Tool",
+                "description": "capture your screen with BrandCam",
+                "permissions": ["tabCapture"],
+                "host_permissions": ["<all_urls>"],
+                "manifest_version": 3,
+            },
+            "user_count": 1000,
+            "permissions_analysis": None,
+        },
+    }
+    anon = anonymize_entry(entry, salt="s", redact_name=True)
+    # capture branch is engaged (non-zero severity) -> the gap would show here
+    orig_sev = _capture_factor_severity(entry)
+    anon_sev = _capture_factor_severity(anon)
+    assert orig_sev[2] not in (None, 0.0), "test must exercise the capture branch"
+    assert orig_sev == anon_sev  # overall score + verdict + capture severity identical
+    # brand token gone, capture keyword preserved
+    blob = json.dumps(anon)
+    assert "BrandCam" not in blob
+    assert "screenshot" in anon["inputs"]["manifest"]["name"].lower()
+    assert "capture" in anon["inputs"]["manifest"]["description"].lower()
+
+
+def test_cli_anonymize_dry_run_is_leak_free(capsys):
+    fixture = _load(GOLDEN[0])
+    needles = _pii_needles(fixture, extract_entry(fixture, source_path=str(GOLDEN[0]))[0])
+    rc = main([str(GOLDEN[0]), "--anonymize", "--anonymization-salt", _SALT, "--redact-name"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    parsed = json.loads(out)  # stdout is still a JSON array
+    assert isinstance(parsed, list) and parsed[0]["label"] == "unknown"
+    for needle in needles:
+        assert needle not in out


### PR DESCRIPTION
Adds full-entry anonymization support to the signal-pack extractor before any real scan-result entries can be committed. Scrubs identifiers and PII across the assembled corpus entry, including source_fixture, signal_pack ids, webstore developer metadata, developer_profile, and manifest PII fields, while preserving scoring-relevant host/domain fields and scored free-text keywords needed for score neutrality.

Includes leak tests across committed golden fixtures, same/different salt behavior, redact-name behavior, runtime-derived PII needles, and score/verdict-neutrality checks including manifest anonymization. No real corpus entries are committed.

No scoring weights, formulas, gates, normalizers, schema, harness, fixtures, golden scores, frontend, or API payloads changed. PR-4 and PR-5 remain blocked.