### PR TITLE
fix(ui): light-only sign-in polish + remove dead dark-mode code

### DIFF
--- a/frontend/src/App.scss
+++ b/frontend/src/App.scss
@@ -984,6 +984,7 @@ body {
 /* User Menu */
 .user-menu-container {
   position: relative;
+  margin-top: 5px; // vertical alignment for the signed-in account menu in the header
 }
 
 .user-menu-trigger {

--- a/frontend/src/App.scss
+++ b/frontend/src/App.scss
@@ -928,8 +928,8 @@ body {
   text-decoration: none;
   background: var(--extensionshield-accent-cta, var(--extensionshield-accent));
   border: 1px solid var(--extensionshield-accent-cta, var(--extensionshield-accent));
-  
-  border-radius: 9999px;
+
+  border-radius: 10px; // match the other CTA/action buttons (was a 9999px pill)
   white-space: nowrap;
   flex-shrink: 0;
   display: inline-flex;

--- a/frontend/src/context/ThemeContext.jsx
+++ b/frontend/src/context/ThemeContext.jsx
@@ -1,68 +1,28 @@
-import React, { createContext, useContext, useState, useEffect, useMemo } from "react";
-import { useLocation } from "react-router-dom";
+import { useEffect } from "react";
 
-const ThemeContext = createContext();
-
-// Context modules co-locate the Provider and its hook by design; this is the
-// canonical React pattern. The rule below is a Fast-Refresh DX heuristic, not a
-// correctness check, so a scoped disable is the appropriate, low-churn choice.
-// eslint-disable-next-line react-refresh/only-export-components
-export const useTheme = () => {
-  const context = useContext(ThemeContext);
-  if (!context) {
-    throw new Error("useTheme must be used within a ThemeProvider");
+// The app is light-only — the dark-mode toggle was removed. This provider simply
+// guarantees <html class="light"> (index.css keys ALL styling off `.light`) and
+// clears any dark preference persisted by older builds so returning users aren't
+// stranded. There is no theme state, toggle, or context value anymore.
+function forceLightTheme() {
+  if (typeof document !== "undefined") {
+    document.documentElement.classList.add("light");
   }
-  return context;
-};
-
-// Routes that should always use dark mode (none - all pages support light/dark)
-const FORCE_DARK_ROUTES = [];
-
-export const ThemeProvider = ({ children }) => {
-  const location = useLocation();
-  const [theme, setTheme] = useState(() => {
-    // Dark mode toggle was removed; clear any persisted dark preference so returning
-    // users aren't stuck in dark mode with no way to escape.
-    if (localStorage.getItem("theme") === "dark") {
+  try {
+    if (typeof localStorage !== "undefined" && localStorage.getItem("theme")) {
       localStorage.removeItem("theme");
     }
-    if (typeof document !== "undefined") {
-      document.documentElement.classList.add("light");
-    }
-    return "light";
-  });
+  } catch {
+    /* ignore storage access errors (e.g. privacy mode) */
+  }
+}
 
-  // Determine effective theme based on route
-  const effectiveTheme = useMemo(() => {
-    // Force dark mode on specific routes (but not homepage)
-    if (location.pathname !== "/" && FORCE_DARK_ROUTES.some(route => location.pathname.startsWith(route))) {
-      return "dark";
-    }
-    return theme;
-  }, [theme, location.pathname]);
+// Apply as early as the module loads so `.light` is present before first paint.
+forceLightTheme();
 
+export const ThemeProvider = ({ children }) => {
   useEffect(() => {
-    // Apply theme via html class only; CSS (.light in index.css) handles backgrounds
-    if (effectiveTheme === "light") {
-      document.documentElement.classList.add("light");
-    } else {
-      document.documentElement.classList.remove("light");
-    }
-
-    // Persist user choice (not effective theme) to localStorage
-    if (effectiveTheme === theme) {
-      localStorage.setItem("theme", theme);
-    }
-  }, [effectiveTheme, theme]);
-
-  const toggleTheme = () => {
-    setTheme((prev) => (prev === "dark" ? "light" : "dark"));
-  };
-
-  return (
-    <ThemeContext.Provider value={{ theme: effectiveTheme, toggleTheme, setTheme, actualTheme: theme }}>
-      {children}
-    </ThemeContext.Provider>
-  );
+    forceLightTheme();
+  }, []);
+  return children;
 };
-

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -198,82 +198,9 @@
   --extensionshield-bg-elevated: #2e2b28;
 }
 
-/* Optional: lighter dark variant (same warm hue) – use data-theme="dark-lighter" on <html> if needed */
-[data-theme="dark-lighter"] {
-  --extensionshield-bg-primary: #252320;
-  --extensionshield-bg-secondary: #2e2b28;
-  --theme-bg-primary: #252320;
-  --theme-bg-secondary: #2e2b28;
-  --color-background: 34 12% 13%;
-  --color-surface: 34 10% 16%;
-  --color-surface-elevated: 34 10% 18%;
-  --color-surface-hover: 34 10% 20%;
-  --color-card: 34 10% 16%;
-  --color-input: 34 12% 14%;
-}
-
-/* ============================================================================
-   DARK MODE (default) – card/surface consistency across all routes
-   Same look as Enterprise page: theme backgrounds and borders everywhere.
-   ============================================================================ */
-:root:not(.light) .surface-card,
-:root:not(.light) .bridge-step,
-:root:not(.light) .deception-card,
-:root:not(.light) .pricing-card,
-:root:not(.light) .link-card,
-:root:not(.light) .contribution-card,
-:root:not(.light) .community-card,
-:root:not(.light) .blog-card,
-:root:not(.light) .finding-card,
-:root:not(.light) .case-study-card,
-:root:not(.light) .research-card,
-:root:not(.light) .enterprise-card,
-:root:not(.light) .enterprise-form,
-:root:not(.light) .highlight-tile,
-:root:not(.light) .methodology-info-box,
-:root:not(.light) .glossary-term,
-:root:not(.light) .extension-card,
-:root:not(.light) .idea-card,
-:root:not(.light) .summary-panel,
-:root:not(.light) .results-sidebar-tile,
-:root:not(.light) .login-overlay-content,
-:root:not(.light) .aggregate-card,
-:root:not(.light) .pipeline-card,
-:root:not(.light) .open-source-credit,
-:root:not(.light) .chart-card,
-:root:not(.light) .recommendation-card,
-:root:not(.light) .capability-card,
-:root:not(.light) .report-card,
-:root:not(.light) .glass-card,
-:root:not(.light) .karma-panel,
-:root:not(.light) .api-card {
-  background: var(--extensionshield-bg-card);
-  border: 1px solid var(--extensionshield-border);
-  box-shadow: var(--extensionshield-card-shadow);
-  color: var(--extensionshield-text-primary);
-}
-
-/* Dark: form fields (e.g. Enterprise, contact forms) inherit theme */
-:root:not(.light) .field input,
-:root:not(.light) .field textarea {
-  background: var(--extensionshield-bg-secondary);
-  border: 1px solid var(--extensionshield-border);
-  color: var(--extensionshield-text-primary);
-}
-
-:root:not(.light) .field input::placeholder,
-:root:not(.light) .field textarea::placeholder {
-  color: var(--extensionshield-text-muted);
-}
-
-/* Dark: headings and body text use theme primary for WCAG */
-:root:not(.light) h1,
-:root:not(.light) h2,
-:root:not(.light) .enterprise-header h1,
-:root:not(.light) .enterprise-card h2,
-:root:not(.light) .enterprise-form h2 {
-  color: var(--extensionshield-text-primary);
-}
+/* Dark mode removed — the app is light-only. The former [data-theme="dark-lighter"]
+   variant and all :root:not(.light) card/field/heading rules were dead code:
+   <html> always carries `.light`, so those selectors never matched. */
 
 /* ============================================================================
    LIGHT MODE THEME

--- a/frontend/src/pages/auth/AuthCallbackPage.scss
+++ b/frontend/src/pages/auth/AuthCallbackPage.scss
@@ -110,30 +110,9 @@
   outline-offset: 2px;
 }
 
-// Dark mode support
-@media (prefers-color-scheme: dark) {
-  .auth-callback-content {
-    background: rgba(26, 32, 44, 0.95);
-    color: #f7fafc;
-  }
-
-  .auth-callback-title {
-    color: #f7fafc;
-  }
-
-  .auth-callback-message {
-    color: #e2e8f0;
-  }
-
-  .auth-callback-submessage {
-    color: #a0aec0;
-  }
-
-  .spinner-ring {
-    border-color: #4a5568;
-    border-top-color: #667eea;
-  }
-}
+// The sign-in card stays light in all cases — the app is light-only, so it must
+// not follow the OS dark preference (that made the "Signing you in…" card render
+// as a dark panel on machines set to dark mode).
 
 /* ─────────────────────────────────────────────────────────────────────────────
    Success-state visuals only. Independent of the processing/error card chrome

--- a/frontend/src/pages/auth/AuthCallbackPage.scss
+++ b/frontend/src/pages/auth/AuthCallbackPage.scss
@@ -182,13 +182,3 @@
   }
 }
 
-/* Dark mode: lighter check tone for contrast on dark surfaces */
-@media (prefers-color-scheme: dark) {
-  .auth-callback-success-heading {
-    color: #f7fafc;
-  }
-  .auth-callback-success-status {
-    color: #a0aec0;
-  }
-}
-

--- a/frontend/src/pages/auth/AuthDiagnosticsPage.scss
+++ b/frontend/src/pages/auth/AuthDiagnosticsPage.scss
@@ -156,32 +156,5 @@
   }
 }
 
-// Dark mode support
-@media (prefers-color-scheme: dark) {
-  .auth-diagnostics-content {
-    background: rgba(26, 32, 44, 0.95);
-    color: #f7fafc;
-  }
-  
-  .diagnostics-header h1 {
-    color: #f7fafc;
-  }
-  
-  .diagnostics-section h2 {
-    color: #e2e8f0;
-  }
-  
-  .diagnostics-item .value {
-    color: #f7fafc;
-  }
-  
-  .diagnostics-item .label {
-    color: #a0aec0;
-  }
-  
-  .diagnostics-footer {
-    border-top-color: #4a5568;
-    color: #a0aec0;
-  }
-}
+// Dark mode removed — this page is light-only.
 


### PR DESCRIPTION
Header/sign-in polish and dark-mode cleanup (app is light-only).

- `.action-signin`: 9999px pill → 10px to match the other action/CTA buttons.
- OAuth "Signing you in…" card no longer follows the OS dark preference — it flashed as a dark panel on machines set to dark while the rest of the app stayed light.
- `.user-menu-container`: +5px top margin for signed-in header alignment.
- Remove dead dark-mode code: the `[data-theme="dark-lighter"]` + `:root:not(.light)` CSS, the two `@media (prefers-color-scheme: dark)` blocks, and the vestigial ThemeContext machinery (nothing consumed `useTheme`).

Verified the app renders light with the OS set to dark, sign-in button = 10px, and no console errors.