### PR TITLE
perf(scan): faster /scan list load, no more N+1

### DIFF
--- a/frontend/src/pages/scanner/ScannerPage.jsx
+++ b/frontend/src/pages/scanner/ScannerPage.jsx
@@ -217,13 +217,12 @@ const ScannerPage = () => {
         setAllScans([]);
         return;
       }
-      const enrichedScans = await enrichScans(history, { skipFullFetch: false });
-      if (enrichedScans.length > 0) {
-        setAllScans(enrichedScans);
-      } else {
-        const fallbackScans = await enrichScans(history, { skipFullFetch: false });
-        setAllScans(fallbackScans.length > 0 ? fallbackScans : []);
-      }
+      // /api/recent already returns everything the list needs (metadata, scoring_v2,
+      // report_view_model, governance_bundle, risk_and_signals), so skip the per-row
+      // /api/scan/results fetch — that N+1 shipped ~10 extra full-payload requests
+      // (each with a live Chrome Web Store probe) on every load and every poll tick.
+      const enrichedScans = await enrichScans(history, { skipFullFetch: true });
+      setAllScans(enrichedScans);
     } catch (err) {
       setAllScans([]);
       setLoadError(err?.message || "Failed to load recent scans");

--- a/src/extension_shield/api/database.py
+++ b/src/extension_shield/api/database.py
@@ -1627,7 +1627,12 @@ class SupabaseDatabase:
         When search is provided, results are ranked by relevance: exact title first, then title starts with, then title contains, then ID; then by recency.
         When include_all=True, returns all completed scans regardless of visibility/source (for QA export).
         """
-        select_cols = "extension_id, extension_name, url, slug, scanned_at, created_at, updated_at, security_score, risk_level, total_findings, total_files, high_risk_count, medium_risk_count, low_risk_count, metadata, webstore_analysis, sast_results, permissions_analysis, manifest, summary, icon_base64, icon_media_type"
+        # Note: icon_base64 is intentionally NOT selected — the list view loads icons via
+        # /api/scan/icon/{id}, so pulling the (often ~25KB) base64 blob per row just to drop
+        # it from the response wastes Supabase→app bandwidth. `summary` is still selected
+        # because scoring_v2/report_view_model/governance_bundle are promoted out of it below;
+        # the /api/recent handler strips the raw `summary` from the wire response.
+        select_cols = "extension_id, extension_name, url, slug, scanned_at, created_at, updated_at, security_score, risk_level, total_findings, total_files, high_risk_count, medium_risk_count, low_risk_count, metadata, webstore_analysis, sast_results, permissions_analysis, manifest, summary, icon_media_type"
         try:
             # When searching, fetch more candidates so we can rank by relevance then trim to limit
             limit_fetch = min(200, limit * 15) if (search and search.strip()) else limit

--- a/src/extension_shield/api/main.py
+++ b/src/extension_shield/api/main.py
@@ -3700,6 +3700,17 @@ async def get_recent_scans(limit: int = 10, search: str = None):
                 # Continue processing other scans even if one fails
                 scan["risk_and_signals"] = {"risk": 0, "signals": {}}
 
+        # Slim the list payload before returning. The scan-list view derives its badges
+        # and findings from the top-level scoring_v2 / report_view_model / governance_bundle
+        # / risk_and_signals (promoted/computed above), so the raw `summary` JSONB blob
+        # (~100KB/row) and the inline base64 icon (~25KB/row) are dead weight on the wire —
+        # the icon is served separately via /api/scan/icon/{id}. Dropping them turns a
+        # multi-MB, 10-row response into a fraction of the size without changing what renders.
+        for scan in recent:
+            if isinstance(scan, dict):
+                scan.pop("summary", None)
+                scan.pop("icon_base64", None)
+
         logger.info(f"[get_recent_scans] Returning {len(recent)} enriched scans")
         return {"recent": recent, "db_backend": db_backend}
     except Exception as e:


### PR DESCRIPTION
The /scan list made ~11 requests per load — a 2.5MB /api/recent plus a full re-fetch of every row — and repeated it every 10s, which was slow and kept tripping the 10s client timeout into the load error.

Now it makes one lean request:
- skip the per-row /api/scan/results fetch (the recent payload already has metadata, scoring_v2, report_view_model and governance_bundle)
- strip the raw summary blob and inline base64 icons from /api/recent (icons load via /api/scan/icon)

Table renders identically (names, ratings, risk, signals, findings). Verified locally. Does not touch the Scan History orphan issue or OpenAI credits.