### PR TITLE
Fix: download large Chrome extensions (over 25MB were failing)

### DIFF
--- a/src/extension_shield/core/extension_downloader.py
+++ b/src/extension_shield/core/extension_downloader.py
@@ -76,16 +76,19 @@ class ExtensionDownloader:
             file_path = os.path.join(self.extension_storage_path, filename)
             os.makedirs(self.extension_storage_path, exist_ok=True)
 
-            # Download the file (SSRF protection: only allow clients2.google.com)
-            # Chrome-like headers are required; Google returns HTML/204 without them
+            # Only allow clients2.google.com (SSRF). Chrome-like headers avoid HTML/204.
+            # Extensions can be large (AdBlock is ~75MB), so raise the default 25MB
+            # limit. Change it with MAX_CRX_BYTES.
             ALLOWED_HOSTS = {"clients2.google.com"}
             headers = {"User-Agent": ExtensionDownloader.CHROME_USER_AGENT}
+            max_crx_bytes = int(os.getenv("MAX_CRX_BYTES", str(200 * 1024 * 1024)))  # 200MB
             response = safe_get(
                 download_url,
                 allowed_hosts=ALLOWED_HOSTS,
                 stream=True,
                 timeout=120,
                 headers=headers,
+                max_bytes=max_crx_bytes,
             )
             response.raise_for_status()
 
@@ -106,10 +109,29 @@ class ExtensionDownloader:
                 if not any(t in content_type for t in allowed_types):
                     logger.warning("Unexpected content type: %s", content_type)
 
-            # Save the file
+            # Save the file, and stop if it goes over the limit while streaming
+            # (the Content-Length header is not always present).
+            written = 0
+            oversized = False
             with open(file_path, "wb") as f:
                 for chunk in response.iter_content(chunk_size=8192):
+                    if not chunk:
+                        continue
+                    written += len(chunk)
+                    if written > max_crx_bytes:
+                        oversized = True
+                        break
                     f.write(chunk)
+
+            if oversized:
+                # Discard the truncated file so it is never treated as a valid CRX.
+                logger.error(
+                    "Download exceeded max size (%s bytes) for %s; discarding.",
+                    max_crx_bytes, extension_id,
+                )
+                if os.path.exists(file_path):
+                    os.remove(file_path)
+                return None
 
             file_size = os.path.getsize(file_path)
             logger.info("Downloaded %s to %s (%s bytes)", extension_id, file_path, file_size)

--- a/src/extension_shield/utils/http_safety.py
+++ b/src/extension_shield/utils/http_safety.py
@@ -190,12 +190,15 @@ def safe_get(
         if content_length:
             try:
                 size = int(content_length)
+            except (TypeError, ValueError):
+                # Bad Content-Length header: warn and let it through.
+                logger.warning("Invalid Content-Length header: %s", content_length)
+            else:
+                # Check the size here, not inside the try above, so this error
+                # is not caught by the except and lost.
                 if size > max_bytes:
                     response.close()
                     raise ValueError(f"Response too large: {size} bytes (max: {max_bytes})")
-            except ValueError:
-                # Invalid Content-Length, allow but warn
-                logger.warning("Invalid Content-Length header: %s", content_length)
     else:
         # For non-streaming, check content size
         if len(response.content) > max_bytes:

--- a/tests/test_safe_get_size_limit.py
+++ b/tests/test_safe_get_size_limit.py
@@ -1,0 +1,80 @@
+"""Regression tests for the CRX-download size bug.
+
+`safe_get` previously raised its "Response too large" ValueError *inside* the same
+try block whose `except ValueError` was meant only for a bad Content-Length header,
+so the size guard was silently swallowed — after `response.close()` had already run.
+Callers streaming the (now-closed) response wrote 0 bytes, surfacing as
+"Extension download returned no file" for any extension over the 25MB default cap
+(e.g. AdBlock ~75MB).
+"""
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from extension_shield.utils import http_safety
+
+
+def _resp(content_length):
+    r = MagicMock()
+    r.headers = {} if content_length is None else {"Content-Length": str(content_length)}
+    r.close = MagicMock()
+    return r
+
+
+@patch.object(http_safety, "validate_outbound_url", lambda *a, **k: None)
+@patch.object(http_safety.requests, "get")
+def test_oversized_stream_raises_cleanly(mock_get):
+    resp = _resp(50 * 1024 * 1024)  # 50MB > 25MB cap
+    mock_get.return_value = resp
+    with pytest.raises(ValueError, match="Response too large"):
+        http_safety.safe_get(
+            "https://clients2.google.com/x",
+            allowed_hosts={"clients2.google.com"},
+            stream=True,
+            max_bytes=25 * 1024 * 1024,
+        )
+    resp.close.assert_called_once()  # closed, but the error propagates (not swallowed)
+
+
+@patch.object(http_safety, "validate_outbound_url", lambda *a, **k: None)
+@patch.object(http_safety.requests, "get")
+def test_under_cap_returns_response(mock_get):
+    resp = _resp(1 * 1024 * 1024)  # 1MB < cap
+    mock_get.return_value = resp
+    got = http_safety.safe_get(
+        "https://clients2.google.com/x",
+        allowed_hosts={"clients2.google.com"},
+        stream=True,
+        max_bytes=25 * 1024 * 1024,
+    )
+    assert got is resp
+    resp.close.assert_not_called()
+
+
+@patch.object(http_safety, "validate_outbound_url", lambda *a, **k: None)
+@patch.object(http_safety.requests, "get")
+def test_large_cap_allows_75mb(mock_get):
+    """With a CRX-appropriate cap (like the downloader now passes), 75MB is allowed."""
+    resp = _resp(75 * 1024 * 1024)
+    mock_get.return_value = resp
+    got = http_safety.safe_get(
+        "https://clients2.google.com/x",
+        allowed_hosts={"clients2.google.com"},
+        stream=True,
+        max_bytes=200 * 1024 * 1024,
+    )
+    assert got is resp
+
+
+@patch.object(http_safety, "validate_outbound_url", lambda *a, **k: None)
+@patch.object(http_safety.requests, "get")
+def test_invalid_content_length_does_not_raise(mock_get):
+    resp = _resp("not-a-number")
+    mock_get.return_value = resp
+    got = http_safety.safe_get(
+        "https://clients2.google.com/x",
+        allowed_hosts={"clients2.google.com"},
+        stream=True,
+        max_bytes=25 * 1024 * 1024,
+    )
+    assert got is resp  # warns, does not raise, does not close


### PR DESCRIPTION
## What
Large Chrome extensions failed to scan with "Extension download returned no file". AdBlock (75MB) was one example — the report showed a download error instead of a real result.

## Why
`safe_get` limits responses to 25MB. When a file was bigger, it raised a "too large" error, but that error was raised inside a try block whose `except` caught it. The response got closed, so the caller streamed 0 bytes and treated it as a failed download.

## What changed
- Move the size check out of the parse try/except so the error is no longer swallowed.
- Raise the download limit for extensions to 200MB (set with `MAX_CRX_BYTES`).
- If a download does go over the limit, stop and delete the partial file instead of keeping a broken one.

## Testing
- AdBlock now downloads the full 75MB (was 0 bytes) and extracts fine (442 files, 327MB).
- New unit tests for the size limit pass.
- A genuinely oversized download now fails cleanly and shows a partial report, not a crash.

Note: this only changes the download path. Small extensions were never affected.