### PR TITLE
Anonymous users wait 3 minutes between scans

### DIFF
--- a/src/extension_shield/api/main.py
+++ b/src/extension_shield/api/main.py
@@ -421,6 +421,9 @@ _health_start_time = datetime.now(timezone.utc)
 # -----------------------------------------------------------------------------
 DAILY_DEEP_SCAN_LIMIT = 3  # authenticated users
 ANONYMOUS_DAILY_DEEP_SCAN_LIMIT = 1  # anonymous (IP-based) users – after 1 scan, prompt login
+# Seconds an anonymous (IP-based) user must wait between scans. 0 turns it off.
+# Signed-in users are not affected. Change with ANONYMOUS_SCAN_COOLDOWN_SECONDS.
+ANONYMOUS_SCAN_COOLDOWN_SECONDS = int(os.getenv("ANONYMOUS_SCAN_COOLDOWN_SECONDS", "180"))  # 3 min
 
 # -----------------------------------------------------------------------------
 # Scan freshness cutoff
@@ -436,6 +439,8 @@ ANONYMOUS_DAILY_DEEP_SCAN_LIMIT = 1  # anonymous (IP-based) users – after 1 sc
 _DEFAULT_SCAN_FRESHNESS_CUTOFF = "2026-07-08T01:37:14+00:00"  # #257 ship instant (UTC)
 # deep_scan_usage[user_id][YYYY-MM-DD] = used_count
 deep_scan_usage: Dict[str, Dict[str, int]] = {}
+# Last scan time per IP, used for the anonymous cooldown. Kept in memory per worker.
+_last_deep_scan_at: Dict[str, datetime] = {}
 # Lock to prevent race conditions when multiple concurrent requests check/increment the same counter
 import threading as _threading
 _deep_scan_usage_lock = _threading.Lock()
@@ -556,6 +561,23 @@ def _require_admin_or_telemetry_key(request: Request) -> None:
             status_code=403,
             detail="Invalid admin API key"
         )
+
+
+def _anon_scan_cooldown_remaining(rate_limit_key: str) -> int:
+    """Seconds an anonymous (IP-based) user must still wait before another deep scan.
+
+    Returns 0 when the cooldown is disabled, for authenticated users, in dev, or
+    when enough time has elapsed. Authenticated users are exempt.
+    """
+    if ANONYMOUS_SCAN_COOLDOWN_SECONDS <= 0 or not rate_limit_key.startswith("ip:"):
+        return 0
+    if not get_settings().is_prod():
+        return 0
+    last = _last_deep_scan_at.get(rate_limit_key)
+    if not last:
+        return 0
+    elapsed = (datetime.now(timezone.utc) - last).total_seconds()
+    return max(0, int(ANONYMOUS_SCAN_COOLDOWN_SECONDS - elapsed))
 
 
 def _deep_scan_limit_status(rate_limit_key: str) -> Dict[str, Any]:
