### PR TITLE
fix scanner results for unavailable extensions

### DIFF
--- a/frontend/public/extensionshield_extension_unavailable_illustration.svg
+++ b/frontend/public/extensionshield_extension_unavailable_illustration.svg
@@ -1,0 +1,125 @@
+<svg width="670" height="255" viewBox="0 0 670 255" fill="none"
+     xmlns="http://www.w3.org/2000/svg" role="img"
+     aria-labelledby="title desc">
+  <title id="title">Extension unavailable illustration</title>
+  <desc id="desc">A soft browser window with an extension puzzle piece and unavailable badge.</desc>
+
+  <defs>
+    <linearGradient id="panel" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#FBFAF6"/>
+      <stop offset="100%" stop-color="#F5F1E8"/>
+    </linearGradient>
+
+    <linearGradient id="topbar" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#EFEBDD"/>
+      <stop offset="100%" stop-color="#E8E2D2"/>
+    </linearGradient>
+
+    <linearGradient id="piece" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#D9D8CC"/>
+      <stop offset="100%" stop-color="#C7C5B7"/>
+    </linearGradient>
+
+    <linearGradient id="badge" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#EAE6D7"/>
+      <stop offset="100%" stop-color="#DCD6C3"/>
+    </linearGradient>
+
+    <filter id="shadow" x="-40%" y="-40%" width="180%" height="180%">
+      <feDropShadow dx="0" dy="10" stdDeviation="14"
+                    flood-color="#C8C1AF" flood-opacity="0.20"/>
+    </filter>
+
+    <filter id="softBlur" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="10"/>
+    </filter>
+
+    <filter id="tinyBlur" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="3"/>
+    </filter>
+  </defs>
+
+  <!-- very soft ambient glow -->
+  <ellipse cx="335" cy="142" rx="220" ry="92"
+           fill="#F4F0E6" opacity="0.55" filter="url(#softBlur)"/>
+
+  <!-- left cloud -->
+  <g opacity="0.72" filter="url(#tinyBlur)">
+    <ellipse cx="190" cy="151" rx="48" ry="23" fill="#F2EFE7"/>
+    <circle cx="170" cy="136" r="24" fill="#F2EFE7"/>
+    <circle cx="197" cy="128" r="31" fill="#F2EFE7"/>
+    <circle cx="227" cy="139" r="24" fill="#F2EFE7"/>
+  </g>
+
+  <!-- right cloud -->
+  <g opacity="0.72" filter="url(#tinyBlur)">
+    <ellipse cx="478" cy="154" rx="54" ry="24" fill="#F2EFE7"/>
+    <circle cx="453" cy="136" r="25" fill="#F2EFE7"/>
+    <circle cx="484" cy="128" r="31" fill="#F2EFE7"/>
+    <circle cx="516" cy="140" r="25" fill="#F2EFE7"/>
+  </g>
+
+  <!-- main browser card -->
+  <g filter="url(#shadow)">
+    <rect x="192" y="58" width="250" height="157" rx="18" fill="url(#panel)"/>
+    <path d="M210 58H424C433.941 58 442 66.0589 442 76V92H192V76C192 66.0589 200.059 58 210 58Z"
+          fill="url(#topbar)"/>
+    <circle cx="211" cy="75" r="5.5" fill="#D6D0B9"/>
+    <circle cx="228" cy="75" r="5.5" fill="#D6D0B9"/>
+    <circle cx="245" cy="75" r="5.5" fill="#D6D0B9"/>
+  </g>
+
+  <!-- puzzle piece -->
+  <g transform="translate(0,1)">
+    <path d="
+      M287 126
+      C287 118 293 112 301 112
+      H312
+      V101
+      C312 91 319 83 329 83
+      C339 83 346 91 346 101
+      V112
+      H357
+      C365 112 371 118 371 126
+      V138
+      H383
+      C393 138 401 145 401 155
+      C401 165 393 172 383 172
+      H371
+      V185
+      C371 193 365 199 357 199
+      H343
+      V186
+      C343 176 336 168 326 168
+      C316 168 309 176 309 186
+      V199
+      H301
+      C293 199 287 193 287 185
+      V172
+      H275
+      C265 172 257 165 257 155
+      C257 145 265 138 275 138
+      H287
+      Z" fill="url(#piece)"/>
+  </g>
+
+  <!-- unavailable badge -->
+  <g filter="url(#shadow)">
+    <circle cx="423" cy="165" r="36" fill="url(#badge)"/>
+    <path d="M410 152L436 178M436 152L410 178"
+          stroke="#FFFFFF" stroke-width="6" stroke-linecap="round"/>
+  </g>
+
+  <!-- decorative dots and pluses -->
+  <circle cx="131" cy="95" r="6" fill="#A9DABF" opacity="0.85"/>
+  <circle cx="505" cy="180" r="4.5" fill="#A9DABF" opacity="0.85"/>
+
+  <g stroke="#E8E1CF" stroke-width="3" stroke-linecap="round" opacity="0.9">
+    <path d="M465 89V101M459 95H471"/>
+    <path d="M159 174V186M153 180H165"/>
+  </g>
+
+  <g stroke="#A9DABF" stroke-width="3" stroke-linecap="round" opacity="0.9">
+    <path d="M477 178V188M472 183H482"/>
+  </g>
+</svg>

--- a/frontend/src/components/report/LayerModal.jsx
+++ b/frontend/src/components/report/LayerModal.jsx
@@ -226,14 +226,17 @@ const LayerModal = ({
   keyFindings = [],
   gateResults = [],
   layerReasons = [],
+  evidence = null,
 }) => {
   const config = LAYER_CONFIG[layer] || LAYER_CONFIG.security;
   const Icon = config.Icon;
 
   // Severity-first modal model from real normalized factors/findings only.
+  // `evidence` (shared coverage-availability map) drives the "Cleared" vs
+  // "Not analyzed" split from the same coverage the Analyzer Coverage section uses.
   const { all, issues, notAnalyzed, cleared, about } = React.useMemo(
-    () => buildLayerModalModel({ factors, keyFindings, gateResults, layerReasons }),
-    [factors, keyFindings, gateResults, layerReasons]
+    () => buildLayerModalModel({ factors, keyFindings, gateResults, layerReasons, evidence }),
+    [factors, keyFindings, gateResults, layerReasons, evidence]
   );
   const hasChecks = all.length > 0;
   // Reputation/maintenance factors (e.g. Store Reputation, Publisher update age)

--- a/frontend/src/components/report/LayerModal.test.jsx
+++ b/frontend/src/components/report/LayerModal.test.jsx
@@ -384,3 +384,96 @@ describe('LayerModal rendering', () => {
     expect(screen.queryByText(/Context signal — informs confidence/)).toBeNull();
   });
 });
