### PR TITLE
fix(scan): VirusTotal concurrency + rescan orphaned/failed history rows

### DIFF
--- a/frontend/src/pages/ScanHistoryPage.jsx
+++ b/frontend/src/pages/ScanHistoryPage.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { useAuth } from "../context/AuthContext";
 import databaseService from "../services/databaseService";
+import realScanService from "../services/realScanService";
 import {
   getSignalColorClass,
   getSignalDisplayLabel,
@@ -129,6 +130,52 @@ const formatTimeAgo = (timestamp) => {
   return scanTime.toLocaleDateString();
 };
 
+// Shown for history rows whose scan is missing (orphaned by a DB reset) or
+// failed — those get a fresh scan kicked off instead of a misleading verdict.
+const RescanPill = () => (
+  <span
+    className="rescan-pill"
+    title="This scan is missing or incomplete and is being re-run"
+    style={{
+      display: "inline-flex",
+      alignItems: "center",
+      padding: "2px 10px",
+      borderRadius: 999,
+      fontSize: 12,
+      fontWeight: 600,
+      color: "#7a5b00",
+      background: "#fff4d6",
+      border: "1px solid #f0d488",
+      whiteSpace: "nowrap",
+    }}
+  >
+    Rescanning…
+  </span>
+);
+
+// Shown for rows that can't be re-fetched from the store (e.g. uploaded/private
+// builds whose scan was lost) — a neutral state instead of a misleading verdict.
+const UnavailablePill = () => (
+  <span
+    className="unavailable-pill"
+    title="This scan isn't available and can't be re-fetched from the Chrome Web Store"
+    style={{
+      display: "inline-flex",
+      alignItems: "center",
+      padding: "2px 10px",
+      borderRadius: 999,
+      fontSize: 12,
+      fontWeight: 600,
+      color: "#555",
+      background: "#ececec",
+      border: "1px solid #ccc",
+      whiteSpace: "nowrap",
+    }}
+  >
+    Unavailable
+  </span>
+);
+
 const ScanHistoryPage = () => {
   const [allScans, setAllScans] = useState([]);
   const [loading, setLoading] = useState(true);
@@ -139,6 +186,7 @@ const ScanHistoryPage = () => {
   const [rowsPerPage, setRowsPerPage] = useState(25);
   const [hoveredRow, setHoveredRow] = useState(null);
   const tableWrapperRef = useRef(null);
+  const rescanTriggeredRef = useRef(new Set()); // ext ids we've kicked a rescan for this session
   const navigate = useNavigate();
   const { isAuthenticated, openSignInModal, accessToken } = useAuth();
 
@@ -201,6 +249,46 @@ const ScanHistoryPage = () => {
       isMounted = false;
     };
   }, [accessToken, canLoadHistory, debouncedSearch, isAuthenticated]);
+
+  // Issue 2: kick off bounded rescans for orphaned/failed history rows so they
+  // resolve to real reports instead of a stale/missing verdict. Capped and
+  // de-duped per session; the backend adds its own concurrency + VirusTotal-quota
+  // guards, so this cannot become a rescan storm.
+  useEffect(() => {
+    const MAX_PER_LOAD = 8;
+    const CONCURRENCY = 2;
+    const isStoreId = (id) => /^[a-p]{32}$/.test(id || ""); // only CWS ids are rescannable from a store URL
+    const queue = allScans
+      .filter((s) => s?.needs_rescan && isStoreId(s.extension_id) && !rescanTriggeredRef.current.has(s.extension_id))
+      .slice(0, MAX_PER_LOAD);
+    if (queue.length === 0) return;
+
+    let cancelled = false;
+    const worker = async () => {
+      while (!cancelled && queue.length) {
+        const scan = queue.shift();
+        if (!scan || rescanTriggeredRef.current.has(scan.extension_id)) continue;
+        // Mark right before firing (not the whole batch up front) so ids a
+        // cancelled run never reached stay eligible on the next load.
+        rescanTriggeredRef.current.add(scan.extension_id);
+        try {
+          await realScanService.triggerScan(
+            `https://chromewebstore.google.com/detail/_/${scan.extension_id}`,
+            { historyRefresh: true }
+          );
+        } catch {
+          // Leave it marked: a rate-limit/backpressure failure must not re-fire
+          // on every history reload (e.g. each search keystroke). A fresh session
+          // (component remount) resets the ref and retries.
+        }
+      }
+    };
+    for (let i = 0; i < Math.min(CONCURRENCY, queue.length); i += 1) worker();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [allScans]);
 
   useEffect(() => {
     const tableWrapper = tableWrapperRef.current;
@@ -516,19 +604,31 @@ const ScanHistoryPage = () => {
                               )}
                             </td>
                             <td>
-                              <RiskVerdictBadge level={scan.risk_level} score={scan.score} decision={resolveScanVerdict(scan)} />
+                              {scan.needs_rescan ? (
+                                <RescanPill />
+                              ) : scan.unavailable ? (
+                                <UnavailablePill />
+                              ) : (
+                                <RiskVerdictBadge level={scan.risk_level} score={scan.score} decision={resolveScanVerdict(scan)} />
+                              )}
                             </td>
                             <td className="signals-cell">
-                              <div className="signals-container">
-                                <SignalChip type="security" signal={scan.signals?.security_signal} />
-                                <SignalChip type="privacy" signal={scan.signals?.privacy_signal} />
-                                <SignalChip type="governance" signal={scan.signals?.governance_signal} />
-                              </div>
+                              {scan.needs_rescan || scan.unavailable ? (
+                                <span className="no-data">{scan.needs_rescan ? "Pending rescan" : "—"}</span>
+                              ) : (
+                                <div className="signals-container">
+                                  <SignalChip type="security" signal={scan.signals?.security_signal} />
+                                  <SignalChip type="privacy" signal={scan.signals?.privacy_signal} />
+                                  <SignalChip type="governance" signal={scan.signals?.governance_signal} />
+                                </div>
+                              )}
                             </td>
                             <td className="evidence-cell">
                               <div className="evidence-container">
                                 <span className="findings-count">
-                                  {scan.findings_count || 0} finding{scan.findings_count !== 1 ? "s" : ""}
+                                  {scan.needs_rescan || scan.unavailable
+                                    ? "—"
+                                    : `${scan.findings_count || 0} finding${scan.findings_count !== 1 ? "s" : ""}`}
                                 </span>
                                 <button
                                   className="view-report-btn"

--- a/frontend/src/pages/scanner/ScanResultsPageV2.jsx
+++ b/frontend/src/pages/scanner/ScanResultsPageV2.jsx
@@ -203,6 +203,7 @@ const ScanResultsPageV2 = () => {
     () => typeof window === "undefined" || window.innerWidth > 768
   );
   const [expandedFinding, setExpandedFinding] = useState(null);
+  const [rescanStarted, setRescanStarted] = useState(false);
   const publisherDetailsRef = useRef(null);
 
   useEffect(() => {
@@ -304,6 +305,19 @@ const ScanResultsPageV2 = () => {
 
   const getFileContent = async (extensionId, filePath) => {
     return await realScanService.getFileContent(extensionId, filePath);
+  };
+
+  // Re-run a failed/partial scan (Issue 2). Uses the canonical store URL so the
+  // backend re-attempts the download+analysis instead of re-serving the partial row.
+  const handleRescanPartial = async () => {
+    const id = viewModel?.meta?.extensionId || scanId;
+    if (!id || !/^[a-p]{32}$/.test(id)) return; // only Chrome Web Store extensions can be re-fetched
+    setRescanStarted(true);
+    try {
+      await realScanService.triggerScan(`https://chromewebstore.google.com/detail/_/${id}`, { historyRefresh: true });
+    } catch {
+      // Best-effort; the banner already tells the user a rescan was started.
+    }
   };
 
   const openEvidenceDrawer = (evidenceIds) => {
@@ -785,7 +799,19 @@ const ScanResultsPageV2 = () => {
           ? "Partial report: We couldn't download the extension package. Scores and limited findings below are based on available data (e.g. store listing)."
           : `Partial report: ${err}. Scores and limited findings below are based on available data (e.g. manifest, webstore).`;
         return (
-          <StatusMessage type="info" message={bannerMessage} />
+          <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+            <StatusMessage type="info" message={bannerMessage} />
+            {rescanStarted ? (
+              <StatusMessage
+                type="info"
+                message="Rescan started — this report will update once the fresh scan completes. Check back in a minute."
+              />
+            ) : /^[a-p]{32}$/.test(viewModel?.meta?.extensionId || scanId || "") ? (
+              <Button variant="outline" onClick={handleRescanPartial} style={{ alignSelf: "flex-start" }}>
+                Rescan now
+              </Button>
+            ) : null}
+          </div>
         );
       })()}
 

--- a/frontend/src/services/realScanService.js
+++ b/frontend/src/services/realScanService.js
@@ -108,7 +108,7 @@ class RealScanService {
   // Trigger a scan for an extension URL. Pass { force: true } to bypass the cached
   // fast path and force a fresh deep scan — server-gated: honored only in dev or
   // when the admin rescan token matches RESCAN_ADMIN_TOKEN, ignored otherwise.
-  async triggerScan(url, { force = false } = {}) {
+  async triggerScan(url, { force = false, historyRefresh = false } = {}) {
     const headers = {
       "Content-Type": "application/json",
       ...this.getRequestHeaders(),
@@ -116,10 +116,14 @@ class RealScanService {
     const adminToken = force ? this.getAdminRescanToken() : "";
     if (adminToken) headers["X-Admin-Rescan-Token"] = adminToken;
 
+    const payload = { url };
+    if (force) payload.force = true;
+    if (historyRefresh) payload.history_refresh = true;
+
     const { response, body } = await fetchJson(`${this.baseURL}/api/scan/trigger`, {
       method: "POST",
       headers,
-      body: JSON.stringify(force ? { url, force: true } : { url }),
+      body: JSON.stringify(payload),
     });
 
     if (response.ok) {

--- a/src/extension_shield/api/database.py
+++ b/src/extension_shield/api/database.py
@@ -64,6 +64,53 @@ def _escape_postgrest_like_term(term: str) -> str:
     return re.sub(r"([%_\\])", r"\\\1", term)
 
 
+def _annotate_needs_rescan(rows: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Flag user-history rows whose scan_results row is MISSING (orphaned by a DB
+    cutover) or FAILED/partial, so callers render a 'rescan' state and kick off a
+    fresh scan instead of a misleading 'NOT SAFE'/'Partial' report.
+
+    For a real Chrome Web Store id (32 chars a-p) this sets needs_rescan=True +
+    rescan_reason ('not_scanned' | 'failed'), which the UI auto-rescans from the
+    store. Uploaded/private scans (UUID ids) cannot be re-fetched from the store,
+    so they get unavailable=True instead (a neutral state, never a doomed rescan
+    or a stuck spinner). Completed rows are left untouched. Works for both the
+    SQLite LEFT JOIN shape (missing row → NULL columns) and the Supabase shape
+    (missing row → bare {"extension_id": id} stub).
+    """
+    for r in rows:
+        if not isinstance(r, dict):
+            continue
+        status = r.get("status")
+        has_scan = bool(r.get("extension_name")) or status is not None
+        broken = (not has_scan) or (isinstance(status, str) and status.lower() in ("failed", "error"))
+        if not broken:
+            continue
+        reason = "not_scanned" if not has_scan else "failed"
+        ext = r.get("extension_id") or ""
+        if re.fullmatch(r"[a-p]{32}", ext):
+            r["needs_rescan"] = True
+            r["rescan_reason"] = reason
+        else:
+            r["unavailable"] = True
+            r["rescan_reason"] = reason
+    return rows
+
+
+def _promote_summary_fields(record: Dict[str, Any]) -> None:
+    """Copy the modern report fields up from the stored `summary` JSONB blob to
+    top-level keys, so API consumers get scoring_v2 / report_view_model /
+    governance_bundle / virustotal_analysis without unpacking `summary`.
+
+    Mutates `record` in place; no-op when `summary` is absent or not a dict.
+    """
+    summary = record.get("summary")
+    if not isinstance(summary, dict):
+        return
+    for _field in ("scoring_v2", "report_view_model", "governance_bundle", "virustotal_analysis"):
+        if _field in summary:
+            record[_field] = summary.get(_field)
+
+
 class Database:
     """SQLite database manager (dev fallback when Postgres/Supabase is not used)."""
 
@@ -710,10 +757,24 @@ class Database:
                 
                 cursor.execute(base_query, (user_id, limit))
                 rows = cursor.fetchall()
-                return [dict(row) for row in rows]
+                return _annotate_needs_rescan([dict(row) for row in rows])
         except Exception as e:
             print(f"Error getting user scan history: {e}")
             return []
+
+    def user_has_extension_in_history(self, user_id: str, extension_id: str) -> bool:
+        """True if this user already has this extension in their scan history."""
+        try:
+            with self.get_connection() as conn:
+                cursor = conn.cursor()
+                cursor.execute(
+                    "SELECT 1 FROM user_scan_history WHERE user_id = ? AND extension_id = ? LIMIT 1",
+                    (user_id, extension_id),
+                )
+                return cursor.fetchone() is not None
+        except Exception as e:
+            print(f"Error checking user scan history membership: {e}")
+            return False
 
     def get_scan_result(self, identifier: str) -> Optional[Dict[str, Any]]:
         """Get scan result by extension ID or slug. Identifier can be 32-char extension ID, upload UUID, or name slug."""
@@ -902,17 +963,8 @@ class Database:
                     try:
                         row_dict = self._row_to_dict(row)
                         
-                        # Extract modern fields from summary JSON if present (for signal calculation)
-                        summary = row_dict.get("summary", {})
-                        if isinstance(summary, dict):
-                            if "scoring_v2" in summary:
-                                row_dict["scoring_v2"] = summary.get("scoring_v2")
-                            if "report_view_model" in summary:
-                                row_dict["report_view_model"] = summary.get("report_view_model")
-                            if "governance_bundle" in summary:
-                                row_dict["governance_bundle"] = summary.get("governance_bundle")
-                            if "virustotal_analysis" in summary:
-                                row_dict["virustotal_analysis"] = summary.get("virustotal_analysis")
+                        # Promote modern report fields from the summary JSONB (for signal calculation)
+                        _promote_summary_fields(row_dict)
                         
                         result_rows.append(row_dict)
                     except Exception as row_error:
@@ -1502,17 +1554,8 @@ class SupabaseDatabase:
                 r.pop("updated_at", None)
                 r.pop("created_at", None)
                 
-                # Extract modern fields from summary JSONB if present
-                summary = r.get("summary", {})
-                if isinstance(summary, dict):
-                    if "scoring_v2" in summary:
-                        r["scoring_v2"] = summary.get("scoring_v2")
-                    if "report_view_model" in summary:
-                        r["report_view_model"] = summary.get("report_view_model")
-                    if "governance_bundle" in summary:
-                        r["governance_bundle"] = summary.get("governance_bundle")
-                    if "virustotal_analysis" in summary:
-                        r["virustotal_analysis"] = summary.get("virustotal_analysis")
+                # Promote modern report fields from the summary JSONB
+                _promote_summary_fields(r)
                 
                 by_id[r.get("extension_id")] = r
 
@@ -1522,10 +1565,26 @@ class SupabaseDatabase:
                 ext = h.get("extension_id")
                 row = by_id.get(ext, {"extension_id": ext})
                 out.append(row)
-            return out
+            return _annotate_needs_rescan(out)
         except Exception as e:
             print(f"Error getting user scan history (Supabase): {e}")
             return []
+
+    def user_has_extension_in_history(self, user_id: str, extension_id: str) -> bool:
+        """True if this user already has this extension in their scan history."""
+        try:
+            resp = (
+                self.client.table("user_scan_history")
+                .select("id")
+                .eq("user_id", user_id)
+                .eq("extension_id", extension_id)
+                .limit(1)
+                .execute()
+            )
+            return bool(getattr(resp, "data", None))
+        except Exception as e:
+            print(f"Error checking user scan history membership (Supabase): {e}")
+            return False
 
     def get_scan_result(self, identifier: str) -> Optional[Dict[str, Any]]:
         """Get scan result by extension ID or slug. Identifier can be 32-char extension ID, upload UUID, or name slug."""
@@ -1560,18 +1619,8 @@ class SupabaseDatabase:
                 result["timestamp"] = ts
             result.pop("scanned_at", None)
             
-            # Extract modern fields from summary JSONB if present
-            # Also check top-level in case they were stored there (backward compatibility)
-            summary = result.get("summary", {})
-            if isinstance(summary, dict):
-                if "scoring_v2" in summary:
-                    result["scoring_v2"] = summary.get("scoring_v2")
-                if "report_view_model" in summary:
-                    result["report_view_model"] = summary.get("report_view_model")
-                if "governance_bundle" in summary:
-                    result["governance_bundle"] = summary.get("governance_bundle")
-                if "virustotal_analysis" in summary:
-                    result["virustotal_analysis"] = summary.get("virustotal_analysis")
+            # Promote modern report fields from the summary JSONB
+            _promote_summary_fields(result)
             
             # If not found in summary, check top-level (for backward compatibility with old scans)
             # Note: Supabase might return these as top-level fields if they were stored that way
@@ -1606,17 +1655,8 @@ class SupabaseDatabase:
                 row.pop("updated_at", None)
                 row.pop("created_at", None)
                 
-                # Extract modern fields from summary JSONB if present
-                summary = row.get("summary", {})
-                if isinstance(summary, dict):
-                    if "scoring_v2" in summary:
-                        row["scoring_v2"] = summary.get("scoring_v2")
-                    if "report_view_model" in summary:
-                        row["report_view_model"] = summary.get("report_view_model")
-                    if "governance_bundle" in summary:
-                        row["governance_bundle"] = summary.get("governance_bundle")
-                    if "virustotal_analysis" in summary:
-                        row["virustotal_analysis"] = summary.get("virustotal_analysis")
+                # Promote modern report fields from the summary JSONB
+                _promote_summary_fields(row)
             return rows
         except Exception as e:
             print(f"Error getting scan history (Supabase): {e}")
@@ -1666,17 +1706,8 @@ class SupabaseDatabase:
                     row.pop("updated_at", None)
                     row.pop("created_at", None)
                     
-                    # Extract modern fields from summary JSONB if present
-                    summary = row.get("summary", {})
-                    if isinstance(summary, dict):
-                        if "scoring_v2" in summary:
-                            row["scoring_v2"] = summary.get("scoring_v2")
-                        if "report_view_model" in summary:
-                            row["report_view_model"] = summary.get("report_view_model")
-                        if "governance_bundle" in summary:
-                            row["governance_bundle"] = summary.get("governance_bundle")
-                        if "virustotal_analysis" in summary:
-                            row["virustotal_analysis"] = summary.get("virustotal_analysis")
+                    # Promote modern report fields from the summary JSONB
+                    _promote_summary_fields(row)
                 except Exception as row_error:
                     print(f"Error processing row in get_recent_scans (Supabase): {row_error}")
                     # Continue processing other rows

--- a/src/extension_shield/api/main.py
+++ b/src/extension_shield/api/main.py
@@ -5,6 +5,7 @@ Provides REST API endpoints for the frontend to trigger extension analysis
 and retrieve results.
 """
 
+import asyncio
 import base64
 import mimetypes
 import os
@@ -1583,6 +1584,11 @@ def _persist_scan_failure(extension_id: str, failed_payload: Dict[str, Any]) -> 
 
     scan_results[extension_id] = failed_payload
     scan_status[extension_id] = "failed"
+    # Throttle re-attempts of a genuinely unfetchable extension. Without a prior
+    # good report a failed row is eligible for a failed_stale rescan on EVERY
+    # trigger (and the history page auto-fires those), so record the attempt to
+    # gate the next rescan behind the failed-refresh cooldown.
+    _note_failed_refresh(extension_id)
     try:
         db.save_scan_result(failed_payload)
         logger.info("[TIMELINE] saved failed scan to database → extension_id=%s", extension_id)
@@ -2521,6 +2527,21 @@ async def vote_community_review_item(body: ReviewQueueVoteRequest, http_request:
     return {"ok": True}
 
 
+# Bound the number of concurrent heavy scans (CRX download + SAST + VirusTotal +
+# LLM) so a burst of user triggers or history rescans cannot exhaust CPU/network
+# or the VirusTotal quota. Tunable via MAX_CONCURRENT_SCANS (default 3).
+_scan_concurrency = asyncio.Semaphore(int(os.getenv("MAX_CONCURRENT_SCANS", "3")))
+
+
+async def _run_analysis_workflow_bounded(url: str, extension_id: str):
+    """Run a scan under the concurrency cap. The extension is marked 'running'
+    immediately (even while queued behind the semaphore) so duplicate triggers
+    dedupe via the scan_status guard in trigger_scan."""
+    scan_status[extension_id] = "running"
+    async with _scan_concurrency:
+        await run_analysis_workflow(url, extension_id)
+
+
 @app.post("/api/scan/trigger")
 @_rate_limit("6/minute")  # Conservative for VirusTotal (3 keys); cached lookups return immediately without running scan
 async def trigger_scan(scan_request: ScanRequest, background_tasks: BackgroundTasks, request: Request):
@@ -2554,6 +2575,19 @@ async def trigger_scan(scan_request: ScanRequest, background_tasks: BackgroundTa
     # the user asked for a brand-new scan. A staleness refresh is system-initiated:
     # it must not spend the user's daily quota or 429 them on what was a cached lookup.
     system_refresh = False
+
+    # Scan-History auto-refresh of a missing/failed row: for an AUTHENTICATED user
+    # re-scanning an extension already in their own history, treat it as a system
+    # refresh (quota-exempt) rather than a brand-new user scan. Gated on history
+    # membership so it cannot be used to bypass the daily deep-scan limit for
+    # arbitrary new extensions.
+    if bool(getattr(scan_request, "history_refresh", False)):
+        _hr_user_id = getattr(getattr(request, "state", None), "user_id", None)
+        try:
+            if _hr_user_id and db.user_has_extension_in_history(_hr_user_id, extension_id):
+                system_refresh = True
+        except Exception:
+            pass
 
     # If we already have results, use a fast version check only (no blocking store refresh)
     # so cached lookups return immediately. Full store refresh runs on GET when needed.
@@ -2600,7 +2634,14 @@ async def trigger_scan(scan_request: ScanRequest, background_tasks: BackgroundTa
         if force_requested and not force_allowed:
             logger.info("[FORCE_RESCAN] force ignored for %s (not permitted in this environment)", extension_id)
 
-        stale = version_changed or model_stale or cutoff_stale
+        # A previously FAILED/partial scan (e.g. rows the fresh-seed cutover left
+        # behind) must be re-attempted rather than re-served — it is treated as a
+        # system refresh so it neither spends the user's quota nor 429s them. The
+        # failed-refresh cooldown below still prevents rescanning a genuinely
+        # unfetchable extension on every single lookup.
+        failed_stale = str(cached_payload.get("status") or "").lower() in ("failed", "error")
+
+        stale = version_changed or model_stale or cutoff_stale or failed_stale
         # Suppress a staleness rescan when we recently tried and failed to refresh
         # this extension (its preserved good report is still pre-cutoff) — serve the
         # cached report instead of rescanning an unfetchable extension on every lookup.
@@ -2736,7 +2777,7 @@ async def trigger_scan(scan_request: ScanRequest, background_tasks: BackgroundTa
 
     # Start background analysis
     scan_user_ids[extension_id] = getattr(getattr(request, "state", None), "user_id", None)
-    background_tasks.add_task(run_analysis_workflow, url, extension_id)
+    background_tasks.add_task(_run_analysis_workflow_bounded, url, extension_id)
 
     return {
         "message": "Scan triggered successfully",
@@ -2846,7 +2887,7 @@ async def upload_and_scan(
     # Start background analysis with local file path (private upload: user_id + source for DB)
     scan_user_ids[extension_id] = getattr(getattr(request, "state", None), "user_id", None)
     scan_source[extension_id] = "upload"
-    background_tasks.add_task(run_analysis_workflow, str(file_path), extension_id)
+    background_tasks.add_task(_run_analysis_workflow_bounded, str(file_path), extension_id)
 
     return {
         "message": "File uploaded and scan triggered successfully",

--- a/src/extension_shield/api/shared.py
+++ b/src/extension_shield/api/shared.py
@@ -34,6 +34,11 @@ class ScanRequest(BaseModel):
     # recomputed even if the store version is unchanged. Gated server-side
     # (dev mode or a matching admin token); ignored otherwise.
     force: Optional[bool] = False
+    # Set by the Scan History page when auto-refreshing a row whose scan is
+    # missing/failed. Honored only for authenticated users, and only for an
+    # extension already in that user's history, in which case the rescan is a
+    # system refresh (quota-exempt) rather than a brand-new user scan.
+    history_refresh: Optional[bool] = False
 
 
 class ScanStatusResponse(BaseModel):

--- a/src/extension_shield/core/analyzers/virustotal.py
+++ b/src/extension_shield/core/analyzers/virustotal.py
@@ -10,6 +10,7 @@ When one key returns 429, that key is marked rate-limited and the next key is us
 """
 
 import os
+import copy
 import hashlib
 import logging
 import json
@@ -91,25 +92,46 @@ class _VTRateLimiter:
             self._daily_date = today
             self._rate_limited = False
 
-    def wait(self) -> bool:
-        """Block until a slot is available. Returns False if this key is rate-limited."""
-        if self._rate_limited:
-            return False
-        with self._lock:
-            self._reset_daily_if_needed()
-            if self._daily_count >= self._max_day:
-                self._rate_limited = True
+    def wait(self, max_wait: Optional[float] = None) -> bool:
+        """Reserve a request slot for this key.
+
+        max_wait semantics:
+          - None  → wait as long as needed (legacy blocking behavior)
+          - 0     → non-blocking: reserve only if a slot is immediately free
+          - >0    → wait up to this many seconds for a slot
+
+        The slot is reserved atomically UNDER the lock, but any waiting
+        (``time.sleep``) happens with the lock RELEASED so concurrent scans do
+        not serialize behind one sleeping thread. Returns False if the key is
+        rate-limited/quota-exhausted or no slot frees within ``max_wait``.
+        """
+        deadline = None if max_wait is None else time.monotonic() + max(max_wait, 0.0)
+        while True:
+            if self._rate_limited:
                 return False
-            now = time.monotonic()
-            self._timestamps = [t for t in self._timestamps if now - t < 60]
-            if len(self._timestamps) >= self._max_min:
-                sleep_for = 60 - (now - self._timestamps[0]) + 0.5
-                time.sleep(max(sleep_for, 1))
+            with self._lock:
+                self._reset_daily_if_needed()
+                if self._rate_limited:
+                    return False
+                if self._daily_count >= self._max_day:
+                    self._rate_limited = True
+                    return False
                 now = time.monotonic()
                 self._timestamps = [t for t in self._timestamps if now - t < 60]
-            self._timestamps.append(time.monotonic())
-            self._daily_count += 1
-        return True
+                if len(self._timestamps) < self._max_min:
+                    # Slot available — reserve it atomically before releasing the lock.
+                    self._timestamps.append(now)
+                    self._daily_count += 1
+                    return True
+                # No slot right now; compute how long until the oldest ages out.
+                sleep_for = 60 - (now - self._timestamps[0]) + 0.5
+            # Lock released before sleeping.
+            if deadline is not None:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    return False
+                sleep_for = min(sleep_for, remaining)
+            time.sleep(max(min(sleep_for, 2.0), 0.05))
 
 
 class _VTKeyPool:
@@ -124,21 +146,38 @@ class _VTKeyPool:
         self._index = 0
         self._lock = threading.Lock()
 
-    def wait_and_get_key(self) -> Tuple[Optional[int], Optional[str]]:
+    def wait_and_get_key(self, max_wait: Optional[float] = None) -> Tuple[Optional[int], Optional[str]]:
         """
-        Round-robin over keys until one has capacity. Blocks if needed.
-        Returns (key_index, api_key) or (None, None) if all keys are rate-limited.
+        Get a key with available capacity.
+
+        Pass 1 is non-blocking across ALL keys (grab any key with an immediately
+        free slot). If none is free and ``max_wait`` allows waiting, Pass 2 waits
+        (bounded by ``max_wait``) on the next key in the rotation. Any waiting
+        happens inside the per-key limiter with its lock released — the pool lock
+        is only held briefly to advance the round-robin cursor.
+
+        Returns (key_index, api_key) or (None, None) if all keys are rate-limited
+        or no slot frees within ``max_wait``.
         """
         if not self._keys:
             return None, None
         with self._lock:
             start = self._index
-            for i in range(len(self._keys)):
-                idx = (start + i) % len(self._keys)
-                if self._limiters[idx].wait():
+        # Pass 1: non-blocking — take any key with immediate capacity.
+        for i in range(len(self._keys)):
+            idx = (start + i) % len(self._keys)
+            if self._limiters[idx].wait(max_wait=0):
+                with self._lock:
                     self._index = (idx + 1) % len(self._keys)
-                    return idx, self._keys[idx]
-        logger.warning("VirusTotal: all keys rate-limited")
+                return idx, self._keys[idx]
+        # Pass 2: bounded (or unbounded, when max_wait is None) wait on one key.
+        if max_wait is None or max_wait > 0:
+            idx = start % len(self._keys)
+            if self._limiters[idx].wait(max_wait=max_wait):
+                with self._lock:
+                    self._index = (idx + 1) % len(self._keys)
+                return idx, self._keys[idx]
+        logger.warning("VirusTotal: all keys rate-limited or wait budget exhausted")
         return None, None
 
     def mark_rate_limited(self, key_index: int) -> None:
@@ -173,6 +212,54 @@ def _get_vt_key_pool() -> Optional[_VTKeyPool]:
         _vt_key_pool = _VTKeyPool(keys, max_per_minute=4, max_per_day=500)
         logger.info("VirusTotal: using %d API key(s) with rotation", len(keys))
         return _vt_key_pool
+
+
+# ---------------------------------------------------------------------------
+# Process-level VirusTotal verdict cache (keyed by file sha256).
+# Concurrent/repeat scans of the same extension — or of a shared library file
+# common to many extensions — reuse a recent verdict instead of re-spending the
+# (small) free-tier quota. Only DEFINITIVE verdicts are cached (a real report or
+# a genuine "not in VT database"); transient/rate-limit/auth results are never
+# cached so a healthy key retries them.
+# ---------------------------------------------------------------------------
+_vt_hash_cache: Dict[str, Tuple[Dict[str, Any], float]] = {}
+_vt_hash_cache_lock = threading.Lock()
+_VT_HASH_CACHE_TTL = float(os.getenv("VT_HASH_CACHE_TTL_SECONDS", str(6 * 3600)))
+_vt_cache_hits = 0  # process-lifetime observability counter
+
+
+def _vt_cache_get(sha256: str) -> Optional[Dict[str, Any]]:
+    if not sha256:
+        return None
+    with _vt_hash_cache_lock:
+        entry = _vt_hash_cache.get(sha256)
+        if not entry:
+            return None
+        verdict, expiry = entry
+        if time.monotonic() >= expiry:
+            _vt_hash_cache.pop(sha256, None)
+            return None
+        global _vt_cache_hits
+        _vt_cache_hits += 1
+        return copy.deepcopy(verdict)  # deep copy so callers cannot mutate the cached entry (incl. nested)
+
+
+def _vt_cache_put(sha256: str, verdict: Optional[Dict[str, Any]]) -> None:
+    if not sha256 or not isinstance(verdict, dict):
+        return
+    # Never cache transient / rate-limit / auth failures — retry those on a healthy key.
+    if verdict.get("status") in ("RATE_LIMITED", "INVALID_KEY"):
+        return
+    if verdict.get("error"):
+        return
+    with _vt_hash_cache_lock:
+        _vt_hash_cache[sha256] = (copy.deepcopy(verdict), time.monotonic() + _VT_HASH_CACHE_TTL)
+
+
+def vt_cache_stats() -> Dict[str, int]:
+    """Observability for tests/ops: cumulative hit count and current cache size."""
+    with _vt_hash_cache_lock:
+        return {"hits": _vt_cache_hits, "size": len(_vt_hash_cache)}
 
 
 class VirusTotalAnalyzer(BaseAnalyzer):
@@ -301,18 +388,23 @@ class VirusTotalAnalyzer(BaseAnalyzer):
         max_files = self.config.get("max_files_to_scan", 10)
         return files_to_scan[:max_files]
 
-    async def _check_hash_virustotal(self, file_hash: str) -> Optional[Dict[str, Any]]:
+    async def _check_hash_virustotal(self, file_hash: str, max_wait: Optional[float] = None) -> Optional[Dict[str, Any]]:
         """
         Check a file hash against VirusTotal (async version).
         Uses key pool with rotation; on 429 the current key is marked and next key is used next time.
+        A recent cached verdict (process-level, keyed by sha256) is returned without spending quota.
         """
         if not self.enabled:
             return None
 
+        cached = _vt_cache_get(file_hash)
+        if cached is not None:
+            return cached
+
         pool = _get_vt_key_pool()
         if not pool:
             return None
-        key_index, api_key = pool.wait_and_get_key()
+        key_index, api_key = pool.wait_and_get_key(max_wait=max_wait)
         if api_key is None:
             return {
                 "found": False,
@@ -360,6 +452,7 @@ class VirusTotalAnalyzer(BaseAnalyzer):
                 else:
                     results["malware_families"] = []
 
+                _vt_cache_put(file_hash, results)
                 return results
 
         except vt.error.APIError as e:
@@ -368,7 +461,9 @@ class VirusTotalAnalyzer(BaseAnalyzer):
 
             if _is_vt_not_found_error(e, error_str):
                 logger.info("[VirusTotal] Hash not present in database for %s", file_hash)
-                return {"found": False, "message": "Hash not found in VirusTotal database"}
+                _not_found = {"found": False, "message": "Hash not found in VirusTotal database"}
+                _vt_cache_put(file_hash, _not_found)
+                return _not_found
 
             logger.warning("[VirusTotal] API error - status_code=%s, error=%s", status_code, error_str)
 
@@ -397,18 +492,23 @@ class VirusTotalAnalyzer(BaseAnalyzer):
             logger.error("[VirusTotal] Unexpected error: %s", e)
             return {"found": False, "error": str(e)}
 
-    def _check_hash_virustotal_sync(self, file_hash: str) -> Optional[Dict[str, Any]]:
+    def _check_hash_virustotal_sync(self, file_hash: str, max_wait: Optional[float] = None) -> Optional[Dict[str, Any]]:
         """
         Synchronous version of VirusTotal hash check.
         Uses key pool with rotation; on 429 the current key is marked and next key is used next time.
+        A recent cached verdict (process-level, keyed by sha256) is returned without spending quota.
         """
         if not self.enabled:
             return None
 
+        cached = _vt_cache_get(file_hash)
+        if cached is not None:
+            return cached
+
         pool = _get_vt_key_pool()
         if not pool:
             return None
-        key_index, api_key = pool.wait_and_get_key()
+        key_index, api_key = pool.wait_and_get_key(max_wait=max_wait)
         if api_key is None:
             return {
                 "found": False,
@@ -456,6 +556,7 @@ class VirusTotalAnalyzer(BaseAnalyzer):
                 else:
                     results["malware_families"] = []
 
+                _vt_cache_put(file_hash, results)
                 return results
 
         except vt.error.APIError as e:
@@ -464,7 +565,9 @@ class VirusTotalAnalyzer(BaseAnalyzer):
 
             if _is_vt_not_found_error(e, error_str):
                 logger.info("[VirusTotal] Hash not present in database for %s", file_hash)
-                return {"found": False, "message": "Hash not found in VirusTotal database"}
+                _not_found = {"found": False, "message": "Hash not found in VirusTotal database"}
+                _vt_cache_put(file_hash, _not_found)
+                return _not_found
 
             logger.warning("[VirusTotal] API error (sync) - status_code=%s, error=%s", status_code, error_str)
 
@@ -538,15 +641,27 @@ class VirusTotalAnalyzer(BaseAnalyzer):
         pool_desc = f"{pool.key_count} key(s), 4 req/min each" if pool else "no keys"
         logger.info("VirusTotal: Scanning %d files (%s)", len(files_to_scan), pool_desc)
 
+        # Total wall-clock budget for VT lookups this scan. Bounds how long the
+        # analyzer will wait behind the rate limiter so a burst of concurrent
+        # scans cannot make one scan hang for minutes. Cached hashes are served
+        # instantly and do NOT consume this budget.
+        vt_budget_seconds = float(os.getenv("VT_SCAN_BUDGET_SECONDS", "45"))
+        scan_deadline = time.monotonic() + vt_budget_seconds
+
         rate_limited_skips = 0
         for file_info in files_to_scan:
-            if pool and pool.is_exhausted:
+            remaining_budget = scan_deadline - time.monotonic()
+            if pool and (pool.is_exhausted or remaining_budget <= 0):
                 rate_limited_skips += 1
                 results["file_results"].append({
                     "file_name": file_info["name"],
                     "file_path": file_info["path"].replace(extension_dir, ""),
                     "skipped": True,
-                    "reason": "VirusTotal rate limit reached — file skipped",
+                    "reason": (
+                        "VirusTotal rate limit reached — file skipped"
+                        if (pool and pool.is_exhausted)
+                        else "VirusTotal time budget reached — file skipped"
+                    ),
                 })
                 continue
 
@@ -554,7 +669,7 @@ class VirusTotalAnalyzer(BaseAnalyzer):
                 file_path = file_info["path"]
                 hashes = self.compute_all_hashes(file_path)
 
-                vt_result = self._check_hash_virustotal_sync(hashes["sha256"])
+                vt_result = self._check_hash_virustotal_sync(hashes["sha256"], max_wait=remaining_budget)
 
                 file_result = {
                     "file_name": file_info["name"],
@@ -584,10 +699,11 @@ class VirusTotalAnalyzer(BaseAnalyzer):
                         families = vt_result.get("malware_families", [])
                         results["summary"]["detected_families"].extend(families)
 
-                # If VT returned a rate-limit status, stop further lookups this scan
+                # If VT returned a rate-limit status, stop further lookups this scan.
                 if vt_result and vt_result.get("status") == "RATE_LIMITED":
                     logger.warning("VirusTotal rate-limited — skipping remaining files")
                     rate_limited_skips += 1
+                    break
 
             except Exception as e:
                 logger.error("Error analyzing file %s: %s", file_info["path"], e)

--- a/tests/api/test_failed_refresh_cooldown.py
+++ b/tests/api/test_failed_refresh_cooldown.py
@@ -1,0 +1,27 @@
+"""A fresh scan failure (no prior good report) must record the failed-refresh
+cooldown, so failed_stale rescans of an unfetchable extension are throttled to
+once per cooldown instead of firing on every history load."""
+from unittest.mock import patch
+
+import extension_shield.api.main as main
+
+
+def test_fresh_failure_records_cooldown():
+    ext = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    main._failed_refresh_at.pop(ext, None)
+    with patch.object(main.db, "get_scan_result", return_value=None), \
+         patch.object(main.db, "save_scan_result", return_value=None):
+        assert main._in_failed_refresh_cooldown(ext) is False
+        main._persist_scan_failure(ext, {"extension_id": ext, "status": "failed", "security_score": 0})
+        assert main._in_failed_refresh_cooldown(ext) is True
+    main._failed_refresh_at.pop(ext, None)
+
+
+def test_preserved_good_report_still_records_cooldown():
+    ext = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    main._failed_refresh_at.pop(ext, None)
+    good = {"extension_id": ext, "status": "completed", "security_score": 90}
+    with patch.object(main.db, "get_scan_result", return_value=good):
+        main._persist_scan_failure(ext, {"extension_id": ext, "status": "failed", "security_score": 0})
+        assert main._in_failed_refresh_cooldown(ext) is True
+    main._failed_refresh_at.pop(ext, None)

--- a/tests/api/test_scan_freshness_gate_integration.py
+++ b/tests/api/test_scan_freshness_gate_integration.py
@@ -11,7 +11,7 @@ These exercise the wiring that unit tests of the helpers cannot:
 """
 import copy
 import importlib
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from fastapi.testclient import TestClient
@@ -117,7 +117,7 @@ def test_trigger_rescans_precutoff_cached_row_without_consuming_credit(client):
     _seed_cached(PRE_CUTOFF, ScoringEngine.VERSION)
     consume = MagicMock()
     with patch.object(main, "_fast_live_version_check", return_value=None), \
-         patch.object(main, "run_analysis_workflow", MagicMock()), \
+         patch.object(main, "run_analysis_workflow", AsyncMock()), \
          patch.object(main, "_consume_deep_scan", consume):
         r = client.post("/api/scan/trigger", json={"url": STORE_URL})
     assert r.status_code == 200
@@ -133,7 +133,7 @@ def test_trigger_rescans_none_version_precutoff_row(client):
     # scoring_version=None: model_stale can NOT see this row; only cutoff_stale can.
     _seed_cached(PRE_CUTOFF, None)
     with patch.object(main, "_fast_live_version_check", return_value=None), \
-         patch.object(main, "run_analysis_workflow", MagicMock()), \
+         patch.object(main, "run_analysis_workflow", AsyncMock()), \
          patch.object(main, "_consume_deep_scan", MagicMock()):
         r = client.post("/api/scan/trigger", json={"url": STORE_URL})
     assert r.status_code == 200
@@ -146,7 +146,7 @@ def test_failed_refresh_cooldown_suppresses_repeat_rescan(client):
     _seed_cached(PRE_CUTOFF, ScoringEngine.VERSION)
     main._note_failed_refresh(EXT_ID)
     with patch.object(main, "_fast_live_version_check", return_value=None), \
-         patch.object(main, "run_analysis_workflow", MagicMock()) as rw:
+         patch.object(main, "run_analysis_workflow", AsyncMock()) as rw:
         r = client.post("/api/scan/trigger", json={"url": STORE_URL})
     assert r.status_code == 200
     body = r.json()
@@ -167,7 +167,7 @@ def test_persist_scan_failure_records_cooldown_when_preserving():
 def test_trigger_serves_postcutoff_cached_row_instantly(client):
     _seed_cached(POST_CUTOFF, ScoringEngine.VERSION)
     with patch.object(main, "_fast_live_version_check", return_value=None), \
-         patch.object(main, "run_analysis_workflow", MagicMock()) as rw:
+         patch.object(main, "run_analysis_workflow", AsyncMock()) as rw:
         r = client.post("/api/scan/trigger", json={"url": STORE_URL})
     assert r.status_code == 200
     body = r.json()

--- a/tests/api/test_upload_limits.py
+++ b/tests/api/test_upload_limits.py
@@ -1,5 +1,5 @@
 import asyncio
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from fastapi.testclient import TestClient
 
@@ -35,7 +35,7 @@ def test_upload_rejects_payload_above_configured_limit(tmp_path):
 
     with patch("extension_shield.api.main.get_settings", return_value=_settings(4)), \
          patch("extension_shield.api.main.RESULTS_DIR", tmp_path), \
-         patch("extension_shield.api.main.run_analysis_workflow") as run_analysis:
+         patch("extension_shield.api.main.run_analysis_workflow", new_callable=AsyncMock) as run_analysis:
         response = client.post(
             "/api/scan/upload",
             files={"file": ("extension.zip", b"PK\x03\x04X", "application/zip")},

--- a/tests/test_history_rescan.py
+++ b/tests/test_history_rescan.py
@@ -1,0 +1,45 @@
+"""Issue 2: history rows for missing/failed scans must be flagged needs_rescan
+instead of rendering as a misleading 'NOT SAFE'/'Partial' report."""
+from extension_shield.api.database import _annotate_needs_rescan
+
+
+def test_orphan_supabase_stub_flagged_not_scanned():
+    rows = [{"extension_id": "fpkbnjejghdcncegfglnapabnljcimdc"}]  # bare stub (no scan_results row)
+    _annotate_needs_rescan(rows)
+    assert rows[0]["needs_rescan"] is True
+    assert rows[0]["rescan_reason"] == "not_scanned"
+
+
+def test_orphan_sqlite_leftjoin_nulls_flagged_not_scanned():
+    rows = [{"extension_id": "abcdefghijklmnopabcdefghijklmnop", "extension_name": None, "status": None, "security_score": None}]
+    _annotate_needs_rescan(rows)
+    assert rows[0]["needs_rescan"] is True
+    assert rows[0]["rescan_reason"] == "not_scanned"
+
+
+def test_uuid_upload_orphan_flagged_unavailable_not_rescan():
+    # Uploaded/private scans use a UUID id and cannot be re-fetched from the store.
+    rows = [{"extension_id": "6e441b7f-eb48-413c-823b-000000000000", "status": None, "extension_name": None}]
+    _annotate_needs_rescan(rows)
+    assert rows[0].get("needs_rescan") is None
+    assert rows[0]["unavailable"] is True
+
+
+def test_failed_row_flagged_failed():
+    rows = [{"extension_id": "lhipdkibljepmfojllcfflfflhflcbgi", "extension_name": "Moonlight", "status": "failed", "security_score": 65}]
+    _annotate_needs_rescan(rows)
+    assert rows[0]["needs_rescan"] is True
+    assert rows[0]["rescan_reason"] == "failed"
+
+
+def test_completed_row_not_flagged():
+    rows = [{"extension_id": "x", "extension_name": "Dark Reader", "status": "completed", "security_score": 92}]
+    _annotate_needs_rescan(rows)
+    assert "needs_rescan" not in rows[0]
+
+
+def test_running_row_not_flagged_as_failed():
+    rows = [{"extension_id": "x", "extension_name": "Foo", "status": "running"}]
+    _annotate_needs_rescan(rows)
+    # 'running' is neither missing nor failed → no rescan flag (it is in progress)
+    assert "needs_rescan" not in rows[0]

--- a/tests/test_virustotal_not_found.py
+++ b/tests/test_virustotal_not_found.py
@@ -24,7 +24,7 @@ def test_not_found_is_unknown_not_clean(tmp_path, monkeypatch):
     monkeypatch.setattr(
         analyzer,
         "_check_hash_virustotal_sync",
-        lambda _h: {"found": False, "message": "Hash not found in VirusTotal database"},
+        lambda _h, max_wait=None: {"found": False, "message": "Hash not found in VirusTotal database"},
     )
 
     result = analyzer.analyze(str(tmp_path))
@@ -41,7 +41,7 @@ def test_found_with_zero_detections_is_clean(tmp_path, monkeypatch):
     monkeypatch.setattr(
         analyzer,
         "_check_hash_virustotal_sync",
-        lambda _h: {
+        lambda _h, max_wait=None: {
             "found": True,
             "detection_stats": {
                 "malicious": 0,
@@ -66,7 +66,7 @@ def test_malicious_detection_is_malicious(tmp_path, monkeypatch):
     monkeypatch.setattr(
         analyzer,
         "_check_hash_virustotal_sync",
-        lambda _h: {
+        lambda _h, max_wait=None: {
             "found": True,
             "detection_stats": {
                 "malicious": 8,

--- a/tests/test_virustotal_ratelimit_cache.py
+++ b/tests/test_virustotal_ratelimit_cache.py
@@ -1,0 +1,120 @@
+"""Concurrency + cache behavior for the VirusTotal rate limiter (Issue 1).
+
+These are white-box tests of the free-tier rate limiter and the process-level
+verdict cache. They do NOT hit the network.
+"""
+import threading
+import time
+
+import extension_shield.core.analyzers.virustotal as vt
+
+
+def _reset_cache():
+    with vt._vt_hash_cache_lock:
+        vt._vt_hash_cache.clear()
+        vt._vt_cache_hits = 0
+
+
+def test_rate_limiter_reserves_up_to_limit_then_nonblocking_false():
+    lim = vt._VTRateLimiter(max_per_minute=2, max_per_day=500)
+    assert lim.wait(max_wait=0) is True
+    assert lim.wait(max_wait=0) is True
+    # Window full -> non-blocking reservation must fail immediately.
+    t0 = time.monotonic()
+    assert lim.wait(max_wait=0) is False
+    assert time.monotonic() - t0 < 0.2  # returned fast, did not sleep
+
+
+def test_rate_limiter_bounded_wait_gives_up():
+    lim = vt._VTRateLimiter(max_per_minute=1, max_per_day=500)
+    assert lim.wait(max_wait=0) is True
+    t0 = time.monotonic()
+    assert lim.wait(max_wait=0.4) is False  # no slot frees within 0.4s
+    elapsed = time.monotonic() - t0
+    assert 0.3 <= elapsed <= 2.0
+
+
+def test_rate_limiter_does_not_sleep_while_holding_lock():
+    """A thread waiting for a slot must not hold the lock while it sleeps."""
+    lim = vt._VTRateLimiter(max_per_minute=1, max_per_day=500)
+    assert lim.wait(max_wait=0) is True  # window now full
+
+    def waiter():
+        lim.wait(max_wait=1.5)  # will loop-sleep outside the lock, then give up
+
+    t = threading.Thread(target=waiter, daemon=True)
+    t.start()
+    time.sleep(0.1)  # let the waiter enter its sleep loop
+    # If the lock were held during sleep, this would block ~1.5s.
+    got = lim._lock.acquire(timeout=0.5)
+    if got:
+        lim._lock.release()
+    t.join(timeout=3)
+    assert got is True, "lock was held during sleep (serialization bug)"
+
+
+def test_daily_quota_marks_rate_limited():
+    lim = vt._VTRateLimiter(max_per_minute=100, max_per_day=2)
+    assert lim.wait(max_wait=0) is True
+    assert lim.wait(max_wait=0) is True
+    assert lim.wait(max_wait=0) is False
+    assert lim.is_rate_limited is True
+
+
+def test_cache_put_get_and_hit_counter():
+    _reset_cache()
+    verdict = {"found": True, "detection_stats": {"malicious": 0, "total_engines": 70}}
+    vt._vt_cache_put("abc123", verdict)
+    got = vt._vt_cache_get("abc123")
+    assert got == verdict
+    got["found"] = False  # mutating the copy must not corrupt the cache
+    assert vt._vt_cache_get("abc123")["found"] is True
+    assert vt.vt_cache_stats()["hits"] == 2
+
+
+def test_cache_never_stores_transient_states():
+    _reset_cache()
+    vt._vt_cache_put("h1", {"found": False, "status": "RATE_LIMITED"})
+    vt._vt_cache_put("h2", {"found": False, "status": "INVALID_KEY"})
+    vt._vt_cache_put("h3", {"found": False, "error": "connection reset"})
+    assert vt._vt_cache_get("h1") is None
+    assert vt._vt_cache_get("h2") is None
+    assert vt._vt_cache_get("h3") is None
+    assert vt.vt_cache_stats()["size"] == 0
+
+
+def test_cache_ttl_expiry(monkeypatch):
+    _reset_cache()
+    monkeypatch.setattr(vt, "_VT_HASH_CACHE_TTL", 0.05)
+    vt._vt_cache_put("short", {"found": False, "message": "Hash not found in VirusTotal database"})
+    assert vt._vt_cache_get("short") is not None
+    time.sleep(0.1)
+    assert vt._vt_cache_get("short") is None
+
+
+def test_check_sync_short_circuits_on_cache_hit(monkeypatch):
+    """A cached sha256 verdict is returned without ever consulting the key pool
+    (so concurrent/repeat scans of the same file spend no quota)."""
+    _reset_cache()
+    analyzer = vt.VirusTotalAnalyzer()
+    analyzer.enabled = True
+    vt._vt_cache_put("deadbeef", {"found": True, "detection_stats": {"malicious": 0, "total_engines": 60}})
+
+    def _boom():
+        raise AssertionError("key pool must not be used on a cache hit")
+
+    monkeypatch.setattr(vt, "_get_vt_key_pool", _boom)
+    result = analyzer._check_hash_virustotal_sync("deadbeef")
+    assert result["found"] is True
+    assert vt.vt_cache_stats()["hits"] >= 1
+
+
+def test_pool_nonblocking_then_bounded():
+    pool = vt._VTKeyPool(["k1"], max_per_minute=1, max_per_day=500)
+    idx, key = pool.wait_and_get_key(max_wait=0)
+    assert key == "k1" and idx == 0
+    # window full for the single key
+    assert pool.wait_and_get_key(max_wait=0) == (None, None)
+    t0 = time.monotonic()
+    assert pool.wait_and_get_key(max_wait=0.4) == (None, None)
+    assert time.monotonic() - t0 >= 0.3


### PR DESCRIPTION
Two backend issues after the fresh-seed DB cutover.

**VirusTotal under concurrent users**
- Rate limiter no longer sleeps while holding its lock, so concurrent scans queue fairly instead of serializing behind one thread.
- Process-level sha256→verdict cache so repeat/concurrent scans of the same files do not re-spend the free-tier quota.
- Per-scan VT time budget so a scan cannot hang for minutes; genuine limits recorded as a distinct RATE_LIMITED state.

**Scan History orphaned/failed rows** (the cutover left `user_scan_history` pointing at archived `scan_results`)
- Flag missing/failed rows `needs_rescan` (store ids) or `unavailable` (uploads); the history UI shows "Rescanning…"/"Unavailable" instead of a misleading "NOT SAFE".
- Bounded, de-duped auto-rescans; failed rows re-attempt; fresh failures record the failed-refresh cooldown so an unfetchable extension is not rescanned on every load.
- History rescans are quota-exempt only for an authenticated user re-scanning an extension already in their own history.
- Bounded asyncio.Semaphore caps concurrent scans.

Also consolidates 5 duplicate summary-promotion blocks into one helper. No changes to the scoring engine, scoring_v2, governance, coverage caps, or schema. +16 tests; full suite green.