@@ -2678,6 +2700,19 @@ async def trigger_scan(scan_request: ScanRequest, background_tasks: BackgroundTa
         after_consume = _deep_scan_limit_status(rate_limit_key)
     else:
         if settings.is_prod():
+            # Anonymous per-IP cooldown: a fresh deep scan must be spaced out.
+            cooldown_left = _anon_scan_cooldown_remaining(rate_limit_key)
+            if cooldown_left > 0:
+                raise HTTPException(
+                    status_code=429,
+                    detail={
+                        "error_code": "SCAN_COOLDOWN",
+                        "message": f"Please wait {cooldown_left}s before scanning another extension. Sign in to remove the wait.",
+                        "is_anonymous": True,
+                        "requires_login": True,
+                        "retry_after_seconds": cooldown_left,
+                    },
+                )
             limit_status = _deep_scan_limit_status(rate_limit_key)
             if limit_status["remaining"] <= 0:
                 limit_num = limit_status.get("limit", 1)
@@ -2695,6 +2730,9 @@ async def trigger_scan(scan_request: ScanRequest, background_tasks: BackgroundTa
 
         # Consume one deep scan since we are starting a new analysis run
         after_consume = _consume_deep_scan(rate_limit_key)
+        # Start the anonymous cooldown clock from this scan.
+        if is_anonymous:
+            _last_deep_scan_at[rate_limit_key] = datetime.now(timezone.utc)
 
     # Start background analysis
     scan_user_ids[extension_id] = getattr(getattr(request, "state", None), "user_id", None)

--- a/tests/api/test_anon_scan_cooldown.py
+++ b/tests/api/test_anon_scan_cooldown.py
@@ -1,0 +1,56 @@
+"""Anonymous per-IP deep-scan cooldown (3 minutes by default)."""
+import importlib
+from datetime import datetime, timezone, timedelta
+
+import pytest
+
+main = importlib.import_module("extension_shield.api.main")
+
+
+class _ProdSettings:
+    def is_prod(self):
+        return True
+
+
+@pytest.fixture(autouse=True)
+def _prod_and_clean(monkeypatch):
+    monkeypatch.setattr(main, "get_settings", lambda: _ProdSettings())
+    monkeypatch.setattr(main, "ANONYMOUS_SCAN_COOLDOWN_SECONDS", 180)
+    main._last_deep_scan_at.clear()
+    yield
+    main._last_deep_scan_at.clear()
+
+
+def test_cooldown_active_returns_remaining():
+    main._last_deep_scan_at["ip:1.2.3.4"] = datetime.now(timezone.utc) - timedelta(seconds=60)
+    r = main._anon_scan_cooldown_remaining("ip:1.2.3.4")
+    assert 115 <= r <= 120  # ~120s left of a 180s window
+
+
+def test_authenticated_users_are_exempt():
+    main._last_deep_scan_at["user-abc"] = datetime.now(timezone.utc)
+    assert main._anon_scan_cooldown_remaining("user-abc") == 0  # not an ip: key
+
+
+def test_no_prior_scan_no_cooldown():
+    assert main._anon_scan_cooldown_remaining("ip:9.9.9.9") == 0
+
+
+def test_elapsed_past_window_no_cooldown():
+    main._last_deep_scan_at["ip:1.1.1.1"] = datetime.now(timezone.utc) - timedelta(seconds=200)
+    assert main._anon_scan_cooldown_remaining("ip:1.1.1.1") == 0
+
+
+def test_disabled_when_zero(monkeypatch):
+    monkeypatch.setattr(main, "ANONYMOUS_SCAN_COOLDOWN_SECONDS", 0)
+    main._last_deep_scan_at["ip:1.1.1.1"] = datetime.now(timezone.utc)
+    assert main._anon_scan_cooldown_remaining("ip:1.1.1.1") == 0
+
+
+def test_dev_has_no_cooldown(monkeypatch):
+    class _Dev:
+        def is_prod(self):
+            return False
+    monkeypatch.setattr(main, "get_settings", lambda: _Dev())
+    main._last_deep_scan_at["ip:1.1.1.1"] = datetime.now(timezone.utc)
+    assert main._anon_scan_cooldown_remaining("ip:1.1.1.1") == 0


### PR DESCRIPTION
## What
Anonymous (not signed-in) users now have to wait 3 minutes before they can start another scan.

## Why
We want to space out anonymous scanning without blocking them for the whole day.

## How
- New per-IP cooldown, default 180 seconds. Change it with `ANONYMOUS_SCAN_COOLDOWN_SECONDS` (set to 0 to turn it off).
- Signed-in users are not affected. No cooldown in dev.
- If someone scans too soon they get a 429 with the number of seconds left, so the front end can show a timer.

## One thing to decide
The anonymous daily limit is still 1 scan per day (`ANONYMOUS_DAILY_DEEP_SCAN_LIMIT = 1`). While that is 1, the daily limit stops the second scan before the 3-minute wait ever applies. To let anonymous users scan again every 3 minutes, raise that number.

## Testing
New unit tests cover: cooldown active, signed-in users skipped, no cooldown after the wait, disabled when set to 0, and no cooldown in dev. All pass.