### PR TITLE
fix(docker): give appuser a writable HOME so Semgrep runs in production

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -85,17 +85,23 @@ ENV PATH="/app/.venv/bin:$PATH"
 # Copy frontend build from stage 1
 COPY --from=frontend-builder /app/frontend/dist ./static
 
-# Create necessary directories and non-root user
-RUN mkdir -p extensions_storage data && \
+# Create necessary directories and non-root user.
+# appuser needs a real, writable HOME: Semgrep (SAST) writes its settings to
+# ~/.semgrep on startup, and a system user's default /nonexistent home makes
+# `semgrep --version` crash — which silently disables SAST in production.
+RUN mkdir -p extensions_storage data /home/appuser && \
     addgroup --system appgroup && \
-    adduser --system --ingroup appgroup appuser && \
-    chown -R appuser:appgroup /app
+    adduser --system --home /home/appuser --ingroup appgroup appuser && \
+    chown -R appuser:appgroup /app /home/appuser
 
 # Drop root privileges
 USER appuser
 
-# Set default environment variables
-ENV EXTENSION_STORAGE_PATH=/app/extensions_storage \
+# Set default environment variables.
+# HOME is set explicitly (belt-and-suspenders with adduser --home above) so
+# Semgrep and any other tool that relies on $HOME always has a writable dir.
+ENV HOME=/home/appuser \
+    EXTENSION_STORAGE_PATH=/app/extensions_storage \
     DATABASE_PATH=/app/data/extension-shield.db \
     LLM_PROVIDER=openai
 


### PR DESCRIPTION
## Problem
Production scans were capped at 65 (insufficient-data): SAST never ran. Root cause is the container's `appuser` having `HOME=/nonexistent` (created via `adduser --system` with no home). Semgrep writes `~/.semgrep` on startup, so `semgrep --version` exited 1 and SAST was silently skipped. Local scans worked because they run as a normal user with a real HOME.

Production log (deploy 91dc09d):
`Semgrep executable check failed for /app/.venv/bin/semgrep: ... returned non-zero exit status 1`

## Fix
Create `appuser` with `--home /home/appuser`, chown it, and set `ENV HOME` explicitly.

## Verification
Reproduced in a `python:3.11-slim` container running as `appuser`:
- old setup → exit 1 (`FileNotFoundError: '/nonexistent/.semgrep'`)
- fixed setup → exit 0 (`semgrep 1.150.0`)

Also confirmed live in the prod container and against local semgrep 1.150.0. Dockerfile-only change; no scoring/pipeline logic touched.