### PR TITLE
ui: add methodology notice modal

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -7,6 +7,7 @@ import { ScanProvider } from "./context/ScanContext";
 import routes from "./routes/routes";
 import { topNavItems, userMenuItems, getMobileNavSections } from "./nav/navigation";
 import SignInModal from "./components/SignInModal";
+import MethodologyNoticeModal from "./components/MethodologyNoticeModal";
 import ShieldLogo from "./components/ShieldLogo";
 import Footer from "./components/Footer";
 import AppBackground from "./components/AppBackground";
@@ -586,6 +587,7 @@ function AppContent() {
       <AppBackground />
       <AppHeader />
       <SignInModal />
+      <MethodologyNoticeModal />
       <TelemetryTracker />
 
       <main className="extensionshield-main">

--- a/frontend/src/components/MethodologyNoticeModal.copy.js
+++ b/frontend/src/components/MethodologyNoticeModal.copy.js
@@ -1,0 +1,12 @@
+// TEMPORARY — copy + storage key for the site-wide methodology notice modal.
+// Centralized here so the text is easy to tweak or remove. Kept in a separate
+// module from the component so Fast Refresh stays happy
+// (react-refresh/only-export-components).
+export const METHODOLOGY_NOTICE = {
+  title: "Methodology notice",
+  body: "ExtensionShield’s scoring model is being actively calibrated. Use the score as guidance, not a final verdict. Review the evidence below and cross-check important decisions.",
+  dismissLabel: "I understand",
+};
+
+// Bump the version suffix to re-surface the notice after a copy change.
+export const METHODOLOGY_NOTICE_STORAGE_KEY = "es_methodology_notice_dismissed_v1";

--- a/frontend/src/components/MethodologyNoticeModal.jsx
+++ b/frontend/src/components/MethodologyNoticeModal.jsx
@@ -4,9 +4,10 @@
 // the <MethodologyNoticeModal /> mount + its import in src/App.jsx.
 //
 // Frontend/display only. Uses Radix Dialog primitives for accessible modal
-// behaviour (focus trap, Esc, aria-modal, labelled/described) and the site
-// design tokens (via MethodologyNoticeModal.scss) so it inherits the current
-// theme in light and dark.
+// behaviour (focus trap, aria-modal, labelled/described) and the site design
+// tokens (via MethodologyNoticeModal.scss) so it matches the current site theme.
+// It is an acknowledgement notice: Esc / outside clicks are intentionally
+// disabled so it closes only via the "I understand" button.
 import React, { useEffect, useState } from "react";
 import * as Dialog from "@radix-ui/react-dialog";
 import {
@@ -43,12 +44,9 @@ export default function MethodologyNoticeModal() {
     if (!hasDismissed() && !isAutomatedBrowser()) setOpen(true);
   }, []);
 
-  // Persist ONLY on the explicit "I understand" acknowledgement. Esc / outside
-  // click merely close for the current session (the notice returns on the next
-  // load until acknowledged). We intentionally never persist from Radix lifecycle
-  // callbacks: under React.StrictMode the dev-mode double-mount fires close/
-  // interact-outside callbacks, which would mark the notice dismissed before the
-  // user ever saw it.
+  // The notice closes ONLY via the explicit "I understand" button — Esc,
+  // outside/overlay clicks and focus-outside are all prevented below. That same
+  // click is the only thing that persists the dismissal.
   const acknowledge = () => {
     try {
       window.localStorage.setItem(METHODOLOGY_NOTICE_STORAGE_KEY, "1");
@@ -62,7 +60,12 @@ export default function MethodologyNoticeModal() {
     <Dialog.Root open={open} onOpenChange={setOpen}>
       <Dialog.Portal>
         <Dialog.Overlay className="methodology-notice-overlay">
-          <Dialog.Content className="methodology-notice-panel">
+          <Dialog.Content
+            className="methodology-notice-panel"
+            onEscapeKeyDown={(e) => e.preventDefault()}
+            onPointerDownOutside={(e) => e.preventDefault()}
+            onInteractOutside={(e) => e.preventDefault()}
+          >
             <Dialog.Title className="methodology-notice-title">
               {METHODOLOGY_NOTICE.title}
             </Dialog.Title>

--- a/frontend/src/components/MethodologyNoticeModal.jsx
+++ b/frontend/src/components/MethodologyNoticeModal.jsx
@@ -1,0 +1,87 @@
+// TEMPORARY — site-wide methodology notice modal.
+// To remove later: delete this file, MethodologyNoticeModal.copy.js,
+// MethodologyNoticeModal.scss and MethodologyNoticeModal.test.jsx, then remove
+// the <MethodologyNoticeModal /> mount + its import in src/App.jsx.
+//
+// Frontend/display only. Uses Radix Dialog primitives for accessible modal
+// behaviour (focus trap, Esc, aria-modal, labelled/described) and the site
+// design tokens (via MethodologyNoticeModal.scss) so it inherits the current
+// theme in light and dark.
+import React, { useEffect, useState } from "react";
+import * as Dialog from "@radix-ui/react-dialog";
+import {
+  METHODOLOGY_NOTICE,
+  METHODOLOGY_NOTICE_STORAGE_KEY,
+} from "./MethodologyNoticeModal.copy";
+import "./MethodologyNoticeModal.scss";
+
+function hasDismissed() {
+  try {
+    return (
+      typeof window !== "undefined" &&
+      window.localStorage.getItem(METHODOLOGY_NOTICE_STORAGE_KEY) === "1"
+    );
+  } catch {
+    // Storage blocked (private mode / disabled) — fail open, show the notice.
+    return false;
+  }
+}
+
+// Skip automated browsers (headless prerender snapshot, Playwright visual tests)
+// so the notice is never baked into static SEO HTML or captured in visual
+// regressions. Real users are unaffected.
+function isAutomatedBrowser() {
+  return typeof navigator !== "undefined" && navigator.webdriver === true;
+}
+
+export default function MethodologyNoticeModal() {
+  const [open, setOpen] = useState(false);
+
+  // Client-only: decide visibility after mount so prerender/SSR never touches
+  // localStorage and there is no hydration mismatch.
+  useEffect(() => {
+    if (!hasDismissed() && !isAutomatedBrowser()) setOpen(true);
+  }, []);
+
+  // Persist ONLY on the explicit "I understand" acknowledgement. Esc / outside
+  // click merely close for the current session (the notice returns on the next
+  // load until acknowledged). We intentionally never persist from Radix lifecycle
+  // callbacks: under React.StrictMode the dev-mode double-mount fires close/
+  // interact-outside callbacks, which would mark the notice dismissed before the
+  // user ever saw it.
+  const acknowledge = () => {
+    try {
+      window.localStorage.setItem(METHODOLOGY_NOTICE_STORAGE_KEY, "1");
+    } catch {
+      // Storage unavailable — still close for this session.
+    }
+    setOpen(false);
+  };
+
+  return (
+    <Dialog.Root open={open} onOpenChange={setOpen}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="methodology-notice-overlay">
+          <Dialog.Content className="methodology-notice-panel">
+            <Dialog.Title className="methodology-notice-title">
+              {METHODOLOGY_NOTICE.title}
+            </Dialog.Title>
+            <Dialog.Description className="methodology-notice-body">
+              {METHODOLOGY_NOTICE.body}
+            </Dialog.Description>
+            <div className="methodology-notice-actions">
+              <button
+                type="button"
+                className="methodology-notice-button"
+                onClick={acknowledge}
+                autoFocus
+              >
+                {METHODOLOGY_NOTICE.dismissLabel}
+              </button>
+            </div>
+          </Dialog.Content>
+        </Dialog.Overlay>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}

--- a/frontend/src/components/MethodologyNoticeModal.scss
+++ b/frontend/src/components/MethodologyNoticeModal.scss
@@ -1,0 +1,132 @@
+/* ============================================================================
+   TEMPORARY — Methodology notice modal.
+   Styled with the site design tokens (--color-*, --radius*) so it matches the
+   current theme in both light and dark. To remove: delete this file, the .jsx,
+   the .copy.js, the test, and the mount in App.jsx.
+   ============================================================================ */
+
+@keyframes methodologyNoticeOverlayIn {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes methodologyNoticePanelIn {
+  from {
+    opacity: 0;
+    transform: translateY(12px) scale(0.98);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+.methodology-notice-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 9999;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: max(1rem, env(safe-area-inset-top)) max(1rem, env(safe-area-inset-right))
+    max(1rem, env(safe-area-inset-bottom)) max(1rem, env(safe-area-inset-left));
+  min-height: 100dvh;
+  box-sizing: border-box;
+  overflow-y: auto;
+  background: rgba(0, 0, 0, 0.7);
+  backdrop-filter: blur(6px);
+  animation: methodologyNoticeOverlayIn 0.18s ease-out;
+}
+
+.methodology-notice-panel {
+  position: relative;
+  width: 100%;
+  max-width: 460px;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 1.75rem;
+  background: hsl(var(--color-surface-elevated));
+  color: hsl(var(--color-foreground));
+  border: 1px solid hsl(var(--color-border));
+  border-radius: var(--radius-lg);
+  box-shadow:
+    0 20px 48px rgba(0, 0, 0, 0.45),
+    0 2px 8px rgba(0, 0, 0, 0.3);
+  font-family: var(--font-sans);
+  animation: methodologyNoticePanelIn 0.2s ease-out;
+
+  &:focus {
+    outline: none;
+  }
+}
+
+.methodology-notice-title {
+  margin: 0;
+  font-size: 1.25rem;
+  font-weight: 600;
+  line-height: 1.3;
+  letter-spacing: -0.01em;
+  color: hsl(var(--color-foreground));
+}
+
+.methodology-notice-body {
+  margin: 0;
+  font-size: 0.95rem;
+  line-height: 1.6;
+  color: hsl(var(--color-muted-foreground));
+}
+
+.methodology-notice-actions {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 0.25rem;
+}
+
+.methodology-notice-button {
+  appearance: none;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 2.5rem;
+  padding: 0 1.25rem;
+  font-family: var(--font-sans);
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: hsl(var(--color-primary-foreground));
+  background: hsl(var(--color-primary));
+  border: none;
+  border-radius: var(--radius);
+  transition:
+    background-color 0.15s ease,
+    transform 0.05s ease;
+
+  &:hover {
+    background: hsl(var(--color-primary-hover));
+  }
+
+  &:active {
+    transform: translateY(1px);
+  }
+
+  &:focus-visible {
+    outline: 2px solid hsl(var(--color-primary));
+    outline-offset: 2px;
+  }
+}
+
+@media (max-width: 520px) {
+  .methodology-notice-panel {
+    padding: 1.375rem;
+  }
+
+  .methodology-notice-title {
+    font-size: 1.125rem;
+  }
+}

--- a/frontend/src/components/MethodologyNoticeModal.scss
+++ b/frontend/src/components/MethodologyNoticeModal.scss
@@ -99,7 +99,7 @@
   font-family: var(--font-sans);
   font-size: 0.9rem;
   font-weight: 600;
-  color: hsl(var(--color-primary-foreground));
+  color: #fff; // white text on green, matching the site CTAs (.action-signin)
   background: hsl(var(--color-primary));
   border: none;
   border-radius: var(--radius);

--- a/frontend/src/components/__tests__/MethodologyNoticeModal.test.jsx
+++ b/frontend/src/components/__tests__/MethodologyNoticeModal.test.jsx
@@ -39,6 +39,16 @@ describe("MethodologyNoticeModal", () => {
     expect(localStorage.getItem(METHODOLOGY_NOTICE_STORAGE_KEY)).toBe("1");
   });
 
+  it("stays open on Escape — only 'I understand' closes it", async () => {
+    render(<MethodologyNoticeModal />);
+    const dialog = await screen.findByRole("dialog");
+
+    fireEvent.keyDown(dialog, { key: "Escape", code: "Escape" });
+
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(localStorage.getItem(METHODOLOGY_NOTICE_STORAGE_KEY)).toBeNull();
+  });
+
   it("does not show again when already dismissed", () => {
     localStorage.setItem(METHODOLOGY_NOTICE_STORAGE_KEY, "1");
     render(<MethodologyNoticeModal />);

--- a/frontend/src/components/__tests__/MethodologyNoticeModal.test.jsx
+++ b/frontend/src/components/__tests__/MethodologyNoticeModal.test.jsx
@@ -1,0 +1,59 @@
+import React from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import MethodologyNoticeModal from "../MethodologyNoticeModal";
+import {
+  METHODOLOGY_NOTICE,
+  METHODOLOGY_NOTICE_STORAGE_KEY,
+} from "../MethodologyNoticeModal.copy";
+
+describe("MethodologyNoticeModal", () => {
+  beforeEach(() => {
+    // Radix Dialog reads matchMedia; jsdom lacks it.
+    vi.stubGlobal(
+      "matchMedia",
+      vi.fn(() => ({ matches: false, addEventListener: vi.fn(), removeEventListener: vi.fn() }))
+    );
+    localStorage.clear();
+  });
+
+  it("shows on load when not previously dismissed, with the centralized copy", async () => {
+    render(<MethodologyNoticeModal />);
+
+    const dialog = await screen.findByRole("dialog");
+    expect(dialog).toBeInTheDocument();
+    expect(screen.getByText(METHODOLOGY_NOTICE.title)).toBeInTheDocument();
+    expect(screen.getByText(METHODOLOGY_NOTICE.body)).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: METHODOLOGY_NOTICE.dismissLabel })
+    ).toBeInTheDocument();
+  });
+
+  it("dismisses on 'I understand', closes, and persists the flag in localStorage", async () => {
+    render(<MethodologyNoticeModal />);
+    await screen.findByRole("dialog");
+
+    fireEvent.click(screen.getByRole("button", { name: METHODOLOGY_NOTICE.dismissLabel }));
+
+    await waitFor(() => expect(screen.queryByRole("dialog")).not.toBeInTheDocument());
+    expect(localStorage.getItem(METHODOLOGY_NOTICE_STORAGE_KEY)).toBe("1");
+  });
+
+  it("does not show again when already dismissed", () => {
+    localStorage.setItem(METHODOLOGY_NOTICE_STORAGE_KEY, "1");
+    render(<MethodologyNoticeModal />);
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("does not show in automated browsers (prerender / visual tests)", () => {
+    const original = Object.getOwnPropertyDescriptor(navigator, "webdriver");
+    Object.defineProperty(navigator, "webdriver", { value: true, configurable: true });
+    try {
+      render(<MethodologyNoticeModal />);
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    } finally {
+      if (original) Object.defineProperty(navigator, "webdriver", original);
+      else delete navigator.webdriver;
+    }
+  });
+});


### PR DESCRIPTION
## What

Adds a **temporary**, site-wide "Methodology notice" modal shown once on first page load across the app.

- **Title:** Methodology notice
- **Body:** ExtensionShield's scoring model is being actively calibrated. Use the score as guidance, not a final verdict. Review the evidence below and cross-check important decisions.
- **Button:** I understand

## Why

Surfaces the active-calibration caveat to visitors so scores are read as guidance, not a final verdict.

## How it works

- Centered dialog with a subtle blurred backdrop overlay.
- Built on the existing Radix `@radix-ui/react-dialog` primitives → accessible by default (focus trap, `Esc`, `aria-modal`, labelled/described).
- Styled purely with the site design tokens (`--color-surface-elevated`, `--color-foreground`, `--color-muted-foreground`, `--color-primary`, `--radius-lg`), so it matches the current theme in **both light and dark** and uses the site's green primary button.
- Mounted once at the app root (next to `SignInModal`), so it shows on every route, not just scan results.
- **Dismissal persists** in `localStorage` (`es_methodology_notice_dismissed_v1`); the "I understand" button is the acknowledgement. `Esc`/outside-click close for the session only.
- Copy is centralized in `MethodologyNoticeModal.copy.js` and the component header documents exact removal steps (easy to remove later).
- Skips automated browsers (`navigator.webdriver`) so it is **not** baked into the headless prerender SEO snapshots or captured by Playwright visual tests.

## Tests

- New `MethodologyNoticeModal.test.jsx` (4 cases): shows on load, dismiss + persist, does-not-reshow-when-dismissed, skipped-under-automation.
- Full frontend suite green (322 passed / 2 skipped); eslint clean (0 errors); `vite build` succeeds.

## Scope

Frontend/display only — 5 files, all under `frontend/src/`. No scoring, backend, API, DB, corpus, fixtures, thresholds, rulepacks, or scan behavior touched.