+
+describe('coverage-driven "Cleared" vs "Not analyzed"', () => {
+  // Every evidence source present — a valid full scan.
+  const ALL_PRESENT = { code: true, malware: true, threatIntel: true, listing: true, manifest: true };
+  // Every evidence source absent — an unavailable extension.
+  const NONE_PRESENT = { code: false, malware: false, threatIntel: false, listing: false, manifest: false };
+
+  it('a factor whose analyzer coverage is absent reads "Not analyzed", not "Clear"', () => {
+    // VirusTotal ran cleanly by severity alone, but malware coverage was absent.
+    const vt = humanizeFactor({ name: 'VirusTotal', severity: 0, confidence: 0.9 }, { ...ALL_PRESENT, malware: false });
+    expect(vt.status).toBe('Not analyzed');
+    expect(vt.statusType).toBe('unknown');
+  });
+
+  it('missing package/manifest coverage makes permission factors "Not analyzed"', () => {
+    const perm = humanizeFactor({ name: 'PermissionsBaseline', severity: 0, confidence: 0.5 }, { ...ALL_PRESENT, manifest: false });
+    expect(perm.statusType).toBe('unknown');
+    const combos = humanizeFactor({ name: 'PermissionCombos', severity: 0, confidence: 0.5 }, { ...ALL_PRESENT, manifest: false });
+    expect(combos.statusType).toBe('unknown');
+  });
+
+  it('missing store listing makes reputation/maintenance factors "Not analyzed"', () => {
+    const store = humanizeFactor({ name: 'Webstore', severity: 0.1, confidence: 0.3 }, { ...ALL_PRESENT, listing: false });
+    expect(store.statusType).toBe('unknown');
+    const age = humanizeFactor({ name: 'Maintenance', severity: 0, confidence: 0.3 }, { ...ALL_PRESENT, listing: false });
+    expect(age.statusType).toBe('unknown');
+  });
+
+  it('a completed analyzer with no finding AND evidence present reads "Clear"', () => {
+    const vt = humanizeFactor({ name: 'VirusTotal', severity: 0, confidence: 0.9, details: { total_engines: 75 } }, ALL_PRESENT);
+    expect(vt.status).toBe('Clear');
+    expect(vt.statusType).toBe('clear');
+    const obf = humanizeFactor({ name: 'Obfuscation', severity: 0, confidence: 0.9 }, ALL_PRESENT);
+    expect(obf.statusType).toBe('clear');
+  });
+
+  it('a completed analyzer WITH a material finding stays an "Issue" (finding wins over coverage)', () => {
+    // Even with all evidence absent, a real severity-bearing finding is an issue.
+    const manifest = humanizeFactor({ name: 'Manifest', severity: 0.5, confidence: 0.5 }, NONE_PRESENT);
+    expect(manifest.statusType).toBe('issues');
+    expect(manifest.status).toBe('Issue');
+  });
+
+  it('the VirusTotal/ChromeStats confidence-0 sentinel fires even without an evidence map', () => {
+    expect(humanizeFactor({ name: 'VirusTotal', severity: 0, confidence: 0 }).statusType).toBe('unknown');
+    expect(humanizeFactor({ name: 'ChromeStats', severity: 0, confidence: 0 }).statusType).toBe('unknown');
+  });
+
+  it('empty / null / default factor values never become "Clear" when evidence is absent', () => {
+    // Zero severity + zero/absent details would fall through to "Clear" under the
+    // old logic; with evidence absent they must read "Not analyzed".
+    ['SAST', 'Obfuscation', 'VirusTotal', 'ChromeStats', 'Webstore', 'Maintenance',
+     'Manifest', 'PermissionsBaseline', 'PermissionCombos', 'CaptureSignals',
+     'ToSViolations', 'Consistency', 'DisclosureAlignment'].forEach((name) => {
+      const f = humanizeFactor({ name, severity: 0, confidence: 0 }, NONE_PRESENT);
+      expect(f.statusType).not.toBe('clear');
+    });
+  });
+
+  it('a valid full scan (all evidence present) leaves clean factors "Clear" — unchanged', () => {
+    const factors = [
+      { name: 'SAST', severity: 0, confidence: 0.8, details: { files_scanned: 8, deduped_findings: 0 } },
+      { name: 'VirusTotal', severity: 0, confidence: 1.0, details: { total_engines: 75 } },
+      { name: 'Webstore', severity: 0.1, confidence: 0.9 },
+    ];
+    const { cleared, notAnalyzed } = triageFactors(factors, ALL_PRESENT);
+    expect(cleared.map((c) => c.label).sort()).toEqual(['Code Safety', 'Malware Scan', 'Store Reputation']);
+    expect(notAnalyzed).toEqual([]);
+  });
+
+  it('buildLayerModalModel threads the evidence map into the cleared/not-analyzed split', () => {
+    const factors = [
+      { name: 'VirusTotal', severity: 0, confidence: 0.9, details: { total_engines: 75 } }, // malware coverage absent -> not analyzed
+      { name: 'Manifest', severity: 0.5, confidence: 0.9 },                                  // real finding -> issue
+    ];
+    const model = buildLayerModalModel({ factors, evidence: { ...ALL_PRESENT, malware: false } });
+    expect(model.notAnalyzed.map((r) => r.title)).toContain('Malware Scan');
+    expect(model.cleared.some((c) => c.label === 'Malware Scan')).toBe(false);
+    expect(model.issues.map((r) => r.title)).toContain('Extension Config');
+  });
+
+  it('without an evidence map, triage is unchanged (backward compatible)', () => {
+    // Same assertion the legacy triage test makes — no evidence arg passed.
+    const factors = [
+      { name: 'SAST', severity: 0.1 },
+      { name: 'Webstore', severity: 0.2 },
+      { name: 'NetworkExfil', severity: 0, details: { network_analysis_enabled: false } },
+    ];
+    const { cleared, notAnalyzed } = triageFactors(factors);
+    expect(cleared.map((i) => i.label).sort()).toEqual(['Code Safety', 'Store Reputation']);
+    expect(notAnalyzed.map((i) => i.label)).toEqual(['Data Sharing']);
+  });
+});

