### PR TITLE
feat: add Chrome Web Store liveness metadata and unavailable gate

### DIFF
--- a/frontend/src/pages/scanner/ScanResultsPageV2.jsx
+++ b/frontend/src/pages/scanner/ScanResultsPageV2.jsx
@@ -34,6 +34,7 @@ import {
   resolveFindingEvidenceLabel,
   resolveScanAvailability,
   resolveEvidenceAvailability,
+  resolveStoreStatus,
 } from "../../utils/reportDisplay";
 import FileViewerModal from "../../components/FileViewerModal";
 import StatusMessage from "../../components/StatusMessage";
@@ -673,7 +674,16 @@ const ScanResultsPageV2 = () => {
   // A definitively UNAVAILABLE extension (acquisition failed AND no real evidence
   // of any kind) has nothing to score: render a dedicated unavailable state, never
   // a normal scored report with an insufficient-data placeholder score/layer cards.
-  if (availability.unavailable) {
+  //
+  // Part 4 — temporal availability drift: an extension with a valid historical scan
+  // that the Chrome Web Store now reports unavailable (store_status.status ===
+  // 'unavailable') must ALSO render the unavailable state, not a scored report. This
+  // is availability metadata only — the stored historical score is unchanged and
+  // simply not displayed here.
+  const storeUnavailable = resolveStoreStatus(scanResults).unavailable;
+  if (availability.unavailable || storeUnavailable) {
+    // Historical variant: we hold a prior scan, but the live listing can't be verified.
+    const historicalUnavailable = storeUnavailable && !availability.unavailable;
     // Real current extension id (route/result), never hardcoded.
     const unavailableExtId = scanResults?.extension_id || currentExtensionId || scanId;
     return (
@@ -700,8 +710,17 @@ const ScanResultsPageV2 = () => {
             />
             <h1 id="uav-heading" className="uav-heading">Extension not available</h1>
             <p className="uav-copy">
-              This Chrome Web Store item is currently unavailable.<br />
-              It may have been removed, unpublished, or be temporarily inaccessible.
+              {historicalUnavailable ? (
+                <>
+                  This Chrome Web Store item is currently unavailable. ExtensionShield has a
+                  historical scan for this extension, but the current listing can no longer be verified.
+                </>
+              ) : (
+                <>
+                  This Chrome Web Store item is currently unavailable.<br />
+                  It may have been removed, unpublished, or be temporarily inaccessible.
+                </>
+              )}
             </p>
             <div className="uav-actions">
               <Button
@@ -724,7 +743,11 @@ const ScanResultsPageV2 = () => {
             <hr className="uav-divider" />
             <div className="uav-note">
               <Info size={16} aria-hidden="true" className="uav-note-icon" />
-              <span>No current score was generated because the listing and package were unavailable.</span>
+              <span>
+                {historicalUnavailable
+                  ? "No current score was generated or changed by this availability check."
+                  : "No current score was generated because the listing and package were unavailable."}
+              </span>
             </div>
             {unavailableExtId && (
               <p className="uav-extid">

--- a/frontend/src/utils/reportDisplay.js
+++ b/frontend/src/utils/reportDisplay.js
@@ -301,6 +301,23 @@ export function resolveScanAvailability(raw) {
   };
 }
 
+/**
+ * Chrome Web Store liveness (Part 4): read the additive `store_status` metadata the
+ * API attaches (never a scoring field). An extension the Store now reports
+ * unavailable must render the unavailable state even when a valid historical scan
+ * exists. Availability only — it never reads or changes any score. Only a confirmed
+ * `unavailable` gates the UI; `available` / `unknown` / missing render normally.
+ */
+export function resolveStoreStatus(raw) {
+  const s = raw && typeof raw === 'object' ? raw.store_status : null;
+  const status = (s && typeof s === 'object' && typeof s.status === 'string') ? s.status : 'unknown';
+  return {
+    status,
+    unavailable: status === 'unavailable',
+    reason: (s && typeof s === 'object' && typeof s.reason === 'string') ? s.reason : null,
+  };
+}
+
 /** Compact severity band from a finding's severity (string level or 0..1 number). */
 export function findingSeverityLevel(finding) {
   const s = finding == null ? undefined : (typeof finding === 'object' ? finding.severity : finding);

--- a/frontend/src/utils/reportDisplay.test.js
+++ b/frontend/src/utils/reportDisplay.test.js
@@ -13,6 +13,7 @@ import {
   resolveDecisionAuthorityDisplay,
   resolveEvidenceAvailability,
   resolveScanAvailability,
+  resolveStoreStatus,
   GOVERNANCE_SCORE_LABEL,
   POLICY_DECISION_LABEL,
 } from './reportDisplay';
@@ -463,5 +464,28 @@ describe('resolveScanAvailability — unavailable vs partial vs full', () => {
   it('never marks a null/garbage payload unavailable', () => {
     expect(resolveScanAvailability(null).unavailable).toBe(false);
     expect(resolveScanAvailability(undefined).available).toBe(true);
+  });
+});
+
+describe('resolveStoreStatus — Chrome Web Store liveness (Part 4)', () => {
+  it('reports unavailable when the store_status metadata says unavailable', () => {
+    const raw = { status: 'completed', store_status: { status: 'unavailable', reason: 'Chrome Web Store item unavailable' } };
+    const s = resolveStoreStatus(raw);
+    expect(s.unavailable).toBe(true);
+    expect(s.status).toBe('unavailable');
+    expect(s.reason).toMatch(/unavailable/i);
+  });
+
+  it('does NOT gate on available / unknown / missing store_status', () => {
+    expect(resolveStoreStatus({ store_status: { status: 'available' } }).unavailable).toBe(false);
+    expect(resolveStoreStatus({ store_status: { status: 'unknown' } }).unavailable).toBe(false);
+    expect(resolveStoreStatus({ status: 'completed' }).unavailable).toBe(false); // no field
+    expect(resolveStoreStatus({}).status).toBe('unknown');
+  });
+
+  it('is defensive against null/garbage payloads', () => {
+    expect(resolveStoreStatus(null).unavailable).toBe(false);
+    expect(resolveStoreStatus(undefined).status).toBe('unknown');
+    expect(resolveStoreStatus({ store_status: 'nope' }).unavailable).toBe(false);
   });
 });

--- a/src/extension_shield/api/database.py
+++ b/src/extension_shield/api/database.py
@@ -290,6 +290,91 @@ class Database:
             """
             )
 
+            # Chrome Web Store liveness — EXTENSION-LEVEL availability metadata.
+            # Keyed by extension_id (one row per extension). This is store status
+            # ONLY: it never influences scoring, recompute-on-read, or any corpus/
+            # Track A label. See core/store_liveness.py for the resolution rules.
+            cursor.execute(
+                """
+                CREATE TABLE IF NOT EXISTS extension_store_status (
+                    extension_id                  TEXT PRIMARY KEY,
+                    store_status                  TEXT NOT NULL DEFAULT 'unknown',
+                    store_status_reason           TEXT,
+                    store_status_source           TEXT NOT NULL DEFAULT 'auto',
+                    store_status_checked_at       TEXT,
+                    first_detected_unavailable_at TEXT,
+                    last_seen_available_at        TEXT,
+                    updated_at                    TEXT DEFAULT CURRENT_TIMESTAMP
+                )
+            """
+            )
+
+    # ------------------------------------------------------------------
+    # Extension store-status (Chrome Web Store liveness) — metadata only.
+    # ------------------------------------------------------------------
+    _STORE_STATUS_COLUMNS = (
+        "extension_id, store_status, store_status_reason, store_status_source, "
+        "store_status_checked_at, first_detected_unavailable_at, last_seen_available_at, updated_at"
+    )
+
+    def get_store_status(self, extension_id: str) -> Optional[Dict[str, Any]]:
+        """Return the durable store-status row for an extension, or None."""
+        if not extension_id:
+            return None
+        try:
+            with self.get_connection() as conn:
+                cursor = conn.cursor()
+                cursor.execute(
+                    f"SELECT {self._STORE_STATUS_COLUMNS} FROM extension_store_status WHERE extension_id = ?",
+                    (extension_id,),
+                )
+                row = cursor.fetchone()
+                return dict(row) if row else None
+        except Exception as exc:
+            logger.debug("get_store_status failed for %s: %s", extension_id, exc)
+            return None
+
+    def upsert_store_status(self, extension_id: str, **fields: Any) -> bool:
+        """Insert or replace the store-status row. Caller supplies already-resolved
+        field values (see core/store_liveness.resolve_store_status)."""
+        if not extension_id:
+            return False
+        try:
+            now = datetime.now(timezone.utc).isoformat()
+            with self.get_connection() as conn:
+                cursor = conn.cursor()
+                cursor.execute(
+                    """
+                    INSERT INTO extension_store_status (
+                        extension_id, store_status, store_status_reason, store_status_source,
+                        store_status_checked_at, first_detected_unavailable_at,
+                        last_seen_available_at, updated_at
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                    ON CONFLICT(extension_id) DO UPDATE SET
+                        store_status = excluded.store_status,
+                        store_status_reason = excluded.store_status_reason,
+                        store_status_source = excluded.store_status_source,
+                        store_status_checked_at = excluded.store_status_checked_at,
+                        first_detected_unavailable_at = excluded.first_detected_unavailable_at,
+                        last_seen_available_at = excluded.last_seen_available_at,
+                        updated_at = excluded.updated_at
+                    """,
+                    (
+                        extension_id,
+                        fields.get("store_status", "unknown"),
+                        fields.get("store_status_reason"),
+                        fields.get("store_status_source", "auto"),
+                        fields.get("store_status_checked_at"),
+                        fields.get("first_detected_unavailable_at"),
+                        fields.get("last_seen_available_at"),
+                        now,
+                    ),
+                )
+            return True
+        except Exception as exc:
+            logger.debug("upsert_store_status failed for %s: %s", extension_id, exc)
+            return False
+
     def save_scan_result(self, result: Dict[str, Any]) -> bool:
         """Save or update scan result."""
         try:
@@ -1056,6 +1141,50 @@ class SupabaseDatabase:
         from supabase import create_client  # type: ignore
 
         self.client = create_client(supabase_url, supabase_key)
+
+    # ------------------------------------------------------------------
+    # Extension store-status (Chrome Web Store liveness) — metadata only.
+    # Gracefully degrades to no-op when the `extension_store_status` table has
+    # not yet been migrated into Supabase (feature simply reports "unknown").
+    # ------------------------------------------------------------------
+    STORE_STATUS_TABLE = "extension_store_status"
+
+    def get_store_status(self, extension_id: str) -> Optional[Dict[str, Any]]:
+        if not extension_id:
+            return None
+        try:
+            resp = (
+                self.client.table(self.STORE_STATUS_TABLE)
+                .select("*")
+                .eq("extension_id", extension_id)
+                .limit(1)
+                .execute()
+            )
+            data = getattr(resp, "data", None) or []
+            return data[0] if data else None
+        except Exception as exc:
+            logger.debug("Supabase get_store_status unavailable for %s: %s", extension_id, exc)
+            return None
+
+    def upsert_store_status(self, extension_id: str, **fields: Any) -> bool:
+        if not extension_id:
+            return False
+        try:
+            row = {
+                "extension_id": extension_id,
+                "store_status": fields.get("store_status", "unknown"),
+                "store_status_reason": fields.get("store_status_reason"),
+                "store_status_source": fields.get("store_status_source", "auto"),
+                "store_status_checked_at": fields.get("store_status_checked_at"),
+                "first_detected_unavailable_at": fields.get("first_detected_unavailable_at"),
+                "last_seen_available_at": fields.get("last_seen_available_at"),
+                "updated_at": datetime.now(timezone.utc).isoformat(),
+            }
+            self.client.table(self.STORE_STATUS_TABLE).upsert(row).execute()
+            return True
+        except Exception as exc:
+            logger.debug("Supabase upsert_store_status unavailable for %s: %s", extension_id, exc)
+            return False
 
     def save_scan_result(self, result: Dict[str, Any]) -> bool:
         try:

--- a/src/extension_shield/api/main.py
+++ b/src/extension_shield/api/main.py
@@ -39,6 +39,7 @@ from slowapi.middleware import SlowAPIMiddleware
 from extension_shield.core.report_generator import ReportGenerator
 from extension_shield.core.extension_metadata import ExtensionMetadata
 from extension_shield.core.chromestats_downloader import ChromeStatsDownloader
+from extension_shield.core import store_liveness
 
 from extension_shield.workflow.graph import build_graph
 from extension_shield.workflow.state import WorkflowState, WorkflowStatus
@@ -2006,6 +2007,23 @@ def _build_scoring_v2_for_payload(payload: Dict[str, Any], extension_id: str) ->
         return {}
 
 
+def _attach_store_status(payload: Dict[str, Any]) -> None:
+    """Attach ADDITIVE Chrome Web Store availability metadata to a served payload.
+
+    Store status is availability only — it never reads or changes scoring_v2,
+    recompute-on-read, coverage, or any corpus/Track A label. Fail-open: any error
+    (or a Supabase table that has not been migrated yet) leaves status "unknown",
+    which the frontend renders as a normal report.
+    """
+    try:
+        ext_id = payload.get("extension_id")
+        if not ext_id:
+            return
+        payload["store_status"] = store_liveness.get_store_status_for_payload(db, ext_id)
+    except Exception as exc:  # never let availability metadata break the report
+        logger.debug("attach store_status failed: %s", exc)
+
+
 def _extract_risk_and_signals(payload: Dict[str, Any]) -> Dict[str, Any]:
     """
     Extract risk and signals mapping from scan results payload.
@@ -2916,6 +2934,7 @@ async def get_scan_results(identifier: str, http_request: Request):
             # Add risk and signals mapping
             payload["risk_and_signals"] = _extract_risk_and_signals(payload)
             scan_results[extension_id] = payload
+            _attach_store_status(payload)
             log_scan_results_return_shape("memory", payload)
             if payload.get("error"):
                 payload["error"] = _sanitize_error_for_client(payload["error"])
@@ -2963,6 +2982,7 @@ async def get_scan_results(identifier: str, http_request: Request):
             except Exception as persist_err:
                 logger.debug("[get_scan_results] Failed to persist upgraded payload: %s", persist_err)
         
+        _attach_store_status(payload)
         log_scan_results_return_shape("db", payload)
         if payload.get("error"):
             payload["error"] = _sanitize_error_for_client(payload["error"])
@@ -3001,6 +3021,7 @@ async def get_scan_results(identifier: str, http_request: Request):
                 db.save_scan_result(payload)
             except Exception:
                 pass
+            _attach_store_status(payload)
             log_scan_results_return_shape("file", payload)
             if payload.get("error"):
                 payload["error"] = _sanitize_error_for_client(payload["error"])

--- a/src/extension_shield/cli/main.py
+++ b/src/extension_shield/cli/main.py
@@ -491,6 +491,55 @@ def serve(host: str, port: int, reload: bool):
     )
 
 
+@cli.group("store-status")
+def store_status():
+    """Curate Chrome Web Store availability metadata (availability only — never
+    affects scoring, recompute-on-read, or any corpus/Track A label).
+
+    Use `set ... unavailable` to mark a storefront-delisted extension (which has no
+    automated signal) so its report shows the "Extension not available" state.
+    """
+
+
+@store_status.command("set")
+@click.argument("extension_id")
+@click.argument("status", type=click.Choice(["available", "unavailable", "unknown"]))
+@click.option("--reason", default=None, help="Optional human note (e.g. 'delisted from store').")
+def store_status_set(extension_id: str, status: str, reason: Optional[str]):
+    """Set a CURATED store status for EXTENSION_ID. Curated status wins over the probe."""
+    from extension_shield.api.database import db
+    from extension_shield.core import store_liveness
+
+    ok = store_liveness.set_curated_status(db, extension_id, status, reason)
+    if ok:
+        console.print(f"[green]✓[/green] {extension_id} → store_status=[cyan]{status}[/cyan] (curated)")
+    else:
+        console.print(f"[red]✗[/red] Failed to set store status for {extension_id}")
+
+
+@store_status.command("get")
+@click.argument("extension_id")
+def store_status_get(extension_id: str):
+    """Show the stored store-status row for EXTENSION_ID."""
+    from extension_shield.api.database import db
+
+    row = db.get_store_status(extension_id)
+    if not row:
+        console.print(f"[yellow]No store status recorded for {extension_id}[/yellow]")
+        return
+    console.print(row)
+
+
+@store_status.command("probe")
+@click.argument("extension_id")
+def store_status_probe(extension_id: str):
+    """Run the live availability probe for EXTENSION_ID (read-only; no DB write)."""
+    from extension_shield.core import store_liveness
+
+    result = store_liveness.probe_store_availability(extension_id)
+    console.print(result)
+
+
 @cli.command()
 def version():
     """Show version information."""

--- a/src/extension_shield/core/store_liveness.py
+++ b/src/extension_shield/core/store_liveness.py
@@ -1,0 +1,286 @@
+"""
+Chrome Web Store liveness — extension availability METADATA.
+
+This module answers one narrow question: "is this extension still served by the
+Chrome Web Store?" It is deliberately separate from scoring. It NEVER changes a
+score, a recompute-on-read result, a coverage value, or any corpus / Track A
+label. The resolved status is additive metadata plus a presentation gate.
+
+Signal (proven in Phase 1):
+  - The Omaha update endpoint (clients2.google.com/service/update2/crx, the same
+    endpoint the downloader uses) can only DISPROVE availability. It gives a
+    definitive signal ONLY for the *artifact-withdrawn* class:
+        HTTP 204/404 -> no artifact / not found    -> "unavailable" (definitive)
+        HTTP 302  -> an artifact IS served         -> "unknown" (NOT "available")
+        anything else / error / timeout / HTML     -> "unknown" (fail-open)
+  - A 302 (redirect to a downloadable CRX) does NOT prove the storefront listing
+    exists: storefront-delisted extensions may return the same 302 response as live
+    extensions, so a served artifact does not confirm storefront availability. The
+    auto probe never CONFIRMS availability — it can only report "unavailable"
+    (204/404) or "unknown".
+  - Storefront POLICY delistings (page still lists a real name but shows a
+    JS-rendered "no longer available" banner) have NO server-side signal here and
+    are handled via CURATED status (see set_curated_status / the CLI).
+
+The probe MUST NOT download, save, or analyze the CRX body, and MUST NOT scrape
+store-page HTML. It observes only the update endpoint's status line.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from datetime import datetime, timezone, timedelta
+from typing import Any, Dict, Optional
+
+from extension_shield.utils.http_safety import safe_get
+
+logger = logging.getLogger(__name__)
+
+# Statuses (tri-state).
+AVAILABLE = "available"
+UNAVAILABLE = "unavailable"
+UNKNOWN = "unknown"
+
+# Sources / provenance.
+SOURCE_AUTO = "auto"
+SOURCE_CURATED = "curated"
+
+# Generic reason for an auto-detected removal. Detailed/attributed reasons are a
+# future follow-up — we never infer WHY an item was removed.
+REASON_UNAVAILABLE = "Chrome Web Store item unavailable"
+# An "available" reason is only ever set by a CURATED record — the auto probe never
+# confirms availability (a 302 only proves an artifact is served, not that the
+# storefront listing exists).
+REASON_AVAILABLE = "Marked available"
+# A 302 means the update endpoint served an artifact, but that does not establish
+# storefront availability — so the storefront status stays UNKNOWN (fail-open).
+REASON_ARTIFACT_SERVED = "Artifact served by the update endpoint; storefront status unverified"
+REASON_UNKNOWN = "Availability check inconclusive"
+
+# Cache TTLs (seconds). Definitive results are cached longer than "unknown" ones,
+# so a transient failure is retried sooner without hammering the endpoint.
+DEFINITIVE_TTL_SECONDS = 24 * 60 * 60
+UNKNOWN_TTL_SECONDS = 60 * 60
+# Bounded, short timeout so a Google outage never slows the report endpoint.
+PROBE_TIMEOUT = (3, 4)
+
+_UPDATE_HOST = "clients2.google.com"
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _update_url(extension_id: str) -> str:
+    """Same update2/crx endpoint the downloader uses (core/extension_downloader.py),
+    built here so the probe stays independent of the download machinery."""
+    chrome_version = os.getenv("CHROME_VERSION", "131.0.0.0")
+    return (
+        "https://clients2.google.com/service/update2/crx"
+        f"?response=redirect&prodversion={chrome_version}"
+        "&acceptformat=crx2%2Ccrx3"
+        f"&x=id%3D{extension_id}%26uc"
+    )
+
+
+def probe_store_availability(extension_id: str) -> Dict[str, Any]:
+    """Probe the update endpoint (no redirect follow, no body read) and classify.
+
+    Returns {status, reason, checked_at}. Never raises — any error is "unknown".
+    """
+    checked_at = _now_iso()
+    if not extension_id:
+        return {"status": UNKNOWN, "reason": REASON_UNKNOWN, "checked_at": checked_at}
+    try:
+        resp = safe_get(
+            _update_url(extension_id),
+            allowed_hosts={_UPDATE_HOST},
+            timeout=PROBE_TIMEOUT,
+            headers={
+                "User-Agent": (
+                    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+                    "(KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36"
+                ),
+                "Accept": "application/x-chrome-extension,*/*",
+            },
+            stream=True,            # never buffer the body
+            allow_redirects=False,  # never follow the redirect / download the CRX
+        )
+        status_code = resp.status_code
+        try:
+            resp.close()  # discard without reading the body
+        except Exception:
+            pass
+        if status_code in (204, 404):
+            return {"status": UNAVAILABLE, "reason": REASON_UNAVAILABLE, "checked_at": checked_at}
+        # A 302 means an artifact is served, which does NOT prove the storefront
+        # listing exists (delisted-but-served extensions return 302 too). The auto
+        # probe never confirms availability -> storefront status stays UNKNOWN.
+        if status_code == 302:
+            return {"status": UNKNOWN, "reason": REASON_ARTIFACT_SERVED, "checked_at": checked_at}
+        # 200 (consent/HTML), 429, 5xx, etc. are not a definitive removal.
+        return {"status": UNKNOWN, "reason": REASON_UNKNOWN, "checked_at": checked_at}
+    except Exception as exc:
+        logger.debug("store liveness probe failed for %s: %s", extension_id, exc)
+        return {"status": UNKNOWN, "reason": REASON_UNKNOWN, "checked_at": checked_at}
+
+
+def resolve_store_status(
+    current: Optional[Dict[str, Any]],
+    probe: Dict[str, Any],
+    *,
+    now: Optional[str] = None,
+) -> Optional[Dict[str, Any]]:
+    """Pure precedence resolver (no I/O — unit-testable).
+
+    Rules:
+      - CURATED wins: an auto probe never overwrites a human-set row -> returns
+        None (no write).
+      - UNKNOWN never overwrites a prior CONFIRMED (available/unavailable) row ->
+        returns None.
+      - first_detected_unavailable_at is set ONCE and preserved thereafter.
+      - last_seen_available_at is preserved unless a fresh "available" updates it.
+
+    Returns the field dict to upsert, or None when nothing should change.
+    """
+    now = now or _now_iso()
+    status = probe.get("status", UNKNOWN)
+    reason = probe.get("reason")
+    checked_at = probe.get("checked_at", now)
+    cur = current or {}
+
+    # Curated rows are authoritative; the automated probe must not touch them.
+    if cur.get("store_status_source") == SOURCE_CURATED:
+        return None
+
+    prior_first_unavail = cur.get("first_detected_unavailable_at")
+    prior_last_avail = cur.get("last_seen_available_at")
+    prior_status = cur.get("store_status")
+
+    if status == UNAVAILABLE:
+        return {
+            "store_status": UNAVAILABLE,
+            "store_status_reason": reason,
+            "store_status_source": SOURCE_AUTO,
+            "store_status_checked_at": checked_at,
+            "first_detected_unavailable_at": prior_first_unavail or now,
+            "last_seen_available_at": prior_last_avail,
+        }
+    if status == AVAILABLE:
+        return {
+            "store_status": AVAILABLE,
+            "store_status_reason": reason,
+            "store_status_source": SOURCE_AUTO,
+            "store_status_checked_at": checked_at,
+            "first_detected_unavailable_at": prior_first_unavail,
+            "last_seen_available_at": now,
+        }
+    # status == UNKNOWN
+    if prior_status in (AVAILABLE, UNAVAILABLE):
+        # Do not erase a prior definitive fact with an inconclusive probe.
+        return None
+    return {
+        "store_status": UNKNOWN,
+        "store_status_reason": reason,
+        "store_status_source": SOURCE_AUTO,
+        "store_status_checked_at": checked_at,
+        "first_detected_unavailable_at": prior_first_unavail,
+        "last_seen_available_at": prior_last_avail,
+    }
+
+
+def _ttl_for(status: Optional[str]) -> int:
+    return DEFINITIVE_TTL_SECONDS if status in (AVAILABLE, UNAVAILABLE) else UNKNOWN_TTL_SECONDS
+
+
+def _is_fresh(current: Optional[Dict[str, Any]], *, now: Optional[datetime] = None) -> bool:
+    if not current or not current.get("store_status_checked_at"):
+        return False
+    try:
+        checked = datetime.fromisoformat(str(current["store_status_checked_at"]))
+        if checked.tzinfo is None:
+            checked = checked.replace(tzinfo=timezone.utc)
+    except Exception:
+        return False
+    now = now or datetime.now(timezone.utc)
+    age = (now - checked).total_seconds()
+    return age < _ttl_for(current.get("store_status"))
+
+
+def public_status(current: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+    """The additive API-payload shape (never leaks source/internal columns)."""
+    cur = current or {}
+    return {
+        "status": cur.get("store_status") or UNKNOWN,
+        "reason": cur.get("store_status_reason"),
+        "checked_at": cur.get("store_status_checked_at"),
+        "first_detected_unavailable_at": cur.get("first_detected_unavailable_at"),
+    }
+
+
+def get_store_status_for_payload(db: Any, extension_id: str, *, allow_probe: bool = True) -> Dict[str, Any]:
+    """Cached, TTL-gated, fail-open resolver used by the result GET path.
+
+    Serves the cached status; refreshes with one bounded probe only when stale/
+    missing (and never for curated rows). NEVER raises — on any error it returns
+    the last known status, or "unknown" (which the gate renders normally).
+    """
+    if not extension_id:
+        return public_status(None)
+    try:
+        current = db.get_store_status(extension_id)
+    except Exception:
+        current = None
+
+    # Curated status is authoritative and needs no network probe.
+    if current and current.get("store_status_source") == SOURCE_CURATED:
+        return public_status(current)
+
+    if not allow_probe or _is_fresh(current):
+        return public_status(current)
+
+    try:
+        probe = probe_store_availability(extension_id)
+        resolved = resolve_store_status(current, probe)
+        if resolved is not None:
+            db.upsert_store_status(extension_id, **resolved)
+            current = db.get_store_status(extension_id) or {**(current or {}), **resolved}
+    except Exception as exc:
+        logger.debug("get_store_status_for_payload refresh failed for %s: %s", extension_id, exc)
+
+    return public_status(current)
+
+
+def set_curated_status(
+    db: Any,
+    extension_id: str,
+    status: str,
+    reason: Optional[str] = None,
+) -> bool:
+    """Human/admin curated status (CLI). Curated rows win over the auto probe.
+
+    Used to mark storefront policy-delistings (which have no automated signal)
+    as unavailable. Marking unavailable stamps first_detected_unavailable_at once.
+    """
+    status = (status or "").strip().lower()
+    if status not in (AVAILABLE, UNAVAILABLE, UNKNOWN):
+        raise ValueError(f"invalid status {status!r}; expected available|unavailable|unknown")
+    now = _now_iso()
+    try:
+        current = db.get_store_status(extension_id) or {}
+    except Exception:
+        current = {}
+    fields = {
+        "store_status": status,
+        "store_status_reason": reason if reason is not None else (
+            REASON_UNAVAILABLE if status == UNAVAILABLE else None
+        ),
+        "store_status_source": SOURCE_CURATED,
+        "store_status_checked_at": now,
+        "first_detected_unavailable_at": (
+            current.get("first_detected_unavailable_at") or now
+        ) if status == UNAVAILABLE else current.get("first_detected_unavailable_at"),
+        "last_seen_available_at": now if status == AVAILABLE else current.get("last_seen_available_at"),
+    }
+    return bool(db.upsert_store_status(extension_id, **fields))

--- a/tests/api/test_store_liveness.py
+++ b/tests/api/test_store_liveness.py
@@ -1,0 +1,251 @@
+"""Chrome Web Store liveness — mocked tests (no live network, no live Google endpoint).
+
+Covers the probe classification, the pure precedence resolver, durable persistence,
+curated precedence, the cached/fail-open payload resolver, and the additive API join.
+Store status must never mutate scores.
+"""
+from datetime import datetime, timezone, timedelta
+from unittest.mock import patch
+
+import pytest
+
+from extension_shield.api.database import Database
+from extension_shield.core import store_liveness as sl
+
+
+class _FakeResp:
+    def __init__(self, status_code):
+        self.status_code = status_code
+
+    def close(self):
+        pass
+
+
+def _iso(dt):
+    return dt.isoformat()
+
+
+# --------------------------------------------------------------------------- probe
+@pytest.mark.parametrize(
+    "status_code,expected",
+    # A 302 (artifact served) is UNKNOWN, never AVAILABLE — the auto probe can only
+    # DISPROVE availability (204/404), never confirm the storefront listing.
+    [(302, sl.UNKNOWN), (204, sl.UNAVAILABLE), (404, sl.UNAVAILABLE),
+     (200, sl.UNKNOWN), (429, sl.UNKNOWN), (500, sl.UNKNOWN)],
+)
+def test_probe_classifies_status_codes(status_code, expected):
+    with patch.object(sl, "safe_get", return_value=_FakeResp(status_code)) as m:
+        result = sl.probe_store_availability("bbnmecacdlabkdobimdkklpgmllebgip")
+    assert result["status"] == expected
+    # Never follows redirects / downloads the CRX body.
+    _, kwargs = m.call_args
+    assert kwargs.get("allow_redirects") is False
+    assert kwargs.get("stream") is True
+
+
+def test_probe_never_confirms_available_from_302():
+    """The auto probe must NEVER emit 'available' — a 302 only proves an artifact is
+    served (delisted-but-served extensions return 302 too)."""
+    with patch.object(sl, "safe_get", return_value=_FakeResp(302)):
+        result = sl.probe_store_availability("bbnmecacdlabkdobimdkklpgmllebgip")
+    assert result["status"] == sl.UNKNOWN
+    assert result["status"] != sl.AVAILABLE
+
+
+def test_probe_fail_open_on_network_error():
+    with patch.object(sl, "safe_get", side_effect=OSError("boom")):
+        result = sl.probe_store_availability("bbnmecacdlabkdobimdkklpgmllebgip")
+    assert result["status"] == sl.UNKNOWN  # never raises
+
+
+# ------------------------------------------------------------------- resolver rules
+def test_resolve_curated_never_overwritten_by_probe():
+    current = {"store_status": "unavailable", "store_status_source": sl.SOURCE_CURATED}
+    for probe_status in (sl.AVAILABLE, sl.UNAVAILABLE, sl.UNKNOWN):
+        out = sl.resolve_store_status(current, {"status": probe_status, "reason": "x", "checked_at": "t"})
+        assert out is None
+
+
+def test_resolve_unknown_never_overwrites_confirmed():
+    for confirmed in (sl.AVAILABLE, sl.UNAVAILABLE):
+        current = {"store_status": confirmed, "store_status_source": sl.SOURCE_AUTO}
+        out = sl.resolve_store_status(current, {"status": sl.UNKNOWN, "reason": "x", "checked_at": "t"})
+        assert out is None
+
+
+def test_resolve_unknown_writes_when_no_prior_confirmed():
+    out = sl.resolve_store_status(None, {"status": sl.UNKNOWN, "reason": "x", "checked_at": "t"})
+    assert out and out["store_status"] == sl.UNKNOWN
+
+
+def test_resolve_unavailable_sets_first_detected_once():
+    now = "2026-07-11T00:00:00+00:00"
+    first = sl.resolve_store_status(None, {"status": sl.UNAVAILABLE, "reason": "r", "checked_at": now}, now=now)
+    assert first["first_detected_unavailable_at"] == now
+    # A later unavailable probe must PRESERVE the original first-detected timestamp.
+    current = {"store_status": "unavailable", "store_status_source": "auto",
+               "first_detected_unavailable_at": now}
+    later = sl.resolve_store_status(current, {"status": sl.UNAVAILABLE, "reason": "r", "checked_at": "2026-08-01T00:00:00+00:00"})
+    assert later["first_detected_unavailable_at"] == now
+
+
+def test_resolve_available_updates_last_seen():
+    now = "2026-07-11T00:00:00+00:00"
+    out = sl.resolve_store_status(None, {"status": sl.AVAILABLE, "reason": "r", "checked_at": now}, now=now)
+    assert out["store_status"] == sl.AVAILABLE and out["last_seen_available_at"] == now
+
+
+# --------------------------------------------------------------------- persistence
+def test_db_roundtrip_and_keyed_by_extension_id(tmp_path):
+    db = Database(db_path=str(tmp_path / "liveness.db"))
+    ext = "bbnmecacdlabkdobimdkklpgmllebgip"
+    assert db.get_store_status(ext) is None
+    db.upsert_store_status(ext, store_status="unavailable", store_status_reason="r",
+                           store_status_source="auto", store_status_checked_at="t",
+                           first_detected_unavailable_at="t", last_seen_available_at=None)
+    row = db.get_store_status(ext)
+    assert row["extension_id"] == ext and row["store_status"] == "unavailable"
+    # Second upsert updates the SAME row (extension-level, not per-scan duplication).
+    db.upsert_store_status(ext, store_status="available", store_status_source="auto",
+                           store_status_checked_at="t2")
+    assert db.get_store_status(ext)["store_status"] == "available"
+
+
+def test_set_curated_status_wins_and_stamps_first_detected(tmp_path):
+    db = Database(db_path=str(tmp_path / "curated.db"))
+    ext = "ijickplbjolieoligpppakdmfdajmgij"
+    assert sl.set_curated_status(db, ext, "unavailable", reason="delisted") is True
+    row = db.get_store_status(ext)
+    assert row["store_status"] == "unavailable"
+    assert row["store_status_source"] == sl.SOURCE_CURATED
+    assert row["first_detected_unavailable_at"] is not None
+
+
+# --------------------------------------------------- cached / fail-open payload path
+def test_payload_curated_skips_probe(tmp_path):
+    db = Database(db_path=str(tmp_path / "c.db"))
+    ext = "ijickplbjolieoligpppakdmfdajmgij"
+    sl.set_curated_status(db, ext, "unavailable")
+    with patch.object(sl, "probe_store_availability", side_effect=AssertionError("must not probe")):
+        out = sl.get_store_status_for_payload(db, ext)
+    assert out["status"] == "unavailable"
+
+
+def test_payload_fresh_cache_skips_probe(tmp_path):
+    db = Database(db_path=str(tmp_path / "f.db"))
+    ext = "cjpalhdlnbpafiamejdnhcphjbkeiagm"
+    fresh = _iso(datetime.now(timezone.utc))
+    db.upsert_store_status(ext, store_status="available", store_status_source="auto",
+                           store_status_checked_at=fresh, last_seen_available_at=fresh)
+    with patch.object(sl, "probe_store_availability", side_effect=AssertionError("must not probe")):
+        out = sl.get_store_status_for_payload(db, ext)
+    assert out["status"] == "available"
+
+
+def test_payload_stale_triggers_probe_and_persists(tmp_path):
+    db = Database(db_path=str(tmp_path / "s.db"))
+    ext = "cjpalhdlnbpafiamejdnhcphjbkeiagm"
+    stale = _iso(datetime.now(timezone.utc) - timedelta(days=3))
+    db.upsert_store_status(ext, store_status="available", store_status_source="auto",
+                           store_status_checked_at=stale, last_seen_available_at=stale)
+    with patch.object(sl, "probe_store_availability",
+                      return_value={"status": sl.UNAVAILABLE, "reason": sl.REASON_UNAVAILABLE,
+                                    "checked_at": _iso(datetime.now(timezone.utc))}):
+        out = sl.get_store_status_for_payload(db, ext)
+    assert out["status"] == "unavailable"
+    assert db.get_store_status(ext)["store_status"] == "unavailable"
+
+
+def test_payload_probe_error_fails_open(tmp_path):
+    db = Database(db_path=str(tmp_path / "e.db"))
+    ext = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    with patch.object(sl, "probe_store_availability", side_effect=RuntimeError("google down")):
+        out = sl.get_store_status_for_payload(db, ext)  # must not raise
+    assert out["status"] == "unknown"
+
+
+def test_public_status_hides_internal_source():
+    row = {"store_status": "unavailable", "store_status_reason": "r",
+           "store_status_source": "curated", "store_status_checked_at": "t",
+           "first_detected_unavailable_at": "t"}
+    pub = sl.public_status(row)
+    assert set(pub.keys()) == {"status", "reason", "checked_at", "first_detected_unavailable_at"}
+    assert "store_status_source" not in pub
+
+
+# ------------------------------------------------------- API join does not touch scores
+def test_attach_store_status_is_additive_and_score_safe(tmp_path):
+    import extension_shield.api.main as main
+    db = Database(db_path=str(tmp_path / "join.db"))
+    ext = "bbnmecacdlabkdobimdkklpgmllebgip"
+    sl.set_curated_status(db, ext, "unavailable", reason="delisted")
+    payload = {"extension_id": ext, "scoring_v2": {"overall_score": 94, "security_score": 92},
+               "security_score": 94}
+    with patch.object(main, "db", db):
+        main._attach_store_status(payload)
+    assert payload["store_status"]["status"] == "unavailable"
+    # Historical scores are untouched by the availability join.
+    assert payload["scoring_v2"] == {"overall_score": 94, "security_score": 92}
+    assert payload["security_score"] == 94
+
+
+# ------------------------------------------------ addendum: 302=unknown + view gating
+def test_payload_302_yields_unknown_never_available(tmp_path):
+    """A 302 probe (artifact served) leaves effective status UNKNOWN, never available;
+    the normal report renders only because unknown fails open."""
+    db = Database(db_path=str(tmp_path / "u.db"))
+    ext = "cjpalhdlnbpafiamejdnhcphjbkeiagm"
+    with patch.object(sl, "safe_get", return_value=_FakeResp(302)):
+        out = sl.get_store_status_for_payload(db, ext)
+    assert out["status"] == "unknown"
+    assert out["status"] != "available"
+    # Nothing durable claims availability from a 302.
+    row = db.get_store_status(ext)
+    assert (row or {}).get("store_status") != "available"
+
+
+def test_curated_unavailable_wins_over_later_302(tmp_path):
+    """Curated 'unavailable' must not be flipped by a later automatic 302 (which is
+    only 'artifact served'). Curated short-circuits the probe entirely."""
+    db = Database(db_path=str(tmp_path / "w.db"))
+    ext = "bbnmecacdlabkdobimdkklpgmllebgip"
+    sl.set_curated_status(db, ext, "unavailable", reason="delisted")
+    with patch.object(sl, "safe_get", return_value=_FakeResp(302)):
+        out = sl.get_store_status_for_payload(db, ext)
+    assert out["status"] == "unavailable"
+    assert db.get_store_status(ext)["store_status_source"] == "curated"
+
+
+def test_attach_gates_already_scanned_removed_without_probe_or_rescan(tmp_path):
+    """An already-scanned (completed) cached result that is curated-unavailable gates
+    to unavailable on VIEW, with no probe/network/rescan and no score mutation."""
+    import extension_shield.api.main as main
+    db = Database(db_path=str(tmp_path / "g.db"))
+    ext = "bbnmecacdlabkdobimdkklpgmllebgip"
+    sl.set_curated_status(db, ext, "unavailable", reason="delisted")
+    payload = {"extension_id": ext, "status": "completed",
+               "scoring_v2": {"overall_score": 94}, "overall_security_score": 94}
+    # If the view path tried to probe (network) or rescan, this would raise.
+    with patch.object(main, "db", db), \
+         patch.object(sl, "probe_store_availability", side_effect=AssertionError("no probe")):
+        main._attach_store_status(payload)
+    assert payload["store_status"]["status"] == "unavailable"
+    assert payload["scoring_v2"] == {"overall_score": 94}      # scores unmutated
+    assert payload["overall_security_score"] == 94
+
+
+def test_attach_is_independent_of_scan_timestamp(tmp_path):
+    """Result-view gating does not depend on the scan's freshness/timestamp: a
+    pre-cutoff and a post-cutoff payload both receive the same effective store_status."""
+    import extension_shield.api.main as main
+    db = Database(db_path=str(tmp_path / "t.db"))
+    ext = "ijickplbjolieoligpppakdmfdajmgij"
+    sl.set_curated_status(db, ext, "unavailable")
+    old = {"extension_id": ext, "timestamp": "2020-01-01T00:00:00+00:00"}
+    new = {"extension_id": ext, "timestamp": "2026-12-31T00:00:00+00:00"}
+    with patch.object(main, "db", db), \
+         patch.object(sl, "probe_store_availability", side_effect=AssertionError("no probe")):
+        main._attach_store_status(old)
+        main._attach_store_status(new)
+    assert old["store_status"]["status"] == "unavailable"
+    assert new["store_status"]["status"] == old["store_status"]["status"]


### PR DESCRIPTION
- Add extension-level store availability status (extension_store_status), keyed by extension_id
- Treat update-endpoint 204/404 as unavailable; 302 (served CRX) as unknown, never confirmed available
- Add store-status CLI (set/get/probe) for curated storefront delistings
- Attach additive store_status to result GET responses; reuse the existing unavailable page for extensions with a historical scan
- Preserve historical scores; never trigger rescans or touch scoring
- Add mocked backend and frontend tests