--- a/frontend/src/components/report/layerFactors.js
+++ b/frontend/src/components/report/layerFactors.js
@@ -327,8 +327,8 @@ function gateIssueRow(gate, index) {
   };
 }
 
-export function buildLayerModalModel({ factors = [], keyFindings = [], gateResults = [], layerReasons = [] } = {}) {
-  const { all, issues, notAnalyzed, cleared } = triageFactors(factors);
+export function buildLayerModalModel({ factors = [], keyFindings = [], gateResults = [], layerReasons = [], evidence } = {}) {
+  const { all, issues, notAnalyzed, cleared } = triageFactors(factors, evidence);
   const issueRows = [];
   const seen = new Set();
 
@@ -517,23 +517,62 @@ export function groupFactorsByDomain(factors = []) {
     .map((domain) => ({ domain, factors: buckets.get(domain.id) }));
 }
 
+// Which shared coverage/evidence source (from resolveEvidenceAvailability) each
+// factor depends on. When that source is unavailable the factor could not have
+// been evaluated, so it reads "Not analyzed", never "Clear". Presentation only;
+// factor OWNERSHIP and scoring are unchanged. NetworkExfil is intentionally
+// absent — it carries its own explicit did-not-run flag (below).
+const FACTOR_EVIDENCE = {
+  SAST: 'code',
+  Obfuscation: 'code',
+  VirusTotal: 'malware',
+  ChromeStats: 'threatIntel',
+  Webstore: 'listing',
+  Maintenance: 'listing',
+  Manifest: 'manifest',
+  PermissionsBaseline: 'manifest',
+  PermissionCombos: 'manifest',
+  CaptureSignals: 'manifest',
+  ToSViolations: 'manifest',
+  Consistency: 'manifest',
+  DisclosureAlignment: 'manifest',
+};
+
 /**
  * A check whose underlying analysis did not run has no coverage and must not be
- * shown as "Clear" (that overstates certainty). The network/exfil analyzer
- * reports this via details.network_analysis_enabled === false.
+ * shown as "Clear" (that overstates certainty).
+ *
+ * Signals, in order:
+ *  1. explicit per-analyzer did-not-run flags the payload already carries
+ *     (network_analysis_enabled, VirusTotal engines, SAST files);
+ *  2. the scoring engine's own no-coverage sentinel — VirusTotal / ChromeStats
+ *     are emitted with confidence 0 when the analyzer produced nothing;
+ *  3. (opt-in) the shared evidence-availability map from
+ *     resolveEvidenceAvailability — the SAME coverage the Analyzer Coverage
+ *     section reports. When provided, a factor whose required evidence source
+ *     was unavailable is "Not analyzed". Omitting it preserves the legacy,
+ *     signal-only behavior so existing callers are unaffected.
  */
-export function isNotAnalyzed(factor) {
-  const details = factor?.details;
-  if (!details || typeof details !== 'object') return false;
+export function isNotAnalyzed(factor, evidence) {
+  if (!factor || typeof factor !== 'object') return false;
+  const details = (factor.details && typeof factor.details === 'object') ? factor.details : {};
   // Network/exfil analyzer explicitly reports it did not run.
   if (details.network_analysis_enabled === false) return true;
   // VirusTotal returned no coverage (hash not in DB / unavailable / rate-limited):
   // zero engines scanned. A real clean scan reports dozens of engines, so a
   // severity-0 VT factor with 0 engines is "did not run", not "clean".
-  if (factor?.name === 'VirusTotal' && Number(details.total_engines) === 0) return true;
+  if (factor.name === 'VirusTotal' && Number(details.total_engines) === 0) return true;
   // SAST analyzed no code (minified/bundled-only, or the download failed):
   // 0 files scanned and nothing deduped means it could not clear code safety.
-  if (factor?.name === 'SAST' && Number(details.files_scanned) === 0 && !details.deduped_findings) return true;
+  if (factor.name === 'SAST' && Number(details.files_scanned) === 0 && !details.deduped_findings) return true;
+  // Engine no-coverage sentinel: the VirusTotal / ChromeStats normalizers emit
+  // confidence 0 when the analyzer had no usable result (e.g. package missing).
+  if ((factor.name === 'VirusTotal' || factor.name === 'ChromeStats') && factor.confidence === 0) return true;
+  // Coverage-derived: required evidence source was unavailable.
+  if (evidence && typeof evidence === 'object') {
+    const need = FACTOR_EVIDENCE[factor.name];
+    if (need && evidence[need] === false) return true;
+  }
   return false;
 }
 
@@ -544,7 +583,7 @@ export function isNotAnalyzed(factor) {
  *  - unknown: the check could not run -> "Not analyzed" (never "Clear").
  *  - clear:   the check ran and found nothing material.
  */
-export function humanizeFactor(factor) {
+export function humanizeFactor(factor, evidence) {
   const info = FACTOR_HUMAN[factor.name] || {
     label: factor.name,
     category: 'other',
@@ -567,7 +606,7 @@ export function humanizeFactor(factor) {
     // modal agrees with the card / Issue Overview / Key Findings, which all
     // exclude it. At >= 0.6 (>180 days) it remains a visible caution.
     statusType = (isAdvisoryTrust && severity < 0.6) ? 'clear' : 'issues';
-  } else if (isNotAnalyzed(factor)) {
+  } else if (isNotAnalyzed(factor, evidence)) {
     statusType = 'unknown';
     tone = 'neutral';
     status = 'Not analyzed';
@@ -594,8 +633,8 @@ export function humanizeFactor(factor) {
  * issues (most severe first) -> not analyzed -> cleared (alphabetical).
  * Keeping this pure makes the "issues first / not-analyzed distinct" ordering testable.
  */
-export function triageFactors(factors = []) {
-  const humanised = (factors || []).map(humanizeFactor);
+export function triageFactors(factors = [], evidence) {
+  const humanised = (factors || []).map((factor) => humanizeFactor(factor, evidence));
   return {
     all: humanised,
     issues: humanised

--- a/frontend/src/pages/scanner/ScanResultsPageV2.jsx
+++ b/frontend/src/pages/scanner/ScanResultsPageV2.jsx
@@ -18,6 +18,9 @@ import {
   ExternalLink,
   AlertTriangle,
   ListChecks,
+  Info,
+  Search,
+  RotateCw,
 } from "lucide-react";
 import {
   resolveVerdictDisplay,
@@ -29,6 +32,8 @@ import {
   findingCategory,
   preciseFindingTitle,
   resolveFindingEvidenceLabel,
+  resolveScanAvailability,
+  resolveEvidenceAvailability,
 } from "../../utils/reportDisplay";
 import FileViewerModal from "../../components/FileViewerModal";
 import StatusMessage from "../../components/StatusMessage";
@@ -659,6 +664,79 @@ const ScanResultsPageV2 = () => {
   const formatScanDate = (ts) =>
     ts ? new Date(ts).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" }) : "—";
 
+  // Shared coverage-availability map (same coverage the Analyzer Coverage section
+  // reports). Drives the unavailable-state gate below and the "Cleared" vs
+  // "Not analyzed" split in the layer modals — one source of truth, no duplicate heuristic.
+  const availability = resolveScanAvailability(scanResults);
+  const evidenceAvailability = resolveEvidenceAvailability(scanResults);
+
+  // A definitively UNAVAILABLE extension (acquisition failed AND no real evidence
+  // of any kind) has nothing to score: render a dedicated unavailable state, never
+  // a normal scored report with an insufficient-data placeholder score/layer cards.
+  if (availability.unavailable) {
+    // Real current extension id (route/result), never hardcoded.
+    const unavailableExtId = scanResults?.extension_id || currentExtensionId || scanId;
+    return (
+      <>
+        {genericNoindexHead}
+        <div className="results-v2 results-v2-dashboard results-v2-unavailable">
+          <nav className="results-v2-nav">
+            <Link to="/scan" className="nav-back">← Back</Link>
+          </nav>
+          <nav className="report-breadcrumb" aria-label="Breadcrumb">
+            <Link to="/">Home</Link>
+            <ChevronRight size={14} aria-hidden="true" />
+            <Link to="/scan">Scan Results</Link>
+            <ChevronRight size={14} aria-hidden="true" />
+            <span className="report-breadcrumb-current">{meta?.name || scanId || "Report"}</span>
+          </nav>
+
+          <section className="uav-card" aria-labelledby="uav-heading">
+            <img
+              className="uav-illustration"
+              src="/extensionshield_extension_unavailable_illustration.svg"
+              alt=""
+              aria-hidden="true"
+            />
+            <h1 id="uav-heading" className="uav-heading">Extension not available</h1>
+            <p className="uav-copy">
+              This Chrome Web Store item is currently unavailable.<br />
+              It may have been removed, unpublished, or be temporarily inaccessible.
+            </p>
+            <div className="uav-actions">
+              <Button
+                variant="outline"
+                className="uav-btn uav-btn--primary"
+                onClick={() => navigate("/scan")}
+              >
+                <Search size={18} aria-hidden="true" />
+                Scan another extension
+              </Button>
+              <Button
+                variant="outline"
+                className="uav-btn uav-btn--secondary"
+                onClick={() => window.location.reload()}
+              >
+                <RotateCw size={18} aria-hidden="true" />
+                Try again
+              </Button>
+            </div>
+            <hr className="uav-divider" />
+            <div className="uav-note">
+              <Info size={16} aria-hidden="true" className="uav-note-icon" />
+              <span>No current score was generated because the listing and package were unavailable.</span>
+            </div>
+            {unavailableExtId && (
+              <p className="uav-extid">
+                Extension ID: <span className="uav-extid-value">{unavailableExtId}</span>
+              </p>
+            )}
+          </section>
+        </div>
+      </>
+    );
+  }
+
   return (
     <>
       {resultsSEOHead}
@@ -1075,6 +1153,7 @@ const ScanResultsPageV2 = () => {
           score={scores?.security?.score}
           band={scores?.security?.band || 'NA'}
           factors={factorsByLayer?.security || []}
+          evidence={evidenceAvailability}
           keyFindings={dedupeFindings(allSecurityFindings)}
           gateResults={scanResults?.scoring_v2?.gate_results?.filter(g => g.triggered && gateIdToLayer(g.gate_id) === 'security') || []}
           layerReasons={scores?.reasons?.filter(r => r.toLowerCase().includes('security') || r.toLowerCase().includes('sast') || r.toLowerCase().includes('malware')) || []}
@@ -1091,6 +1170,7 @@ const ScanResultsPageV2 = () => {
           score={scores?.privacy?.score}
           band={scores?.privacy?.band || 'NA'}
           factors={factorsByLayer?.privacy || []}
+          evidence={evidenceAvailability}
           keyFindings={dedupeFindings(allPrivacyFindings)}
           gateResults={scanResults?.scoring_v2?.gate_results?.filter(g => g.triggered && gateIdToLayer(g.gate_id) === 'privacy') || []}
           layerReasons={scores?.reasons?.filter(r => r.toLowerCase().includes('privacy') || r.toLowerCase().includes('exfil') || r.toLowerCase().includes('tracking')) || []}
@@ -1107,6 +1187,7 @@ const ScanResultsPageV2 = () => {
           score={scores?.governance?.score}
           band={scores?.governance?.band || 'NA'}
           factors={factorsByLayer?.governance || []}
+          evidence={evidenceAvailability}
           keyFindings={dedupeFindings(allGovernanceFindings)}
           gateResults={scanResults?.scoring_v2?.gate_results?.filter(g => g.triggered && gateIdToLayer(g.gate_id) === 'governance') || []}
           layerReasons={scores?.reasons?.filter(r => r.toLowerCase().includes('governance') || r.toLowerCase().includes('policy') || r.toLowerCase().includes('tos') || r.toLowerCase().includes('disclosure')) || []}

--- a/frontend/src/pages/scanner/ScanResultsPageV2.scss
+++ b/frontend/src/pages/scanner/ScanResultsPageV2.scss
@@ -466,7 +466,7 @@
     color: rgba(255, 255, 255, 0.5);
     margin-bottom: 1.5rem;
   }
-  
+
   .error-extension-id {
     display: flex;
     align-items: center;
@@ -527,6 +527,169 @@
   .error-actions {
     display: flex;
     gap: 1rem;
+  }
+}
+
+/* ============================================================================
+   Unavailable-extension state — dedicated card (no score, no report).
+   Renders at the natural content position under the breadcrumb; deliberately
+   NOT vertically centered across the viewport. Theme-aware via --theme-* tokens
+   so heading/copy stay readable in both light and dark (the old error styles
+   used white text, which was invisible on the light surface).
+   ============================================================================ */
+.results-v2-unavailable {
+  /* Full results-content width so the card's left edge lines up with the
+     breadcrumb (and matches the normal report hero, which spans grid-column
+     1 / -1). Capped by the .results-v2 max-width; never a narrow centered box. */
+  .uav-card {
+    width: 100%;
+    box-sizing: border-box;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+    gap: 20px;
+    padding: clamp(40px, 5vw, 56px) clamp(28px, 5vw, 72px);
+    background: var(--theme-bg-card);
+    border: 1px solid var(--theme-border);
+    border-radius: 24px;
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.03), 0 18px 40px rgba(0, 0, 0, 0.05);
+  }
+
+  .uav-illustration {
+    display: block;
+    width: 100%;
+    max-width: 440px;
+    height: auto;
+    margin: 4px auto;
+    user-select: none;
+  }
+
+  .uav-heading {
+    margin: 0;
+    color: var(--theme-text-primary);
+    font-size: clamp(1.6rem, 3.2vw, 2.1rem);
+    font-weight: 700;
+    letter-spacing: -0.01em;
+    line-height: 1.15;
+  }
+
+  .uav-copy {
+    margin: 0;
+    max-width: 640px;
+    color: var(--theme-text-secondary);
+    font-size: 1rem;
+    line-height: 1.6;
+  }
+
+  .uav-actions {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 12px;
+    margin-top: 4px;
+  }
+
+  /* Reuse the shared Button component; scope overrides here so we win over the
+     component's small default size without touching global button styles. */
+  .uav-btn {
+    height: auto;
+    padding: 12px 22px;
+    font-size: 0.95rem;
+    font-weight: 600;
+    border-radius: 12px;
+    line-height: 1.2;
+    box-shadow: none;
+
+    &:focus-visible {
+      outline: 2px solid var(--theme-accent);
+      outline-offset: 2px;
+    }
+  }
+
+  .uav-btn--primary {
+    color: var(--theme-accent);
+    background: transparent;
+    border-color: var(--theme-border-accent);
+
+    &:hover {
+      color: var(--theme-accent);
+      background: var(--theme-accent-subtle);
+      border-color: var(--theme-accent);
+    }
+  }
+
+  .uav-btn--secondary {
+    color: var(--theme-text-secondary);
+    background: transparent;
+    border-color: var(--theme-border);
+
+    &:hover {
+      color: var(--theme-text-primary);
+      background: var(--theme-bg-surface-hover);
+      border-color: var(--theme-border-hover);
+    }
+  }
+
+  .uav-divider {
+    width: 100%;
+    max-width: 760px;
+    height: 0;
+    margin: 8px 0 4px;
+    border: 0;
+    border-top: 1px solid var(--theme-border-subtle);
+  }
+
+  .uav-note {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    max-width: 660px;
+    padding: 12px 18px;
+    background: var(--theme-bg-surface-hover);
+    border: 1px solid var(--theme-border-subtle);
+    border-radius: 12px;
+    color: var(--theme-text-muted);
+    font-size: 0.9rem;
+    line-height: 1.5;
+    text-align: left;
+  }
+
+  .uav-note-icon {
+    flex: 0 0 auto;
+    color: var(--theme-text-muted);
+  }
+
+  .uav-extid {
+    margin: 0;
+    color: var(--theme-text-muted);
+    font-size: 0.85rem;
+    word-break: break-word;
+  }
+
+  .uav-extid-value {
+    font-family: var(--font-mono, monospace);
+  }
+
+  /* Tablet */
+  @media (max-width: 768px) {
+    .uav-card {
+      padding: clamp(28px, 6vw, 40px) clamp(20px, 5vw, 40px);
+      border-radius: 20px;
+    }
+    .uav-illustration { max-width: 360px; }
+  }
+
+  /* Mobile */
+  @media (max-width: 480px) {
+    .uav-card {
+      padding: 24px 20px;
+      gap: 16px;
+    }
+    .uav-illustration { max-width: 300px; }
+    .uav-actions { width: 100%; }
+    .uav-btn { flex: 1 1 100%; width: 100%; }
+    .uav-note { align-items: flex-start; }
   }
 }
 

--- a/frontend/src/utils/reportDisplay.js
+++ b/frontend/src/utils/reportDisplay.js
@@ -224,6 +224,83 @@ export function resolveAnalyzerCoverage(raw) {
   return rows;
 }
 
+// Analyzer-coverage states that mean the analyzer produced a usable result the
+// report may lean on. Anything else (not_run / failed / limited / no_code_scanned)
+// is a coverage GAP, never evidence of a clean result. Kept in sync with the
+// COVERAGE_STATES the Analyzer Coverage section renders.
+const PRODUCTIVE_COVERAGE_STATES = new Set(['full', 'scanned', 'partial']);
+
+/**
+ * Which underlying evidence each scoring factor actually needs. Presentation
+ * only — used to decide "Cleared" vs "Not analyzed" from the SAME coverage the
+ * Analyzer Coverage section reports (never a new/parallel classifier).
+ */
+export function resolveEvidenceAvailability(raw) {
+  if (!raw || typeof raw !== 'object') {
+    // No payload: assume nothing is missing so callers fall back to their own
+    // per-factor signals rather than mass-marking everything "Not analyzed".
+    return { code: true, malware: true, threatIntel: true, listing: true, manifest: true };
+  }
+
+  const stateByKey = {};
+  resolveAnalyzerCoverage(raw).forEach((row) => { stateByKey[row.key] = row.state; });
+  const productive = (key) => PRODUCTIVE_COVERAGE_STATES.has(stateByKey[key]);
+
+  // Store listing presence uses the EXACT check the Coverage section's listing
+  // row uses (see resolveAnalyzerCoverage), so the two never disagree.
+  const md = (raw.metadata && typeof raw.metadata === 'object') ? raw.metadata : {};
+  const hasListing = md.user_count != null || md.rating != null || md.version != null;
+
+  // A parsed manifest is the minimum evidence for manifest/permission/governance
+  // factors. An empty {} (download/extract failed) carries none.
+  const manifest = (raw.manifest && typeof raw.manifest === 'object') ? raw.manifest : {};
+  const hasManifest = Boolean(
+    manifest.manifest_version != null ||
+    manifest.name != null ||
+    manifest.version != null ||
+    Array.isArray(manifest.permissions) ||
+    Array.isArray(manifest.host_permissions)
+  );
+
+  return {
+    code: productive('sast'),
+    malware: productive('virustotal'),
+    threatIntel: productive('chromestats'),
+    listing: hasListing,
+    manifest: hasManifest,
+  };
+}
+
+/**
+ * Decide whether a scan result represents an extension we could actually
+ * analyze. A definitively UNAVAILABLE extension — acquisition failed AND no real
+ * evidence of any kind was captured — must not render a normal scored report
+ * (the recompute-on-read still emits an insufficient-data score, but that score
+ * describes nothing). A failed scan that DID capture real evidence (e.g. the
+ * store listing) is a legitimate partial report and stays available.
+ *
+ * Derived entirely from existing payload fields + the shared coverage adapter;
+ * never mutates and never invents a verdict. A valid/`completed` scan (even a
+ * historical one being served) is always available.
+ */
+export function resolveScanAvailability(raw) {
+  if (!raw || typeof raw !== 'object') {
+    return { available: true, unavailable: false, reason: null };
+  }
+  const acquisitionFailed = String(raw.status || '').toLowerCase() === 'failed';
+  const ev = resolveEvidenceAvailability(raw);
+  const hasAnyEvidence = ev.code || ev.malware || ev.threatIntel || ev.listing || ev.manifest;
+  const unavailable = acquisitionFailed && !hasAnyEvidence;
+  const rawReason = typeof raw.error === 'string' ? raw.error.trim() : '';
+  return {
+    available: !unavailable,
+    unavailable,
+    reason: unavailable
+      ? (rawReason || 'The extension package and store listing could not be retrieved.')
+      : null,
+  };
+}
+
 /** Compact severity band from a finding's severity (string level or 0..1 number). */
 export function findingSeverityLevel(finding) {
   const s = finding == null ? undefined : (typeof finding === 'object' ? finding.severity : finding);

--- a/frontend/src/utils/reportDisplay.test.js
+++ b/frontend/src/utils/reportDisplay.test.js
@@ -11,6 +11,8 @@ import {
   resolveFindingEvidenceLabel,
   describeDecisionAuthority,
   resolveDecisionAuthorityDisplay,
+  resolveEvidenceAvailability,
+  resolveScanAvailability,
   GOVERNANCE_SCORE_LABEL,
   POLICY_DECISION_LABEL,
 } from './reportDisplay';
@@ -333,5 +335,133 @@ describe('resolveDecisionAuthorityDisplay — full authority element model', () 
   it('returns null when there is no authority', () => {
     expect(resolveDecisionAuthorityDisplay(null)).toBeNull();
     expect(resolveDecisionAuthorityDisplay('')).toBeNull();
+  });
+});
+
+// A definitively unavailable extension: acquisition failed and NOTHING real was
+// captured (no signal_pack, all-null store metadata, empty manifest). Mirrors the
+// served payload for a "This item is not available" extension whose download
+// returned no file.
+const UNAVAILABLE_PAYLOAD = {
+  status: 'failed',
+  error: 'Extension download returned no file.',
+  url: 'https://chromewebstore.google.com/detail/pgpidfocdapogajplhjofamgeboonmmj',
+  metadata: {
+    title: null, user_count: null, rating: null, version: null, last_updated: null,
+  },
+  manifest: {},
+};
+
+// A legitimate partial: the package download failed, but the store listing WAS
+// captured — real evidence exists, so the report stays available (qualified).
+const PARTIAL_LISTING_PAYLOAD = {
+  status: 'failed',
+  error: 'Extension download returned no file.',
+  url: 'https://chromewebstore.google.com/detail/abc',
+  metadata: { user_count: 5000, rating: 4.2, version: '1.2.3' },
+  manifest: {},
+};
+
+// A valid full scan: analyzers ran, listing + manifest present.
+const FULL_SCAN_PAYLOAD = {
+  status: 'completed',
+  metadata: { user_count: 20000, rating: 4.9, version: '2.0.0' },
+  manifest: { name: 'X', version: '2.0.0', manifest_version: 3, permissions: ['storage'] },
+  governance_bundle: {
+    signal_pack: {
+      sast: { files_scanned: 3 },
+      virustotal: { enabled: true, total_engines: 75, malicious_count: 0 },
+      chromestats: {
+        enabled: true, risk_indicators: ['x'], total_risk_score: 5,
+        install_trends: { m: 1 }, rating_patterns: {}, developer_reputation: {},
+      },
+    },
+  },
+};
+
+describe('resolveEvidenceAvailability — coverage-derived evidence presence', () => {
+  it('reports every evidence source ABSENT for an unavailable extension', () => {
+    const ev = resolveEvidenceAvailability(UNAVAILABLE_PAYLOAD);
+    expect(ev).toEqual({
+      code: false, malware: false, threatIntel: false, listing: false, manifest: false,
+    });
+  });
+
+  it('reports the store listing PRESENT for a package-download-only failure', () => {
+    const ev = resolveEvidenceAvailability(PARTIAL_LISTING_PAYLOAD);
+    expect(ev.listing).toBe(true);
+    // The package still could not be analyzed.
+    expect(ev.code).toBe(false);
+    expect(ev.manifest).toBe(false);
+  });
+
+  it('reports every evidence source PRESENT for a valid full scan', () => {
+    const ev = resolveEvidenceAvailability(FULL_SCAN_PAYLOAD);
+    expect(ev).toEqual({
+      code: true, malware: true, threatIntel: true, listing: true, manifest: true,
+    });
+  });
+
+  it('a full scan with ChromeStats absent still reports the other sources present', () => {
+    const noCs = {
+      ...FULL_SCAN_PAYLOAD,
+      governance_bundle: { signal_pack: {
+        sast: { files_scanned: 3 },
+        virustotal: { enabled: true, total_engines: 75, malicious_count: 0 },
+      } },
+    };
+    const ev = resolveEvidenceAvailability(noCs);
+    expect(ev.threatIntel).toBe(false); // ChromeStats did not run
+    expect(ev.code).toBe(true);
+    expect(ev.malware).toBe(true);
+    expect(ev.listing).toBe(true);
+    expect(ev.manifest).toBe(true);
+  });
+
+  it('defaults to "all present" for a null/garbage payload (never mass-marks Not analyzed)', () => {
+    expect(resolveEvidenceAvailability(null)).toEqual({
+      code: true, malware: true, threatIntel: true, listing: true, manifest: true,
+    });
+  });
+});
+
+describe('resolveScanAvailability — unavailable vs partial vs full', () => {
+  it('marks a failed no-evidence extension UNAVAILABLE with the download reason', () => {
+    const a = resolveScanAvailability(UNAVAILABLE_PAYLOAD);
+    expect(a.unavailable).toBe(true);
+    expect(a.available).toBe(false);
+    expect(a.reason).toBe('Extension download returned no file.');
+  });
+
+  it('keeps a failed scan AVAILABLE when real evidence (store listing) exists', () => {
+    const a = resolveScanAvailability(PARTIAL_LISTING_PAYLOAD);
+    expect(a.unavailable).toBe(false);
+    expect(a.available).toBe(true);
+    expect(a.reason).toBeNull();
+  });
+
+  it('keeps a valid full scan AVAILABLE', () => {
+    const a = resolveScanAvailability(FULL_SCAN_PAYLOAD);
+    expect(a.unavailable).toBe(false);
+    expect(a.available).toBe(true);
+  });
+
+  it('a valid historical (completed) scan is AVAILABLE even with no analyzer coverage', () => {
+    // A failed CURRENT scan must not overwrite a good historical one (backend
+    // guard); when the served payload IS the good historical scan (status
+    // completed), it renders normally rather than as "unavailable".
+    const historical = { status: 'completed', metadata: { version: '1.0.0' }, manifest: {} };
+    expect(resolveScanAvailability(historical).unavailable).toBe(false);
+  });
+
+  it('falls back to a generic reason when a failed payload carries no error text', () => {
+    const a = resolveScanAvailability({ status: 'failed', metadata: {}, manifest: {} });
+    expect(a.unavailable).toBe(true);
+    expect(a.reason).toMatch(/could not be retrieved/i);
+  });
+
+  it('never marks a null/garbage payload unavailable', () => {
+    expect(resolveScanAvailability(null).unavailable).toBe(false);
+    expect(resolveScanAvailability(undefined).available).toBe(true);
   });
 });

--- a/tests/api/test_scan_results_endpoint.py
+++ b/tests/api/test_scan_results_endpoint.py
@@ -95,3 +95,70 @@ class TestGetScanResultsUpgrade:
       assert isinstance(rvm["consumer_insights"], dict)
 
 
+class TestFailedScanDoesNotOverwriteHistory:
+  """A failed CURRENT scan must never replace a good historical `completed` scan.
+
+  Pins the _persist_scan_failure guard that backs the frontend "unavailable"
+  fix: when a rescan of a now-unfetchable extension fails, the last good report
+  is preserved (status stays completed) rather than clobbered by a score-0
+  failed placeholder.
+  """
+
+  def test_failed_rescan_preserves_prior_completed_result(self) -> None:
+    from extension_shield.api import main as api_main
+
+    ext_id = "abcdefghijklmnopabcdefghijklmnop"
+    failed_payload = {
+      "extension_id": ext_id,
+      "status": "failed",
+      "error": "Extension download returned no file.",
+      "security_score": 0,
+    }
+    api_main.scan_results.pop(ext_id, None)
+    api_main.scan_status.pop(ext_id, None)
+
+    with patch("extension_shield.api.main.db") as mock_db:
+      # Prior good result exists in the DB.
+      mock_db.get_scan_result = MagicMock(return_value={"status": "completed", "security_score": 88})
+      mock_db.save_scan_result = MagicMock()
+
+      api_main._persist_scan_failure(ext_id, failed_payload)
+
+      # The failed placeholder is NOT written to the DB...
+      mock_db.save_scan_result.assert_not_called()
+      # ...the served status stays "completed"...
+      assert api_main.scan_status.get(ext_id) == "completed"
+      # ...and the transient failed payload is not left in memory.
+      assert ext_id not in api_main.scan_results
+
+    api_main.scan_results.pop(ext_id, None)
+    api_main.scan_status.pop(ext_id, None)
+
+  def test_failed_scan_persists_when_no_prior_good_result(self) -> None:
+    from extension_shield.api import main as api_main
+
+    ext_id = "ponmlkjihgfedcbaponmlkjihgfedcba"
+    failed_payload = {
+      "extension_id": ext_id,
+      "status": "failed",
+      "error": "Extension download returned no file.",
+      "security_score": 0,
+    }
+    api_main.scan_results.pop(ext_id, None)
+    api_main.scan_status.pop(ext_id, None)
+
+    with patch("extension_shield.api.main.db") as mock_db:
+      # No prior result at all.
+      mock_db.get_scan_result = MagicMock(return_value=None)
+      mock_db.save_scan_result = MagicMock()
+
+      api_main._persist_scan_failure(ext_id, failed_payload)
+
+      # With nothing to preserve, the failure IS recorded.
+      mock_db.save_scan_result.assert_called_once_with(failed_payload)
+      assert api_main.scan_status.get(ext_id) == "failed"
+
+    api_main.scan_results.pop(ext_id, None)
+    api_main.scan_status.pop(ext_id, None)
+
+


### PR DESCRIPTION
I fixed the case where an extension that is no longer available could still show a normal scored report.

The unavailable state now hides the score, layer cards, findings, and report navigation. Checks that did not actually run now show as “Not analyzed” instead of incorrectly appearing as “Cleared.”

I also added the new unavailable-extension design with the SVG illustration, actions, explanatory message, dynamic extension ID, and responsive alignment with the results page.

Added regression coverage to make sure failed scans do not overwrite a valid historical scan and existing full reports continue to work.

No scoring weights, thresholds, gates, backend scoring logic, Track A files, or database data were changed.
