### PR TITLE
Redesign /scan/upload with Monaco editor workspace

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -17,6 +17,8 @@
         "@supabase/supabase-js": "^2.94.1",
         "axios": "^1.12.2",
         "framer-motion": "^12.34.0",
+        "jszip": "^3.10.1",
+        "monaco-editor": "^0.56.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-helmet-async": "^2.0.5",
@@ -3885,6 +3887,13 @@
         "@types/react": "^18.0.0"
       }
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@types/use-sync-external-store": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
@@ -4712,6 +4721,12 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "license": "MIT"
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -5129,6 +5144,15 @@
       "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/dompurify": {
+      "version": "3.4.8",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.8.tgz",
+      "integrity": "sha512-yb1cEmaOum7wFvOCSQxyfgVlv5D47Rc30iZWoMpbDIWTnJ6grDDQyu2KFJzB2k7u0pMuJcQ1zphH//fFnw2tjQ==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -6258,6 +6282,12 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "license": "MIT"
+    },
     "node_modules/immer": {
       "version": "10.2.0",
       "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
@@ -6311,6 +6341,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
     },
     "node_modules/internal-slot": {
       "version": "1.1.0",
@@ -6953,6 +6989,18 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -6975,6 +7023,15 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
       }
     },
     "node_modules/lightningcss": {
@@ -7330,6 +7387,18 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/marked": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-14.0.0.tgz",
+      "integrity": "sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -7403,6 +7472,16 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/monaco-editor": {
+      "version": "0.56.0",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.56.0.tgz",
+      "integrity": "sha512-sXboRm3BeBeLm938eaiyLMe0OxzfXIlZvbv4ir/jVgQy1zDhWjgmny0WoN45fuDKhCCQsYMbBJrv/A6jd8aCUg==",
+      "license": "MIT",
+      "dependencies": {
+        "dompurify": "3.4.8",
+        "marked": "14.0.0"
       }
     },
     "node_modules/motion-dom": {
@@ -7679,6 +7758,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -7922,6 +8007,12 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "license": "MIT"
     },
     "node_modules/prop-types": {
@@ -8174,6 +8265,27 @@
         }
       }
     },
+    "node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/readable-stream/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
+    },
     "node_modules/readdirp": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
@@ -8420,6 +8532,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
     "node_modules/safe-push-apply": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
@@ -8569,6 +8687,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+      "license": "MIT"
     },
     "node_modules/shallowequal": {
       "version": "1.1.0",
@@ -8786,6 +8910,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
       }
     },
     "node_modules/string.prototype.matchall": {
@@ -9384,6 +9517,12 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
     },
     "node_modules/victory-vendor": {
       "version": "37.3.6",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -42,6 +42,8 @@
     "@supabase/supabase-js": "^2.94.1",
     "axios": "^1.12.2",
     "framer-motion": "^12.34.0",
+    "jszip": "^3.10.1",
+    "monaco-editor": "^0.56.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-helmet-async": "^2.0.5",

--- a/frontend/src/pages/scanner/AuditCodeEditor.jsx
+++ b/frontend/src/pages/scanner/AuditCodeEditor.jsx
@@ -1,0 +1,197 @@
+import React, { useEffect, useRef } from "react";
+import * as monaco from "monaco-editor/editor/editor.api";
+import EditorWorker from "monaco-editor/editor/editor.worker?worker";
+import "monaco-editor/languages/definitions/javascript/register";
+import "monaco-editor/languages/definitions/css/register";
+import "monaco-editor/languages/definitions/html/register";
+import "monaco-editor/languages/features/json/register";
+
+const THEME_NAME = "extensionshield-audit-light";
+
+let themeDefined = false;
+
+if (typeof window !== "undefined") {
+  window.MonacoEnvironment = {
+    getWorker() {
+      return new EditorWorker();
+    },
+  };
+}
+
+function defineTheme() {
+  if (themeDefined) return;
+
+  monaco.editor.defineTheme(THEME_NAME, {
+    base: "vs",
+    inherit: true,
+    rules: [
+      { token: "comment", foreground: "15803d" },
+      { token: "keyword", foreground: "6d28d9" },
+      { token: "string", foreground: "dc2626" },
+      { token: "number", foreground: "b45309" },
+      { token: "type.identifier", foreground: "1d4ed8" },
+      { token: "identifier", foreground: "0f172a" },
+    ],
+    colors: {
+      "editor.background": "#fffdfa",
+      "editor.foreground": "#111827",
+      "editorLineNumber.foreground": "#6b7280",
+      "editorLineNumber.activeForeground": "#111827",
+      "editor.lineHighlightBackground": "#00000000",
+      "editor.selectionBackground": "#bbf7d044",
+      "editor.inactiveSelectionBackground": "#bbf7d026",
+      "editorCursor.foreground": "#15803d",
+      "editorWhitespace.foreground": "#d1d5db",
+      "editorGutter.background": "#fffdfa",
+    },
+  });
+
+  themeDefined = true;
+}
+
+export default function AuditCodeEditor({
+  value,
+  language = "javascript",
+  readOnly = true,
+  onChange,
+  firstDisplayLine = 1,
+  flaggedDisplayLine = null,
+  ariaLabel = "ExtensionShield code editor",
+}) {
+  const editorRef = useRef(null);
+  const containerRef = useRef(null);
+  const decorationsRef = useRef(null);
+  const modelRef = useRef(null);
+  const onChangeRef = useRef(onChange);
+  const isApplyingValueRef = useRef(false);
+  const initialValueRef = useRef(value || "");
+  const initialLanguageRef = useRef(language || "plaintext");
+  const initialReadOnlyRef = useRef(readOnly);
+  const initialFirstDisplayLineRef = useRef(firstDisplayLine);
+  const initialFlaggedDisplayLineRef = useRef(flaggedDisplayLine);
+  const initialAriaLabelRef = useRef(ariaLabel);
+
+  useEffect(() => {
+    onChangeRef.current = onChange;
+  }, [onChange]);
+
+  useEffect(() => {
+    if (!containerRef.current) return undefined;
+
+    defineTheme();
+
+    const initialReadOnly = initialReadOnlyRef.current;
+    const initialFirstDisplayLine = initialFirstDisplayLineRef.current;
+    const initialFlaggedDisplayLine = initialFlaggedDisplayLineRef.current;
+    const model = monaco.editor.createModel(initialValueRef.current, initialLanguageRef.current);
+    const editor = monaco.editor.create(containerRef.current, {
+      model,
+      theme: THEME_NAME,
+      readOnly: initialReadOnly,
+      domReadOnly: initialReadOnly,
+      automaticLayout: true,
+      minimap: { enabled: false },
+      folding: true,
+      glyphMargin: Boolean(initialFlaggedDisplayLine),
+      lineDecorationsWidth: 18,
+      lineNumbersMinChars: 3,
+      lineNumbers: (lineNumber) => String(initialFirstDisplayLine + lineNumber - 1),
+      renderLineHighlight: "none",
+      renderValidationDecorations: "off",
+      overviewRulerLanes: 0,
+      hideCursorInOverviewRuler: true,
+      scrollbar: {
+        alwaysConsumeMouseWheel: false,
+        horizontalScrollbarSize: 10,
+        verticalScrollbarSize: 10,
+      },
+      scrollBeyondLastLine: false,
+      roundedSelection: false,
+      contextmenu: !initialReadOnly,
+      selectionHighlight: false,
+      occurrencesHighlight: "off",
+      wordBasedSuggestions: "off",
+      quickSuggestions: false,
+      fontFamily: "'SFMono-Regular', 'Menlo', 'Monaco', 'Consolas', monospace",
+      fontSize: 13,
+      lineHeight: 24,
+      padding: { top: 16, bottom: 18 },
+      ariaLabel: initialAriaLabelRef.current,
+    });
+
+    const changeDisposable = editor.onDidChangeModelContent(() => {
+      if (isApplyingValueRef.current) return;
+      onChangeRef.current?.(editor.getValue());
+    });
+
+    editorRef.current = editor;
+    modelRef.current = model;
+
+    return () => {
+      decorationsRef.current?.clear();
+      changeDisposable.dispose();
+      editor.dispose();
+      model.dispose();
+      decorationsRef.current = null;
+      editorRef.current = null;
+      modelRef.current = null;
+    };
+  }, []);
+
+  useEffect(() => {
+    const editor = editorRef.current;
+    if (!editor) return;
+
+    const nextValue = value || "";
+    if (editor.getValue() === nextValue) return;
+
+    isApplyingValueRef.current = true;
+    editor.setValue(nextValue);
+    isApplyingValueRef.current = false;
+  }, [value]);
+
+  useEffect(() => {
+    if (!modelRef.current) return;
+    monaco.editor.setModelLanguage(modelRef.current, language || "plaintext");
+  }, [language]);
+
+  useEffect(() => {
+    editorRef.current?.updateOptions({
+      readOnly,
+      domReadOnly: readOnly,
+      contextmenu: !readOnly,
+    });
+  }, [readOnly]);
+
+  useEffect(() => {
+    editorRef.current?.updateOptions({
+      glyphMargin: Boolean(flaggedDisplayLine),
+      lineNumbers: (lineNumber) => String(firstDisplayLine + lineNumber - 1),
+    });
+  }, [firstDisplayLine, flaggedDisplayLine]);
+
+  useEffect(() => {
+    const editor = editorRef.current;
+    if (!editor) return;
+
+    decorationsRef.current?.clear();
+    decorationsRef.current = null;
+
+    if (!flaggedDisplayLine) return;
+
+    const modelLine = Math.max(1, flaggedDisplayLine - firstDisplayLine + 1);
+    decorationsRef.current = editor.createDecorationsCollection([
+      {
+        range: new monaco.Range(modelLine, 1, modelLine, 1),
+        options: {
+          isWholeLine: true,
+          className: "audit-code-editor__line--flagged",
+          glyphMarginClassName: "audit-code-editor__glyph--flagged",
+          linesDecorationsClassName: "audit-code-editor__line-decoration--flagged",
+        },
+      },
+    ]);
+  }, [firstDisplayLine, flaggedDisplayLine]);
+
+  return <div ref={containerRef} className="audit-code-editor" />;
+}

--- a/frontend/src/pages/scanner/ScanUploadPage.jsx
+++ b/frontend/src/pages/scanner/ScanUploadPage.jsx
@@ -1,80 +1,1183 @@
-import React from "react";
+import React, { Suspense, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Link } from "react-router-dom";
+import JSZip from "jszip";
+import {
+  AlertCircle,
+  ChevronRight,
+  Download,
+  File,
+  FileArchive,
+  FileCode2,
+  FileJson2,
+  FilePlus,
+  FileText,
+  Folder,
+  FolderOpen,
+  LockKeyhole,
+  MoreHorizontal,
+  RefreshCw,
+  Save,
+  ShieldCheck,
+  UploadCloud,
+  X,
+} from "lucide-react";
 import SEOHead from "../../components/SEOHead";
 import { useAuth } from "../../context/AuthContext";
-import PrivateBuildDropzone from "../../components/PrivateBuildDropzone";
-import PrivateBuildTrustPills from "../../components/PrivateBuildTrustPills";
 import "./ScanUploadPage.scss";
 
-const isDev = import.meta.env.DEV;
+const AuditCodeEditor = React.lazy(() => import("./AuditCodeEditor"));
+
+const ACCEPTED_PRIVATE_BUILD_TYPES = [".crx", ".zip"];
+const MAX_UPLOAD_SIZE_MB = 25;
+const MAX_UPLOAD_SIZE_BYTES = MAX_UPLOAD_SIZE_MB * 1024 * 1024;
+const MAX_TEXT_PREVIEW_BYTES = 2 * 1024 * 1024;
+
+const SAMPLE_AUDIT_CODE = `// Listen for messages from content scripts
+chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+  if (message.type === 'FETCH_DATA') {
+    fetch(message.url, {
+      method: 'GET',
+      headers: {
+        'Authorization': message.token,
+        'Content-Type': 'application/json'
+      }
+    })
+    .then(res => res.json())
+    .then(data => sendResponse({ success: true, data }))
+    .catch(err => sendResponse({ success: false, error: err.message }));
+    return true;
+  }
+});
+
+function storeToken(token) {
+  chrome.storage.local.set({ authToken: token }, () => {
+    console.log('Token stored');
+  });
+}`;
+
+const TEXT_FILE_EXTENSIONS = new Set([
+  "bat",
+  "cjs",
+  "conf",
+  "css",
+  "csv",
+  "html",
+  "htm",
+  "ini",
+  "js",
+  "json",
+  "jsx",
+  "less",
+  "log",
+  "mjs",
+  "md",
+  "scss",
+  "svg",
+  "ts",
+  "tsx",
+  "txt",
+  "vue",
+  "xml",
+  "yaml",
+  "yml",
+]);
+
+const TEXT_FILE_NAMES = new Set([
+  "changelog",
+  "license",
+  "notice",
+  "readme",
+]);
+
+const LANGUAGE_BY_EXTENSION = {
+  cjs: "javascript",
+  css: "css",
+  html: "html",
+  htm: "html",
+  js: "javascript",
+  json: "json",
+  jsx: "javascript",
+  less: "less",
+  mjs: "javascript",
+  md: "markdown",
+  scss: "scss",
+  svg: "xml",
+  ts: "typescript",
+  tsx: "typescript",
+  vue: "html",
+  xml: "xml",
+  yaml: "yaml",
+  yml: "yaml",
+};
+
+function formatFileSize(bytes) {
+  if (!Number.isFinite(bytes) || bytes <= 0) return "0 KB";
+  const mb = bytes / (1024 * 1024);
+  if (mb >= 1) return `${mb.toFixed(mb >= 10 ? 0 : 1)} MB`;
+  return `${Math.max(1, Math.round(bytes / 1024))} KB`;
+}
+
+function getFileName(path) {
+  return path.split("/").filter(Boolean).pop() || path;
+}
+
+function getFileExtension(path) {
+  const fileName = getFileName(path).toLowerCase();
+  const dotIndex = fileName.lastIndexOf(".");
+  if (dotIndex <= 0) return "";
+  return fileName.slice(dotIndex + 1);
+}
+
+function getFileLanguage(path) {
+  return LANGUAGE_BY_EXTENSION[getFileExtension(path)] || "plaintext";
+}
+
+function isProbablyTextFile(path, size) {
+  if (size > MAX_TEXT_PREVIEW_BYTES) return false;
+  const name = getFileName(path).toLowerCase();
+  const extension = getFileExtension(path);
+  return TEXT_FILE_EXTENSIONS.has(extension) || TEXT_FILE_NAMES.has(name);
+}
+
+function isSupportedPrivateBuild(file) {
+  if (!file?.name) return false;
+  const extension = `.${getFileExtension(file.name)}`;
+  return ACCEPTED_PRIVATE_BUILD_TYPES.includes(extension) && file.size <= MAX_UPLOAD_SIZE_BYTES;
+}
+
+function normalizeZipPath(path) {
+  return String(path || "")
+    .replace(/\\/g, "/")
+    .replace(/^\/+/, "")
+    .replace(/\/+/g, "/");
+}
+
+function readUint32LE(bytes, offset) {
+  return (
+    bytes[offset]
+    | (bytes[offset + 1] << 8)
+    | (bytes[offset + 2] << 16)
+    | (bytes[offset + 3] << 24)
+  ) >>> 0;
+}
+
+function findZipOffset(bytes) {
+  for (let index = 0; index < bytes.length - 3; index += 1) {
+    if (
+      bytes[index] === 0x50
+      && bytes[index + 1] === 0x4b
+      && bytes[index + 2] === 0x03
+      && bytes[index + 3] === 0x04
+    ) {
+      return index;
+    }
+  }
+  return -1;
+}
+
+function sliceArrayBuffer(bytes, start) {
+  return bytes.buffer.slice(bytes.byteOffset + start, bytes.byteOffset + bytes.byteLength);
+}
+
+function extractZipPayload(arrayBuffer, fileName) {
+  const bytes = new Uint8Array(arrayBuffer);
+  const isCrx = bytes[0] === 0x43 && bytes[1] === 0x72 && bytes[2] === 0x32 && bytes[3] === 0x34;
+
+  if (!isCrx) {
+    return {
+      archiveKind: "ZIP",
+      buffer: arrayBuffer,
+    };
+  }
+
+  const version = readUint32LE(bytes, 4);
+  let zipOffset = -1;
+
+  if (version === 2 && bytes.length >= 16) {
+    const publicKeyLength = readUint32LE(bytes, 8);
+    const signatureLength = readUint32LE(bytes, 12);
+    zipOffset = 16 + publicKeyLength + signatureLength;
+  } else if (version === 3 && bytes.length >= 12) {
+    const headerLength = readUint32LE(bytes, 8);
+    zipOffset = 12 + headerLength;
+  }
+
+  if (zipOffset < 0 || zipOffset >= bytes.length) {
+    zipOffset = findZipOffset(bytes);
+  }
+
+  if (zipOffset < 0 || zipOffset >= bytes.length) {
+    throw new Error(`${fileName} is a CRX file, but its embedded ZIP payload could not be located.`);
+  }
+
+  return {
+    archiveKind: `CRX v${version || "unknown"}`,
+    buffer: sliceArrayBuffer(bytes, zipOffset),
+  };
+}
+
+function sortFiles(files) {
+  return [...files].sort((left, right) => left.path.localeCompare(right.path, undefined, { sensitivity: "base" }));
+}
+
+function buildFileTree(files) {
+  const root = { type: "folder", name: "extension", path: "", children: [] };
+  const folderMap = new Map([["", root]]);
+
+  files.forEach((file) => {
+    const parts = file.path.split("/").filter(Boolean);
+    let parentPath = "";
+    let parentNode = root;
+
+    parts.slice(0, -1).forEach((part) => {
+      const folderPath = parentPath ? `${parentPath}/${part}` : part;
+      let folderNode = folderMap.get(folderPath);
+
+      if (!folderNode) {
+        folderNode = { type: "folder", name: part, path: folderPath, children: [] };
+        folderMap.set(folderPath, folderNode);
+        parentNode.children.push(folderNode);
+      }
+
+      parentPath = folderPath;
+      parentNode = folderNode;
+    });
+
+    parentNode.children.push({
+      type: "file",
+      name: getFileName(file.path),
+      path: file.path,
+      file,
+    });
+  });
+
+  const sortNode = (node) => {
+    node.children.sort((left, right) => {
+      if (left.type !== right.type) return left.type === "folder" ? -1 : 1;
+      return left.name.localeCompare(right.name, undefined, { sensitivity: "base" });
+    });
+    node.children.filter((child) => child.type === "folder").forEach(sortNode);
+  };
+
+  sortNode(root);
+  return root;
+}
+
+function collectFolderPaths(node, paths = {}) {
+  node.children.forEach((child) => {
+    if (child.type === "folder") {
+      paths[child.path] = true;
+      collectFolderPaths(child, paths);
+    }
+  });
+  return paths;
+}
+
+function getArchiveFiles(zip) {
+  return sortFiles(
+    Object.values(zip.files)
+      .filter((entry) => !entry.dir)
+      .map((entry) => {
+        const path = normalizeZipPath(entry.name);
+        const extension = getFileExtension(path);
+        const size = entry._data?.uncompressedSize ?? entry._data?.compressedSize ?? 0;
+
+        return {
+          path,
+          zipPath: entry.name,
+          extension,
+          size,
+          isText: isProbablyTextFile(path, size),
+          language: getFileLanguage(path),
+          source: "archive",
+        };
+      })
+      .filter((file) => file.path && !file.path.startsWith("__MACOSX/"))
+  );
+}
+
+function pickInitialFile(files) {
+  return (
+    files.find((file) => file.path.toLowerCase().endsWith("manifest.json"))
+    || files.find((file) => getFileName(file.path).toLowerCase() === "service_worker.js")
+    || files.find((file) => file.isText)
+    || files[0]
+    || null
+  );
+}
+
+function buildPreviewWorkspace() {
+  const contents = {
+    "manifest.json": JSON.stringify({
+      manifest_version: 3,
+      name: "Coupon Helper",
+      version: "2.1.0",
+      description: "Find and apply coupon codes.",
+      permissions: ["storage", "activeTab"],
+      host_permissions: ["*://*/*"],
+      background: { service_worker: "background/service_worker.js" },
+      content_scripts: [{ matches: ["*://*/*"], js: ["content/content_script.js"] }],
+      action: { default_popup: "popup/popup.html" },
+    }, null, 2),
+    "background/service_worker.js": SAMPLE_AUDIT_CODE,
+    "content/content_script.js": "// Content script\nconst observer = new MutationObserver(() => {});\nobserver.observe(document.body, { childList: true, subtree: true });\n",
+    "popup/popup.html": "<!DOCTYPE html>\n<html>\n<head><link rel=\"stylesheet\" href=\"styles.css\"></head>\n<body><div id=\"app\"></div><script src=\"popup.js\"></script></body>\n</html>\n",
+    "popup/popup.js": "document.addEventListener('DOMContentLoaded', () => {\n  console.log('popup loaded');\n});\n",
+    "popup/styles.css": "#app { width: 280px; padding: 16px; font-family: system-ui, sans-serif; }\nh1 { font-size: 15px; margin: 0; }\n",
+  };
+  const files = sortFiles(
+    Object.entries(contents).map(([path, text]) => ({
+      path,
+      zipPath: path,
+      extension: getFileExtension(path),
+      size: text.length,
+      isText: true,
+      language: getFileLanguage(path),
+      source: "archive",
+    }))
+  );
+  return {
+    workspace: {
+      id: "preview",
+      fileName: "sample-extension.zip",
+      fileSize: files.reduce((sum, f) => sum + f.size, 0),
+      archiveKind: "ZIP",
+      files,
+      tree: buildFileTree(files),
+      textFileCount: files.length,
+      binaryFileCount: 0,
+    },
+    initialContents: contents,
+  };
+}
+
+async function parsePrivateBuildFile(file) {
+  const rawBuffer = await file.arrayBuffer();
+  const { archiveKind, buffer } = extractZipPayload(rawBuffer, file.name);
+  const zip = await JSZip.loadAsync(buffer);
+  const files = getArchiveFiles(zip);
+
+  if (!files.length) {
+    throw new Error("No files were found in this archive.");
+  }
+
+  const tree = buildFileTree(files);
+
+  return {
+    zip,
+    workspace: {
+      id: `${file.name}-${file.size}-${file.lastModified}`,
+      fileName: file.name,
+      fileSize: file.size,
+      archiveKind,
+      files,
+      tree,
+      textFileCount: files.filter((entry) => entry.isText).length,
+      binaryFileCount: files.filter((entry) => !entry.isText).length,
+    },
+  };
+}
+
+function createVirtualTextFile(path) {
+  return {
+    path,
+    zipPath: path,
+    extension: getFileExtension(path),
+    size: 0,
+    isText: true,
+    language: getFileLanguage(path),
+    source: "created",
+  };
+}
+
+function getFileTypeLabel(file) {
+  if (!file) return "No file selected";
+  if (!file.isText) return "Binary";
+  if (file.source === "created") return "New file";
+  return file.extension ? file.extension.toUpperCase() : "Text";
+}
+
+function FileTypeIcon({ file }) {
+  if (!file) return <File size={15} strokeWidth={1.8} />;
+  if (file.extension === "json") return <FileJson2 size={15} strokeWidth={1.8} />;
+  if (["js", "jsx", "ts", "tsx", "mjs", "cjs"].includes(file.extension)) {
+    return <FileCode2 size={15} strokeWidth={1.8} />;
+  }
+  return <FileText size={15} strokeWidth={1.8} />;
+}
+
+function ArchiveTreeNode({
+  node,
+  depth,
+  expandedFolders,
+  selectedPath,
+  dirtyFiles,
+  onToggleFolder,
+  onSelectFile,
+}) {
+  if (node.type === "folder") {
+    const isExpanded = expandedFolders[node.path] !== false;
+
+    return (
+      <>
+        <button
+          type="button"
+          className="archive-tree-row archive-tree-row--folder"
+          style={{ "--tree-depth": depth }}
+          aria-expanded={isExpanded}
+          onClick={() => onToggleFolder(node.path)}
+          title={node.path || "extension"}
+        >
+          <ChevronRight
+            size={14}
+            strokeWidth={1.8}
+            className={`archive-tree-row__chevron ${isExpanded ? "archive-tree-row__chevron--open" : ""}`}
+          />
+          {isExpanded ? <FolderOpen size={15} strokeWidth={1.8} /> : <Folder size={15} strokeWidth={1.8} />}
+          <span>{node.name}</span>
+        </button>
+        {isExpanded && node.children.map((child) => (
+          <ArchiveTreeNode
+            key={child.path}
+            node={child}
+            depth={depth + 1}
+            expandedFolders={expandedFolders}
+            selectedPath={selectedPath}
+            dirtyFiles={dirtyFiles}
+            onToggleFolder={onToggleFolder}
+            onSelectFile={onSelectFile}
+          />
+        ))}
+      </>
+    );
+  }
+
+  const isActive = node.path === selectedPath;
+  const isDirty = Boolean(dirtyFiles[node.path]);
+
+  return (
+    <button
+      type="button"
+      className={`archive-tree-row archive-tree-row--file ${isActive ? "archive-tree-row--active" : ""}`}
+      style={{ "--tree-depth": depth }}
+      onClick={() => onSelectFile(node.path)}
+      title={node.path}
+    >
+      <span className="archive-tree-row__spacer" aria-hidden="true" />
+      <FileTypeIcon file={node.file} />
+      <span>{node.name}</span>
+      {isDirty && <span className="archive-tree-row__dirty" aria-label="Edited file" />}
+    </button>
+  );
+}
+
+function ArchiveExplorer({
+  workspace,
+  expandedFolders,
+  selectedPath,
+  dirtyFiles,
+  onToggleFolder,
+  onSelectFile,
+  onCreateFile,
+}) {
+  return (
+    <aside className="archive-explorer" aria-label="Parsed extension files">
+      <div className="archive-explorer__header">
+        <span>Files</span>
+        <button type="button" className="archive-icon-button" onClick={onCreateFile}>
+          <FilePlus size={15} strokeWidth={1.9} />
+          <span>New</span>
+        </button>
+      </div>
+      <div className="archive-explorer__tree">
+        {workspace.tree.children.map((node) => (
+          <ArchiveTreeNode
+            key={node.path}
+            node={node}
+            depth={0}
+            expandedFolders={expandedFolders}
+            selectedPath={selectedPath}
+            dirtyFiles={dirtyFiles}
+            onToggleFolder={onToggleFolder}
+            onSelectFile={onSelectFile}
+          />
+        ))}
+      </div>
+      <div className="archive-explorer__footer">
+        <span>{workspace.files.length} files</span>
+        <span>{formatFileSize(workspace.fileSize)}</span>
+      </div>
+    </aside>
+  );
+}
+
+function SignedOutCodePreview() {
+  const tabs = ["Overview", "Findings", "Code", "Changes", "Permissions", "Network", "Reputation"];
+
+  return (
+    <section className="scan-report-preview" aria-label="Private extension audit preview">
+      <div className="scan-report-preview__shell">
+        <div className="scan-report-preview__tabs">
+          <nav aria-label="Audit preview sections">
+            {tabs.map((tab) => (
+              <button
+                key={tab}
+                type="button"
+                className={`scan-report-preview__tab ${tab === "Overview" ? "scan-report-preview__tab--active" : ""}`}
+              >
+                <span>{tab}</span>
+                {tab === "Findings" && <strong>7</strong>}
+              </button>
+            ))}
+          </nav>
+          <div className="scan-report-preview__actions">
+            <button type="button" className="scan-report-preview__action">
+              <Download size={16} strokeWidth={2} />
+              <span>Export report</span>
+            </button>
+            <button type="button" className="scan-report-preview__icon-action" aria-label="More report actions">
+              <MoreHorizontal size={18} strokeWidth={2.2} />
+            </button>
+          </div>
+        </div>
+
+        <div className="scan-report-preview__body">
+          <aside className="scan-report-preview__files" aria-label="Example extension files">
+            <div className="scan-report-preview__files-header">
+              <span>Files</span>
+              <RefreshCw size={16} strokeWidth={1.8} />
+            </div>
+            <div className="scan-report-preview__tree">
+              <button type="button" className="scan-preview-file-row scan-preview-file-row--folder" style={{ "--preview-depth": 0 }}>
+                <ChevronRight size={14} strokeWidth={1.9} className="scan-preview-file-row__chevron scan-preview-file-row__chevron--open" />
+                <span>extension</span>
+              </button>
+              <button type="button" className="scan-preview-file-row scan-preview-file-row--folder" style={{ "--preview-depth": 1 }}>
+                <ChevronRight size={14} strokeWidth={1.9} className="scan-preview-file-row__chevron scan-preview-file-row__chevron--open" />
+                <Folder size={16} strokeWidth={1.8} />
+                <span>background</span>
+              </button>
+              <button type="button" className="scan-preview-file-row scan-preview-file-row--file scan-preview-file-row--active" style={{ "--preview-depth": 2 }}>
+                <span className="scan-preview-file-row__type scan-preview-file-row__type--js">JS</span>
+                <span>service_worker.js</span>
+              </button>
+              <button type="button" className="scan-preview-file-row scan-preview-file-row--file" style={{ "--preview-depth": 2 }}>
+                <span className="scan-preview-file-row__type scan-preview-file-row__type--js">JS</span>
+                <span>api.js</span>
+              </button>
+              <button type="button" className="scan-preview-file-row scan-preview-file-row--file" style={{ "--preview-depth": 2 }}>
+                <span className="scan-preview-file-row__type scan-preview-file-row__type--js">JS</span>
+                <span>storage.js</span>
+              </button>
+              <button type="button" className="scan-preview-file-row scan-preview-file-row--file" style={{ "--preview-depth": 2 }}>
+                <span className="scan-preview-file-row__type scan-preview-file-row__type--js">JS</span>
+                <span>utils.js</span>
+              </button>
+              <button type="button" className="scan-preview-file-row scan-preview-file-row--folder" style={{ "--preview-depth": 1 }}>
+                <ChevronRight size={14} strokeWidth={1.9} className="scan-preview-file-row__chevron scan-preview-file-row__chevron--open" />
+                <Folder size={16} strokeWidth={1.8} />
+                <span>content</span>
+              </button>
+              <button type="button" className="scan-preview-file-row scan-preview-file-row--file" style={{ "--preview-depth": 2 }}>
+                <span className="scan-preview-file-row__type scan-preview-file-row__type--js">JS</span>
+                <span>content_script.js</span>
+              </button>
+              <button type="button" className="scan-preview-file-row scan-preview-file-row--file" style={{ "--preview-depth": 2 }}>
+                <span className="scan-preview-file-row__type scan-preview-file-row__type--js">JS</span>
+                <span>inject.js</span>
+              </button>
+              <button type="button" className="scan-preview-file-row scan-preview-file-row--folder" style={{ "--preview-depth": 1 }}>
+                <ChevronRight size={14} strokeWidth={1.9} className="scan-preview-file-row__chevron scan-preview-file-row__chevron--open" />
+                <Folder size={16} strokeWidth={1.8} />
+                <span>popup</span>
+              </button>
+              <button type="button" className="scan-preview-file-row scan-preview-file-row--file" style={{ "--preview-depth": 2 }}>
+                <span className="scan-preview-file-row__type scan-preview-file-row__type--html">&lt;&gt;</span>
+                <span>popup.html</span>
+              </button>
+              <button type="button" className="scan-preview-file-row scan-preview-file-row--file" style={{ "--preview-depth": 2 }}>
+                <span className="scan-preview-file-row__type scan-preview-file-row__type--js">JS</span>
+                <span>popup.js</span>
+              </button>
+              <button type="button" className="scan-preview-file-row scan-preview-file-row--file" style={{ "--preview-depth": 2 }}>
+                <span className="scan-preview-file-row__type scan-preview-file-row__type--css">#</span>
+                <span>styles.css</span>
+              </button>
+              <button type="button" className="scan-preview-file-row scan-preview-file-row--folder" style={{ "--preview-depth": 1 }}>
+                <ChevronRight size={14} strokeWidth={1.9} className="scan-preview-file-row__chevron scan-preview-file-row__chevron--open" />
+                <Folder size={16} strokeWidth={1.8} />
+                <span>options</span>
+              </button>
+              <button type="button" className="scan-preview-file-row scan-preview-file-row--file" style={{ "--preview-depth": 2 }}>
+                <span className="scan-preview-file-row__type scan-preview-file-row__type--html">&lt;&gt;</span>
+                <span>options.html</span>
+              </button>
+              <button type="button" className="scan-preview-file-row scan-preview-file-row--file" style={{ "--preview-depth": 2 }}>
+                <span className="scan-preview-file-row__type scan-preview-file-row__type--json">{"{}"}</span>
+                <span>manifest.json</span>
+              </button>
+              <button type="button" className="scan-preview-file-row scan-preview-file-row--folder" style={{ "--preview-depth": 0 }}>
+                <ChevronRight size={14} strokeWidth={1.9} />
+                <Folder size={16} strokeWidth={1.8} />
+                <span>Locales</span>
+              </button>
+            </div>
+            <div className="scan-report-preview__files-footer">
+              <span>512 files</span>
+              <span>2.4 MB</span>
+            </div>
+          </aside>
+
+          <main className="scan-report-preview__editor" aria-label="Example code editor">
+            <div className="scan-report-preview__editor-header">
+              <div className="scan-report-preview__breadcrumbs">
+                <span>extension</span>
+                <ChevronRight size={14} strokeWidth={1.8} />
+                <span>background</span>
+                <ChevronRight size={14} strokeWidth={1.8} />
+                <span className="scan-report-preview__crumb--type">JS</span>
+                <strong>service_worker.js</strong>
+              </div>
+              <span className="scan-report-preview__readonly">Read-only</span>
+            </div>
+            <Suspense fallback={<div className="audit-code-editor audit-code-editor--loading" aria-label="Loading code preview" />}>
+              <AuditCodeEditor
+                value={SAMPLE_AUDIT_CODE}
+                language="javascript"
+                readOnly
+                firstDisplayLine={32}
+                flaggedDisplayLine={44}
+                ariaLabel="Read-only private build code preview"
+              />
+            </Suspense>
+          </main>
+
+          <aside className="scan-report-preview__details" aria-label="Example audit finding details">
+            <article className="scan-report-preview__detail-card">
+              <header className="scan-report-preview__detail-header">
+                <span>Finding details</span>
+                <strong>High</strong>
+              </header>
+              <div className="scan-report-preview__finding-title">
+                <span aria-hidden="true" />
+                <div>
+                  <h2>Unvalidated fetch URL</h2>
+                  <p>service_worker.js:43</p>
+                </div>
+              </div>
+              <p className="scan-report-preview__finding-copy">
+                The extension fetches data from a URL provided in a runtime message without validating or restricting the destination.
+                This can allow attackers to exfiltrate sensitive data or interact with arbitrary endpoints.
+              </p>
+              <span className="scan-report-preview__cwe">CWE-918</span>
+              <div className="scan-report-preview__recommendation">
+                <span>Recommendation</span>
+                <p>Validate the URL against an allowlist before making the request.</p>
+              </div>
+            </article>
+
+            <article className="scan-report-preview__detail-card scan-report-preview__detail-card--version">
+              <h2>Version comparison</h2>
+              <div className="scan-report-preview__version-row">
+                <span>Current</span>
+                <strong className="scan-report-preview__version-pill scan-report-preview__version-pill--current">172.0</strong>
+                <p>Uploaded just now</p>
+              </div>
+              <div className="scan-report-preview__version-row">
+                <span>Previous</span>
+                <strong className="scan-report-preview__version-pill scan-report-preview__version-pill--previous">171.3</strong>
+                <p>5 days ago</p>
+              </div>
+              <button type="button" className="scan-report-preview__compare">Compare versions</button>
+            </article>
+          </aside>
+        </div>
+      </div>
+    </section>
+  );
+}
 
 export default function ScanUploadPage() {
   const { isAuthenticated, openSignInModal } = useAuth();
+  const fileInputRef = useRef(null);
+  const zipRef = useRef(null);
+  const [workspace, setWorkspace] = useState(null);
+  const [selectedPath, setSelectedPath] = useState("");
+  const [expandedFolders, setExpandedFolders] = useState({});
+  const [fileContents, setFileContents] = useState({});
+  const [dirtyFiles, setDirtyFiles] = useState({});
+  const [uploadError, setUploadError] = useState("");
+  const [selectedFileError, setSelectedFileError] = useState("");
+  const [isDragActive, setIsDragActive] = useState(false);
+  const [isParsing, setIsParsing] = useState(false);
+  const [isLoadingSelectedFile, setIsLoadingSelectedFile] = useState(false);
+  const [savedFiles, setSavedFiles] = useState({});
+  const [isExporting, setIsExporting] = useState(false);
 
-  const canUpload = isDev || isAuthenticated;
-  const showSignInOverlay = !isDev && !isAuthenticated;
+  const isPreviewMode = !isAuthenticated && new URLSearchParams(window.location.search).get("preview") === "uploaded";
+
+  const selectedFile = useMemo(
+    () => workspace?.files.find((file) => file.path === selectedPath) || null,
+    [selectedPath, workspace]
+  );
+
+  const selectedFileContent = selectedPath ? fileContents[selectedPath] || "" : "";
+  const editedFileCount = Object.keys(dirtyFiles).length;
+  const savedFileCount = Object.keys(savedFiles).length;
+  const hasModifiedFiles = editedFileCount > 0 || savedFileCount > 0;
+
+  const clearWorkspace = useCallback(() => {
+    zipRef.current = null;
+    setWorkspace(null);
+    setSelectedPath("");
+    setExpandedFolders({});
+    setFileContents({});
+    setDirtyFiles({});
+    setSavedFiles({});
+    setUploadError("");
+    setSelectedFileError("");
+  }, []);
+
+  const applyParsedWorkspace = useCallback(({ zip, workspace: parsedWorkspace }) => {
+    const initialFile = pickInitialFile(parsedWorkspace.files);
+    zipRef.current = zip;
+    setWorkspace(parsedWorkspace);
+    setExpandedFolders(collectFolderPaths(parsedWorkspace.tree));
+    setFileContents({});
+    setDirtyFiles({});
+    setSavedFiles({});
+    setSelectedFileError("");
+    setSelectedPath(initialFile?.path || "");
+  }, []);
+
+  const applyFile = useCallback(
+    async (file) => {
+      if (!isAuthenticated) {
+        openSignInModal();
+        return;
+      }
+
+      if (!file) return;
+
+      if (!isSupportedPrivateBuild(file)) {
+        setUploadError(`Upload a CRX or ZIP file up to ${MAX_UPLOAD_SIZE_MB} MB.`);
+        return;
+      }
+
+      setIsParsing(true);
+      setUploadError("");
+      setSelectedFileError("");
+
+      try {
+        const parsedArchive = await parsePrivateBuildFile(file);
+        applyParsedWorkspace(parsedArchive);
+      } catch (error) {
+        zipRef.current = null;
+        setWorkspace(null);
+        setSelectedPath("");
+        setFileContents({});
+        setDirtyFiles({});
+        setExpandedFolders({});
+        setUploadError(error instanceof Error ? error.message : "Could not parse this archive.");
+      } finally {
+        setIsParsing(false);
+      }
+    },
+    [applyParsedWorkspace, isAuthenticated, openSignInModal]
+  );
+
+  const handleUploadClick = useCallback(() => {
+    if (!isAuthenticated) {
+      openSignInModal();
+      return;
+    }
+    fileInputRef.current?.click();
+  }, [isAuthenticated, openSignInModal]);
+
+  const handleFileChange = useCallback(
+    (event) => {
+      const file = event.target?.files?.[0];
+      void applyFile(file);
+      if (event.target) event.target.value = "";
+    },
+    [applyFile]
+  );
+
+  const handleDragEnter = useCallback((event) => {
+    event.preventDefault();
+    setIsDragActive(true);
+  }, []);
+
+  const handleDragOver = useCallback((event) => {
+    event.preventDefault();
+  }, []);
+
+  const handleDragLeave = useCallback((event) => {
+    event.preventDefault();
+    if (!event.currentTarget.contains(event.relatedTarget)) {
+      setIsDragActive(false);
+    }
+  }, []);
+
+  const handleDrop = useCallback(
+    (event) => {
+      event.preventDefault();
+      setIsDragActive(false);
+      void applyFile(event.dataTransfer?.files?.[0]);
+    },
+    [applyFile]
+  );
+
+  const toggleFolder = useCallback((path) => {
+    setExpandedFolders((current) => ({
+      ...current,
+      [path]: current[path] === false,
+    }));
+  }, []);
+
+  const handleEditorChange = useCallback(
+    (nextValue) => {
+      if (!selectedPath) return;
+
+      setFileContents((current) => (
+        current[selectedPath] === nextValue
+          ? current
+          : { ...current, [selectedPath]: nextValue }
+      ));
+      setDirtyFiles((current) => (
+        current[selectedPath]
+          ? current
+          : { ...current, [selectedPath]: true }
+      ));
+    },
+    [selectedPath]
+  );
+
+  const handleSaveFile = useCallback(() => {
+    if (!selectedPath || !dirtyFiles[selectedPath]) return;
+    setDirtyFiles((current) => {
+      const next = { ...current };
+      delete next[selectedPath];
+      return next;
+    });
+    setSavedFiles((current) => ({ ...current, [selectedPath]: true }));
+  }, [selectedPath, dirtyFiles]);
+
+  const handleDownloadZip = useCallback(async () => {
+    if (!workspace) return;
+    setIsExporting(true);
+    try {
+      const newZip = new JSZip();
+      for (const file of workspace.files) {
+        if (fileContents[file.path] !== undefined) {
+          newZip.file(file.zipPath, fileContents[file.path]);
+        } else if (zipRef.current) {
+          const entry = zipRef.current.file(file.zipPath);
+          if (entry) {
+            const content = await entry.async("uint8array");
+            newZip.file(file.zipPath, content);
+          }
+        }
+      }
+      const blob = await newZip.generateAsync({ type: "blob" });
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement("a");
+      link.href = url;
+      link.download = workspace.fileName.replace(/\.(crx|zip)$/i, "-edited.zip");
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+      URL.revokeObjectURL(url);
+    } finally {
+      setIsExporting(false);
+    }
+  }, [workspace, fileContents]);
+
+  const createNewFile = useCallback(() => {
+    if (!workspace) return;
+
+    const existingPaths = new Set(workspace.files.map((file) => file.path));
+    let candidate = "new_file.js";
+    let index = 2;
+    while (existingPaths.has(candidate)) {
+      candidate = `new_file_${index}.js`;
+      index += 1;
+    }
+
+    const newFile = createVirtualTextFile(candidate);
+
+    setWorkspace((current) => {
+      if (!current) return current;
+      const files = sortFiles([...current.files, newFile]);
+      const tree = buildFileTree(files);
+      return {
+        ...current,
+        files,
+        tree,
+        textFileCount: files.filter((file) => file.isText).length,
+        binaryFileCount: files.filter((file) => !file.isText).length,
+      };
+    });
+    setFileContents((current) => ({ ...current, [candidate]: "" }));
+    setDirtyFiles((current) => ({ ...current, [candidate]: true }));
+    setExpandedFolders((current) => ({ ...current, ...collectFolderPaths(buildFileTree([newFile])) }));
+    setSelectedPath(candidate);
+  }, [workspace]);
+
+  useEffect(() => {
+    if (!selectedFile) {
+      setSelectedFileError("");
+      setIsLoadingSelectedFile(false);
+      return undefined;
+    }
+
+    if (!selectedFile.isText) {
+      setSelectedFileError("");
+      setIsLoadingSelectedFile(false);
+      return undefined;
+    }
+
+    if (Object.prototype.hasOwnProperty.call(fileContents, selectedFile.path)) {
+      setSelectedFileError("");
+      setIsLoadingSelectedFile(false);
+      return undefined;
+    }
+
+    const entry = zipRef.current?.file(selectedFile.zipPath);
+    let cancelled = false;
+    setIsLoadingSelectedFile(true);
+    setSelectedFileError("");
+
+    if (!entry) {
+      setFileContents((current) => ({ ...current, [selectedFile.path]: "" }));
+      setIsLoadingSelectedFile(false);
+      return undefined;
+    }
+
+    entry.async("string")
+      .then((content) => {
+        if (cancelled) return;
+        setFileContents((current) => ({ ...current, [selectedFile.path]: content }));
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setSelectedFileError("This file could not be decoded as text.");
+      })
+      .finally(() => {
+        if (!cancelled) setIsLoadingSelectedFile(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [fileContents, selectedFile]);
+
+  useEffect(() => {
+    if (!isPreviewMode || workspace) return;
+    const { workspace: pw, initialContents } = buildPreviewWorkspace();
+    setWorkspace(pw);
+    setExpandedFolders(collectFolderPaths(pw.tree));
+    setFileContents(initialContents);
+    setSelectedPath(pickInitialFile(pw.files)?.path || "");
+  }, [isPreviewMode, workspace]);
+
+  const heroTitle = isAuthenticated
+    ? "Upload a private CRX or ZIP build"
+    : "Sign in to upload a private CRX or ZIP build";
+  const heroCopy = isAuthenticated
+    ? "Choose a build to inspect its files locally before scanning."
+    : "We never store your file. Scans are private and results are only visible to your account.";
+  const primaryButtonText = isParsing
+    ? "Parsing build"
+    : isAuthenticated
+      ? workspace
+        ? "Replace build"
+        : "Choose CRX or ZIP"
+      : "Sign in to upload";
 
   return (
     <div className="scan-upload-page">
       <SEOHead
-        title="Scan a CRX File — Pre-release Chrome Extension Security Audit (Pro) | ExtensionShield"
-        description="Scan a CRX or ZIP file for a pre-release Chrome extension security audit: SAST, permissions, network indicators, and policy checks — with evidence for every finding. Private by default."
+        title="Private Extension Audit - Pre-release Chrome Extension Security Review | ExtensionShield"
+        description="Upload a CRX or ZIP for a pre-release Chrome extension security audit: static analysis, permissions review, policy checks, and evidence-backed findings. Private by default."
         pathname="/scan/upload"
       />
-      <section className="scan-upload-hero" aria-label="Private build upload">
-        <div className="scan-upload-content">
-          {/* 3-step indicator: 1 Upload → 2 Scan → 3 Report */}
-          <nav className="scan-upload-steps" aria-label="Scan progress">
-            <div className="scan-upload-steps__step scan-upload-steps__step--active">
-              <span className="scan-upload-steps__circle" aria-hidden>1</span>
-              <span className="scan-upload-steps__label">Upload</span>
-            </div>
-            <span className="scan-upload-steps__connector" aria-hidden />
-            <div className="scan-upload-steps__step">
-              <span className="scan-upload-steps__circle" aria-hidden>2</span>
-              <span className="scan-upload-steps__label">Scan</span>
-            </div>
-            <span className="scan-upload-steps__connector" aria-hidden />
-            <div className="scan-upload-steps__step">
-              <span className="scan-upload-steps__circle" aria-hidden>3</span>
-              <span className="scan-upload-steps__label">Report</span>
-            </div>
-          </nav>
 
-          <p className="scan-upload-kicker">Pro • Private Build Audit</p>
-          <h1 className="scan-upload-headline">Pre-release Chrome Extension Audit</h1>
-          <p className="scan-upload-subhead">
-            Find vulnerabilities, risky permissions, policy violations, and suspicious network behavior—each with evidence + fix guidance.
-          </p>
-
-          <div className="scan-upload-dropzone-wrap">
-            {showSignInOverlay && (
-              <div className="scan-upload-gate scan-upload-gate--signin">
-                <p className="scan-upload-gate__text">Login required</p>
-                <button type="button" className="action-signin scan-upload-gate__btn" onClick={openSignInModal}>
-                  Sign In
-                </button>
-                <p className="scan-upload-gate__secondary">
-                  <Link to="/scan">Or run a free extension risk check →</Link>
-                </p>
-              </div>
-            )}
-            <PrivateBuildDropzone disabled={!canUpload} />
+      <section className="scan-upload-hero" aria-label="Private extension audit">
+        <div
+          className={`scan-upload-hero-card ${isDragActive ? "scan-upload-hero-card--dragging" : ""}`}
+          onDragEnter={handleDragEnter}
+          onDragOver={handleDragOver}
+          onDragLeave={handleDragLeave}
+          onDrop={handleDrop}
+        >
+          <div className="scan-upload-hero-card__visual" aria-hidden="true">
+            <LockKeyhole size={23} strokeWidth={2.15} />
           </div>
 
-          <ul className="scan-upload-feature-strip" aria-label="Pro audit includes">
-            <li>SAST checks</li>
-            <li>Permission / host risk</li>
-            <li>Network indicators + reputation</li>
-            <li>Policy & governance checks</li>
-          </ul>
+          <div className="scan-upload-hero-card__copy">
+            <h1>{heroTitle}</h1>
+            <p>{heroCopy}</p>
+          </div>
 
-          <PrivateBuildTrustPills />
+          <div className="scan-upload-hero-card__actions">
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept={ACCEPTED_PRIVATE_BUILD_TYPES.join(",")}
+              className="scan-upload-page__file-input"
+              onChange={handleFileChange}
+              disabled={isParsing}
+            />
+            <button
+              type="button"
+              className="scan-upload-primary"
+              onClick={handleUploadClick}
+              disabled={isParsing}
+            >
+              <UploadCloud size={17} strokeWidth={2.2} />
+              <span>{primaryButtonText}</span>
+            </button>
+            {workspace && (
+              <button type="button" className="scan-upload-ghost" onClick={clearWorkspace}>
+                <X size={17} strokeWidth={2} />
+                <span>Clear</span>
+              </button>
+            )}
+          </div>
 
-          <p className="scan-upload-privacy">Reports are visible only to your account.</p>
+          {uploadError && (
+            <p className="scan-upload-hero-card__error" role="status">
+              <AlertCircle size={15} strokeWidth={2} />
+              <span>{uploadError}</span>
+            </p>
+          )}
         </div>
       </section>
 
+      {(isAuthenticated || isPreviewMode) && (
+        <section className={`archive-workspace ${isPreviewMode ? "archive-workspace--preview" : ""}`} aria-label="Private build file workspace">
+          <div className="archive-workspace__shell">
+            <div className="archive-workspace__topbar">
+              <div>
+                <span>File workspace</span>
+                {isPreviewMode && <span className="archive-workspace__preview-tag">Preview</span>}
+                <strong>{workspace?.fileName || "No build loaded"}</strong>
+              </div>
+              <div className="archive-workspace__meta">
+                {workspace
+                  ? `${workspace.archiveKind} / ${workspace.files.length} files / ${workspace.textFileCount} text / ${workspace.binaryFileCount} binary`
+                  : "Drop a CRX or ZIP to begin"}
+                {editedFileCount > 0 && <span>{editedFileCount} edited</span>}
+                {hasModifiedFiles && (
+                  <button type="button" className="archive-icon-button" onClick={handleDownloadZip} disabled={isExporting}>
+                    <Download size={14} strokeWidth={2} />
+                    <span>{isExporting ? "Exporting…" : "Export ZIP"}</span>
+                  </button>
+                )}
+              </div>
+            </div>
+
+            {workspace ? (
+              <div className="archive-workspace__body">
+                <ArchiveExplorer
+                  workspace={workspace}
+                  expandedFolders={expandedFolders}
+                  selectedPath={selectedPath}
+                  dirtyFiles={dirtyFiles}
+                  onToggleFolder={toggleFolder}
+                  onSelectFile={setSelectedPath}
+                  onCreateFile={createNewFile}
+                />
+
+                <main className="archive-editor" aria-label="Selected file editor">
+                  <div className="archive-editor__header">
+                    <div className="archive-editor__breadcrumbs">
+                      {(selectedPath || "Select a file").split("/").filter(Boolean).map((part, index, parts) => (
+                        <React.Fragment key={`${part}-${index}`}>
+                          {index > 0 && <ChevronRight size={14} strokeWidth={1.8} />}
+                          <span className={index === parts.length - 1 ? "archive-editor__crumb--active" : ""}>
+                            {part}
+                          </span>
+                        </React.Fragment>
+                      ))}
+                    </div>
+                    <div className="archive-editor__chips">
+                      {selectedFile && dirtyFiles[selectedFile.path] && (
+                        <>
+                          <span className="archive-editor__chip archive-editor__chip--dirty">Edited</span>
+                          <button type="button" className="archive-editor__chip archive-editor__chip--save" onClick={handleSaveFile}>
+                            <Save size={12} strokeWidth={2.2} />
+                            Save
+                          </button>
+                        </>
+                      )}
+                      {selectedFile && savedFiles[selectedFile.path] && !dirtyFiles[selectedFile.path] && (
+                        <span className="archive-editor__chip archive-editor__chip--saved">Saved</span>
+                      )}
+                      <span className="archive-editor__chip">{getFileTypeLabel(selectedFile)}</span>
+                      {selectedFile?.isText && <span className="archive-editor__chip">Editable</span>}
+                    </div>
+                  </div>
+
+                  {selectedFile?.isText ? (
+                    <Suspense fallback={<div className="audit-code-editor audit-code-editor--loading" aria-label="Loading code editor" />}>
+                      <AuditCodeEditor
+                        value={selectedFileContent}
+                        language={selectedFile.language}
+                        readOnly={isLoadingSelectedFile}
+                        onChange={handleEditorChange}
+                        ariaLabel={`Editor for ${selectedFile.path}`}
+                      />
+                    </Suspense>
+                  ) : selectedFile ? (
+                    <div className="archive-editor__empty">
+                      <FileArchive size={28} strokeWidth={1.7} />
+                      <h2>Binary file</h2>
+                      <p>{selectedFile.path} is not shown in the editor. Text files can be opened and edited here.</p>
+                      <span>{formatFileSize(selectedFile.size)}</span>
+                    </div>
+                  ) : (
+                    <div className="archive-editor__empty">
+                      <FileText size={28} strokeWidth={1.7} />
+                      <h2>Select a file</h2>
+                      <p>Choose a file from the explorer to inspect its contents.</p>
+                    </div>
+                  )}
+
+                  {(isLoadingSelectedFile || selectedFileError) && (
+                    <div className={`archive-editor__status ${selectedFileError ? "archive-editor__status--error" : ""}`}>
+                      {selectedFileError || "Loading file..."}
+                    </div>
+                  )}
+                </main>
+              </div>
+            ) : (
+              <button
+                type="button"
+                className={`archive-dropzone ${isDragActive ? "archive-dropzone--dragging" : ""}`}
+                onClick={handleUploadClick}
+                onDragEnter={handleDragEnter}
+                onDragOver={handleDragOver}
+                onDragLeave={handleDragLeave}
+                onDrop={handleDrop}
+              >
+                <FileArchive size={29} strokeWidth={1.8} />
+                <strong>{isParsing ? "Parsing archive" : "Drop CRX/ZIP here"}</strong>
+                <span>or choose a file to inspect the extension source tree</span>
+              </button>
+            )}
+          </div>
+        </section>
+      )}
+
+      {!isAuthenticated && !isPreviewMode && <SignedOutCodePreview />}
+
+      <p className="scan-upload-footnote">
+        <ShieldCheck size={15} strokeWidth={2} />
+        <Link to="/scan">Or run a free extension risk check</Link>
+        <ChevronRight size={15} strokeWidth={2} />
+      </p>
     </div>
   );
 }

--- a/frontend/src/pages/scanner/ScanUploadPage.scss
+++ b/frontend/src/pages/scanner/ScanUploadPage.scss
@@ -1,219 +1,1397 @@
-/* Scan Upload Page – minimal private build upload; theme-aware */
-
 .scan-upload-page {
   min-height: 100vh;
   width: 100%;
-  background: transparent;
   color: var(--extensionshield-text-primary);
-  font-family: var(--font-sans, inherit);
-  display: flex;
-  flex-direction: column;
+  font-family: var(--font-sans, system-ui, sans-serif);
+}
+
+.scan-upload-page__file-input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  opacity: 0;
+  pointer-events: none;
 }
 
 .scan-upload-hero {
   display: flex;
-  flex-direction: column;
-  align-items: center;
-  padding: calc(var(--extensionshield-header-height, 72px) + 2rem) var(--layout-padding-x, 1rem);
-  padding-top: 5rem;
+  justify-content: center;
+  padding: 2.45rem 1rem 0;
 }
 
-.scan-upload-content {
-  width: 100%;
-  max-width: 520px;
-  display: flex;
-  flex-direction: column;
+.scan-upload-hero-card {
+  width: min(100%, 1038px);
+  min-height: 84px;
+  display: grid;
+  grid-template-columns: 46px minmax(0, 1fr) auto;
   align-items: center;
-  text-align: center;
+  gap: 18px;
+  padding: 18px 24px;
+  text-align: left;
+  background: rgba(255, 255, 255, 0.76);
+  border: 1px solid rgba(17, 24, 39, 0.12);
+  border-radius: 9px;
+  box-shadow: 0 10px 30px rgba(36, 34, 30, 0.04);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  transition: border-color 0.18s ease, box-shadow 0.18s ease, background 0.18s ease;
 }
 
-/* 3-step indicator: 1 Upload → 2 Scan → 3 Report */
-.scan-upload-steps {
+.scan-upload-hero-card--dragging {
+  background: rgba(240, 253, 244, 0.86);
+  border-color: rgba(21, 128, 61, 0.48);
+  box-shadow: 0 16px 44px rgba(21, 128, 61, 0.12);
+}
+
+.scan-upload-hero-card__visual {
+  width: 44px;
+  height: 44px;
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 0;
-  margin-bottom: 2rem;
-  flex-wrap: wrap;
-}
-
-.scan-upload-steps__step {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.5rem;
-}
-
-.scan-upload-steps__step--active .scan-upload-steps__circle {
-  background: var(--extensionshield-accent);
-  color: #fff;
-  border-color: var(--extensionshield-accent);
-  box-shadow: 0 0 0 2px rgba(34, 197, 94, 0.2);
-}
-
-.scan-upload-steps__step--active .scan-upload-steps__label {
-  color: var(--extensionshield-text-primary);
-  font-weight: 500;
-}
-
-.scan-upload-steps__circle {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 26px;
-  height: 26px;
+  color: #0b8f43;
+  background: rgba(220, 252, 231, 0.48);
+  border: 1px solid rgba(22, 163, 74, 0.16);
   border-radius: 50%;
-  font-size: 0.75rem;
-  font-weight: 600;
-  color: var(--extensionshield-text-muted);
-  background: transparent;
-  border: 1px solid var(--extensionshield-border);
-  flex-shrink: 0;
+  box-shadow: inset 0 0 0 9px rgba(255, 255, 255, 0.48);
 }
 
-.scan-upload-steps__label {
-  font-size: clamp(0.75rem, 1.2vw, 0.8125rem);
-  color: var(--extensionshield-text-muted);
-  white-space: nowrap;
-}
-
-@media (max-width: 380px) {
-  .scan-upload-steps__label {
-    white-space: normal;
-    max-width: 5em;
-    text-align: left;
-  }
-}
-
-.scan-upload-steps__connector {
-  width: 28px;
-  height: 1px;
-  background: var(--extensionshield-border);
-  margin: 0 0.35rem;
-  flex-shrink: 0;
-}
-
-.scan-upload-kicker {
-  font-size: 0.6875rem;
-  font-weight: 600;
-  color: var(--extensionshield-text-muted);
-  letter-spacing: 0.15em;
-  margin: 0 0 0.5rem;
-  line-height: 1.4;
-}
-
-.scan-upload-headline {
-  font-size: clamp(1.375rem, 3vw, 1.75rem);
-  font-weight: 600;
-  line-height: 1.25;
-  margin: 0 0 0.5rem;
-  letter-spacing: -0.02em;
-  color: var(--extensionshield-text-primary);
-}
-
-.scan-upload-subhead {
-  font-size: clamp(0.9375rem, 1.5vw, 1.0625rem);
-  font-weight: 400;
-  line-height: 1.45;
-  margin: 0 0 2rem;
-  color: var(--extensionshield-text-secondary);
-}
-
-.scan-upload-dropzone-wrap {
-  position: relative;
+.scan-upload-hero-card__copy {
+  min-width: 0;
   width: 100%;
-  max-width: 520px;
-  margin: 3rem auto 1.5rem;
-  display: flex;
-  justify-content: center;
-}
 
-.scan-upload-gate {
-  position: absolute;
-  inset: 0;
-  z-index: 2;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  gap: 1rem;
-  background: rgba(28, 26, 23, 0.75);
-  backdrop-filter: blur(10px);
-  border-radius: 16px;
-  min-height: 200px;
-}
-
-.scan-upload-gate__text {
-  margin: 0;
-  font-size: 0.9375rem;
-  font-weight: 500;
-  color: var(--extensionshield-text-primary);
-}
-
-.scan-upload-gate__btn {
-  padding: 0.5rem 1.25rem;
-  font-size: 0.9375rem;
-  font-weight: 500;
-  color: #fff;
-  background: var(--extensionshield-accent);
-  border: none;
-  border-radius: 10px;
-  cursor: pointer;
-  transition: opacity 0.2s ease, box-shadow 0.2s ease;
-
-  &:hover {
-    opacity: 0.95;
-    box-shadow: 0 4px 12px var(--extensionshield-accent-glow);
+  h1 {
+    margin: 0 0 6px;
+    color: #111827;
+    font-size: 1rem;
+    font-weight: 760;
+    letter-spacing: 0;
+    line-height: 1.25;
   }
+
+  p {
+    max-width: 620px;
+    margin: 0;
+    color: #4b5563;
+    font-size: 0.82rem;
+    font-weight: 560;
+    line-height: 1.45;
+  }
+}
+
+.scan-upload-hero-card__actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 10px;
+  flex-wrap: nowrap;
+  margin-top: 0;
+}
+
+.scan-upload-primary,
+.scan-upload-ghost,
+.archive-icon-button,
+.archive-dropzone,
+.archive-tree-row {
+  font-family: inherit;
 
   &:focus-visible {
-    outline: none;
-    box-shadow: 0 0 0 2px var(--extensionshield-accent);
+    outline: 2px solid var(--extensionshield-accent);
+    outline-offset: 2px;
   }
 }
 
-.scan-upload-gate__secondary {
-  margin: 0.75rem 0 0;
-  font-size: 0.875rem;
+.scan-upload-primary {
+  min-height: 38px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  padding: 0 18px;
+  color: #ffffff;
+  background: linear-gradient(180deg, #08a750 0%, #07893f 100%);
+  border: 1px solid rgba(6, 95, 45, 0.2);
+  border-radius: 6px;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.22), 0 8px 18px rgba(5, 150, 105, 0.16);
+  cursor: pointer;
+  font-size: 0.84rem;
+  font-weight: 700;
+  line-height: 1;
+  transition: background 0.16s ease, border-color 0.16s ease, box-shadow 0.16s ease, transform 0.16s ease;
+
+  &:hover:not(:disabled) {
+    background: linear-gradient(180deg, #0bb457 0%, #087f3b 100%);
+    border-color: rgba(6, 95, 45, 0.32);
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.26), 0 10px 22px rgba(5, 150, 105, 0.22);
+    transform: translateY(-1px);
+  }
+
+  &:active:not(:disabled) {
+    transform: translateY(0);
+  }
+
+  &:disabled {
+    cursor: progress;
+    opacity: 0.72;
+  }
+}
+
+.scan-upload-ghost {
+  min-height: 40px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 0 14px;
+  color: #374151;
+  background: rgba(255, 255, 255, 0.72);
+  border: 1px solid rgba(17, 24, 39, 0.13);
+  border-radius: 6px;
+  cursor: pointer;
+  font-family: inherit;
+  font-size: 0.86rem;
+  font-weight: 700;
+  transition: background 0.16s ease, border-color 0.16s ease, color 0.16s ease, transform 0.16s ease;
+
+  &:hover {
+    color: #111827;
+    background: #ffffff;
+    border-color: rgba(21, 128, 61, 0.24);
+    transform: translateY(-1px);
+  }
+}
+
+.scan-upload-hero-card__error {
+  grid-column: 2 / -1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 7px;
+  margin: 0 !important;
+  color: #b91c1c !important;
+  font-size: 0.84rem !important;
+}
+
+.scan-report-preview {
+  display: flex;
+  justify-content: center;
+  padding: 24px 1rem 0;
+}
+
+.scan-report-preview__shell {
+  width: min(100%, 1242px);
+  overflow: hidden;
+  background: rgba(255, 255, 255, 0.76);
+  border: 1px solid rgba(17, 24, 39, 0.11);
+  border-radius: 10px;
+  box-shadow: 0 14px 38px rgba(36, 34, 30, 0.052);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+}
+
+.scan-report-preview__tabs {
+  min-height: 55px;
+  display: flex;
+  align-items: stretch;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 0 14px;
+  background: rgba(255, 255, 255, 0.72);
+  border-bottom: 1px solid rgba(17, 24, 39, 0.1);
+
+  nav {
+    min-width: 0;
+    display: flex;
+    align-items: stretch;
+    gap: 16px;
+    overflow-x: auto;
+    scrollbar-width: none;
+
+    &::-webkit-scrollbar {
+      display: none;
+    }
+  }
+}
+
+.scan-report-preview__tab {
+  position: relative;
+  min-width: max-content;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 0 10px;
+  color: #4b5563;
+  background: transparent;
+  border: 0;
+  cursor: default;
+  font-family: inherit;
+  font-size: 0.9rem;
+  font-weight: 560;
+
+  &::after {
+    content: "";
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    height: 3px;
+    border-radius: 999px 999px 0 0;
+    background: transparent;
+  }
+
+  strong {
+    min-width: 22px;
+    height: 22px;
+    display: inline-grid;
+    place-items: center;
+    color: #4b5563;
+    background: #eef0f2;
+    border-radius: 999px;
+    font-size: 0.78rem;
+    font-weight: 700;
+  }
+}
+
+.scan-report-preview__tab--active {
+  color: #111827;
+  font-weight: 760;
+
+  &::after {
+    background: #16a34a;
+  }
+}
+
+.scan-report-preview__actions {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.scan-report-preview__action,
+.scan-report-preview__icon-action {
+  height: 36px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: #111827;
+  background: rgba(255, 255, 255, 0.82);
+  border: 1px solid rgba(17, 24, 39, 0.12);
+  border-radius: 7px;
+  cursor: default;
+  font-family: inherit;
+  font-weight: 720;
+}
+
+.scan-report-preview__action {
+  gap: 8px;
+  padding: 0 14px;
+  font-size: 0.87rem;
+}
+
+.scan-report-preview__icon-action {
+  width: 40px;
+}
+
+.scan-report-preview__body {
+  display: grid;
+  grid-template-columns: 265px minmax(0, 1fr) 287px;
+  min-height: 520px;
+}
+
+.scan-report-preview__files {
+  min-width: 0;
+  display: grid;
+  grid-template-rows: auto 1fr auto;
+  background: rgba(248, 248, 247, 0.74);
+  border-right: 1px solid rgba(17, 24, 39, 0.1);
+}
+
+.scan-report-preview__files-header {
+  min-height: 48px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 0 16px;
+  color: #374151;
+  border-bottom: 1px solid rgba(17, 24, 39, 0.08);
+
+  span {
+    font-size: 0.78rem;
+    font-weight: 800;
+    letter-spacing: 0.09em;
+    text-transform: uppercase;
+  }
+
+  svg {
+    color: #6b7280;
+  }
+}
+
+.scan-report-preview__tree {
+  min-height: 0;
+  padding: 10px 12px 12px;
+  overflow: hidden;
+}
+
+.scan-preview-file-row {
+  width: 100%;
+  min-height: 29px;
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  min-width: 0;
+  padding: 0 9px 0 calc(8px + (var(--preview-depth, 0) * 18px));
+  color: #374151;
+  background: transparent;
+  border: 0;
+  border-radius: 6px;
+  cursor: default;
+  font-family: inherit;
+  font-size: 0.83rem;
+  font-weight: 560;
+  line-height: 1;
+  text-align: left;
+
+  span:last-child {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  svg {
+    flex: 0 0 auto;
+    color: #4b5563;
+  }
+}
+
+.scan-preview-file-row--folder {
+  font-weight: 690;
+}
+
+.scan-preview-file-row--active {
+  color: #111827;
+  background: rgba(17, 24, 39, 0.055);
+}
+
+.scan-preview-file-row__chevron {
+  transition: transform 0.14s ease;
+}
+
+.scan-preview-file-row__chevron--open {
+  transform: rotate(90deg);
+}
+
+.scan-preview-file-row__type {
+  width: 20px;
+  flex: 0 0 20px;
+  color: #f97316;
+  font-size: 0.7rem;
+  font-weight: 800;
+  text-align: right;
+}
+
+.scan-preview-file-row__type--html {
+  color: #f97316;
+  font-size: 0.68rem;
+}
+
+.scan-preview-file-row__type--css {
+  color: #2563eb;
+}
+
+.scan-preview-file-row__type--json {
+  color: #17803d;
+}
+
+.scan-report-preview__files-footer {
+  min-height: 38px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 0 16px;
+  color: #6b7280;
+  border-top: 1px solid rgba(17, 24, 39, 0.08);
+  font-size: 0.82rem;
+  font-weight: 560;
+}
+
+.scan-report-preview__editor {
+  min-width: 0;
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr);
+  background: #fffdfa;
+  border-right: 1px solid rgba(17, 24, 39, 0.1);
+
+  .audit-code-editor {
+    min-height: 472px;
+  }
+}
+
+.scan-report-preview__editor-header {
+  min-height: 48px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 14px;
+  padding: 0 16px 0 20px;
+  background: rgba(255, 255, 255, 0.54);
+  border-bottom: 1px solid rgba(17, 24, 39, 0.08);
+}
+
+.scan-report-preview__breadcrumbs {
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  overflow: hidden;
+  color: #6b7280;
+  font-size: 0.83rem;
+  font-weight: 600;
+
+  span,
+  strong {
+    min-width: max-content;
+  }
+
+  strong {
+    color: #111827;
+    font-weight: 760;
+  }
+}
+
+.scan-report-preview__crumb--type {
+  color: #f97316;
+  font-size: 0.74rem;
+  font-weight: 800;
+}
+
+.scan-report-preview__readonly {
+  flex: 0 0 auto;
+  min-height: 28px;
+  display: inline-flex;
+  align-items: center;
+  padding: 0 14px;
+  color: #4b5563;
+  background: #f0f2f5;
+  border-radius: 7px;
+  font-size: 0.76rem;
+  font-weight: 760;
+}
+
+.scan-report-preview__details {
+  min-width: 0;
+  display: grid;
+  align-content: start;
+  gap: 14px;
+  padding: 16px;
+  background: rgba(255, 253, 250, 0.88);
+}
+
+.scan-report-preview__detail-card {
+  min-width: 0;
+  padding: 0 0 16px;
+  overflow: hidden;
+  background: rgba(255, 255, 255, 0.74);
+  border: 1px solid rgba(17, 24, 39, 0.1);
+  border-radius: 8px;
+  box-shadow: 0 8px 20px rgba(15, 23, 42, 0.026);
+}
+
+.scan-report-preview__detail-header {
+  min-height: 50px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 0 14px;
+  border-bottom: 1px solid rgba(17, 24, 39, 0.08);
+
+  span {
+    color: #374151;
+    font-size: 0.78rem;
+    font-weight: 800;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+  }
+
+  strong {
+    display: inline-flex;
+    align-items: center;
+    min-height: 34px;
+    padding: 0 12px;
+    color: #ff1d2e;
+    background: rgba(239, 68, 68, 0.12);
+    border-radius: 7px;
+    font-size: 0.86rem;
+    font-weight: 780;
+  }
+}
+
+.scan-report-preview__finding-title {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 10px;
+  padding: 18px 14px 0;
+
+  > span {
+    width: 10px;
+    height: 10px;
+    margin-top: 6px;
+    background: #ff1d2e;
+    border-radius: 50%;
+  }
+
+  h2,
+  p {
+    margin: 0;
+  }
+
+  h2 {
+    color: #111827;
+    font-size: 0.96rem;
+    font-weight: 780;
+    line-height: 1.25;
+  }
+
+  p {
+    margin-top: 6px;
+    color: #6b7280;
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+    font-size: 0.78rem;
+    font-weight: 700;
+  }
+}
+
+.scan-report-preview__finding-copy {
+  margin: 14px 14px 12px;
+  color: #1f2937;
+  font-size: 0.84rem;
+  font-weight: 520;
+  line-height: 1.55;
+}
+
+.scan-report-preview__cwe {
+  display: inline-flex;
+  align-items: center;
+  min-height: 24px;
+  margin-left: 14px;
+  padding: 0 8px;
+  color: #4b5563;
+  background: #eef0f2;
+  border-radius: 6px;
+  font-size: 0.75rem;
+  font-weight: 720;
+}
+
+.scan-report-preview__recommendation {
+  margin: 17px 14px 0;
+
+  span {
+    display: block;
+    margin-bottom: 8px;
+    color: #4b5563;
+    font-size: 0.72rem;
+    font-weight: 780;
+  }
+
+  p {
+    margin: 0;
+    color: #111827;
+    font-size: 0.83rem;
+    line-height: 1.5;
+  }
+}
+
+.scan-report-preview__detail-card--version {
+  padding: 18px 14px 16px;
+
+  h2 {
+    margin: 0 0 24px;
+    color: #374151;
+    font-size: 0.78rem;
+    font-weight: 800;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+  }
+}
+
+.scan-report-preview__version-row {
+  display: grid;
+  grid-template-columns: 72px 66px minmax(0, 1fr);
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 16px;
+  color: #6b7280;
+  font-size: 0.84rem;
+  font-weight: 600;
+
+  p {
+    min-width: 0;
+    margin: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+}
+
+.scan-report-preview__version-pill {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 29px;
+  border-radius: 7px;
+  font-size: 0.83rem;
+  font-weight: 820;
+}
+
+.scan-report-preview__version-pill--current {
+  color: #059447;
+  background: rgba(16, 185, 129, 0.16);
+}
+
+.scan-report-preview__version-pill--previous {
+  color: #ef4444;
+  background: rgba(239, 68, 68, 0.14);
+}
+
+.scan-report-preview__compare {
+  width: 100%;
+  min-height: 38px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  margin-top: 10px;
+  color: #0a9448;
+  background: #ffffff;
+  border: 1px solid #16a34a;
+  border-radius: 6px;
+  cursor: default;
+  font-family: inherit;
+  font-size: 0.86rem;
+  font-weight: 780;
+}
+
+.archive-workspace {
+  display: flex;
+  justify-content: center;
+  padding: 24px 1rem 0;
+}
+
+.archive-workspace__shell {
+  width: min(100%, 1242px);
+  overflow: hidden;
+  background: rgba(255, 253, 250, 0.92);
+  border: 1px solid rgba(17, 24, 39, 0.12);
+  border-radius: 10px;
+  box-shadow: 0 14px 34px rgba(36, 34, 30, 0.05);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+}
+
+.archive-workspace__topbar {
+  min-height: 52px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 0 16px;
+  background: rgba(255, 255, 255, 0.62);
+  border-bottom: 1px solid rgba(17, 24, 39, 0.1);
+
+  > div:first-child {
+    min-width: 0;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+  }
+
+  span {
+    color: #6b7280;
+    font-size: 0.78rem;
+    font-weight: 800;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+  }
+
+  strong {
+    min-width: 0;
+    overflow: hidden;
+    color: #111827;
+    font-size: 0.9rem;
+    font-weight: 750;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+}
+
+.archive-workspace__meta {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 10px;
+  color: #5b6472;
+  font-size: 0.82rem;
+  font-weight: 600;
+  text-align: right;
+
+  span {
+    display: inline-flex;
+    align-items: center;
+    min-height: 24px;
+    padding: 0 8px;
+    color: #0a9448;
+    background: rgba(5, 150, 105, 0.12);
+    border-radius: 999px;
+    font-size: 0.72rem;
+    letter-spacing: 0;
+    text-transform: none;
+  }
+}
+
+.archive-workspace__body {
+  display: grid;
+  grid-template-columns: 286px minmax(0, 1fr);
+  min-height: 620px;
+}
+
+.archive-workspace--preview {
+  padding-top: 26px;
+
+  .archive-workspace__body {
+    grid-template-columns: 250px minmax(0, 1fr);
+    min-height: 430px;
+  }
+
+  .archive-explorer__tree {
+    overflow: hidden;
+  }
+
+  .archive-tree-row {
+    cursor: default;
+  }
+
+  .audit-code-editor {
+    min-height: 430px;
+  }
+}
+
+.archive-explorer {
+  min-width: 0;
+  display: grid;
+  grid-template-rows: auto 1fr auto;
+  background: rgba(248, 248, 247, 0.74);
+  border-right: 1px solid rgba(17, 24, 39, 0.1);
+}
+
+.archive-explorer__header {
+  min-height: 44px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 0 10px 0 14px;
+  border-bottom: 1px solid rgba(17, 24, 39, 0.08);
+
+  > span {
+    color: #374151;
+    font-size: 0.78rem;
+    font-weight: 800;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+  }
+}
+
+.archive-icon-button {
+  min-height: 30px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  padding: 0 10px;
+  color: #374151;
+  background: rgba(255, 255, 255, 0.76);
+  border: 1px solid rgba(17, 24, 39, 0.12);
+  border-radius: 6px;
+  cursor: pointer;
+  font-family: inherit;
+  font-size: 0.76rem;
+  font-weight: 750;
+  transition: background 0.16s ease, border-color 0.16s ease, color 0.16s ease;
+
+  &:hover {
+    color: #111827;
+    background: #ffffff;
+    border-color: rgba(21, 128, 61, 0.24);
+  }
+}
+
+.archive-explorer__tree {
+  min-height: 0;
+  padding: 8px 8px 10px;
+  overflow: auto;
+}
+
+.archive-tree-row {
+  width: 100%;
+  min-height: 28px;
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  min-width: 0;
+  padding: 0 8px 0 calc(8px + (var(--tree-depth, 0) * 15px));
+  color: #374151;
+  background: transparent;
+  border: 0;
+  border-radius: 5px;
+  cursor: pointer;
+  font-family: inherit;
+  font-size: 0.83rem;
+  font-weight: 560;
+  line-height: 1;
+  text-align: left;
+  transition: background 0.14s ease, color 0.14s ease;
+
+  svg {
+    flex: 0 0 auto;
+  }
+
+  span:not(.archive-tree-row__dirty):last-of-type {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  &:hover {
+    color: #111827;
+    background: rgba(17, 24, 39, 0.055);
+  }
+}
+
+.archive-tree-row--folder {
+  font-weight: 650;
+}
+
+.archive-tree-row--file {
+  color: #4b5563;
+}
+
+.archive-tree-row--active {
+  color: #111827;
+  background: rgba(21, 128, 61, 0.1);
+}
+
+.archive-tree-row__chevron {
+  color: #6b7280;
+  transition: transform 0.14s ease;
+}
+
+.archive-tree-row__chevron--open {
+  transform: rotate(90deg);
+}
+
+.archive-tree-row__spacer {
+  width: 14px;
+  flex: 0 0 14px;
+}
+
+.archive-tree-row__dirty {
+  width: 7px;
+  height: 7px;
+  flex: 0 0 7px;
+  margin-left: auto;
+  background: #0a9448;
+  border-radius: 999px;
+}
+
+.archive-explorer__footer {
+  min-height: 36px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 0 14px;
+  color: #6b7280;
+  border-top: 1px solid rgba(17, 24, 39, 0.08);
+  font-size: 0.8rem;
+  font-weight: 600;
+}
+
+.archive-editor {
+  position: relative;
+  min-width: 0;
+  display: grid;
+  grid-template-rows: auto 1fr;
+  background: #fffdfa;
+}
+
+.archive-editor__header {
+  min-height: 44px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 14px;
+  padding: 0 16px 0 20px;
+  background: rgba(255, 255, 255, 0.5);
+  border-bottom: 1px solid rgba(17, 24, 39, 0.08);
+}
+
+.archive-editor__breadcrumbs {
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  overflow: hidden;
+  color: #6b7280;
+  font-size: 0.83rem;
+  font-weight: 600;
+
+  span {
+    min-width: max-content;
+  }
+}
+
+.archive-editor__crumb--active {
+  color: #111827;
+  font-weight: 750;
+}
+
+.archive-editor__chips {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  gap: 7px;
+}
+
+.archive-editor__chip {
+  display: inline-flex;
+  align-items: center;
+  min-height: 26px;
+  padding: 0 9px;
+  color: #4b5563;
+  background: #f1f2f4;
+  border-radius: 7px;
+  font-size: 0.76rem;
+  font-weight: 750;
+}
+
+.archive-editor__chip--dirty {
+  color: #0a9448;
+  background: rgba(5, 150, 105, 0.13);
+}
+
+.archive-editor__chip--save {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  color: #ffffff;
+  background: linear-gradient(180deg, #08a750 0%, #07893f 100%);
+  border: 1px solid rgba(6, 95, 45, 0.2);
+  cursor: pointer;
+  transition: background 0.14s ease, transform 0.14s ease;
+
+  &:hover {
+    background: linear-gradient(180deg, #0bb457 0%, #087f3b 100%);
+    transform: translateY(-1px);
+  }
+}
+
+.archive-editor__chip--saved {
+  color: #0a9448;
+  background: rgba(5, 150, 105, 0.09);
+  font-style: italic;
+}
+
+.archive-workspace__preview-tag {
+  display: inline-flex;
+  align-items: center;
+  min-height: 22px;
+  padding: 0 8px;
+  color: #b45309;
+  background: rgba(245, 158, 11, 0.14);
+  border-radius: 999px;
+  font-size: 0.68rem !important;
+  font-weight: 750;
+  letter-spacing: 0.04em !important;
+  text-transform: uppercase !important;
+}
+
+.archive-editor__empty,
+.archive-dropzone {
+  min-height: 360px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+  gap: 10px;
+  padding: 36px 20px;
+  color: #4b5563;
+  text-align: center;
+
+  h2,
+  strong {
+    margin: 0;
+    color: #111827;
+    font-size: 1rem;
+    font-weight: 760;
+  }
+
+  p,
+  span {
+    max-width: 360px;
+    margin: 0;
+    color: #5b6472;
+    font-size: 0.9rem;
+    font-weight: 520;
+    line-height: 1.55;
+  }
+}
+
+.archive-dropzone {
+  width: calc(100% - 32px);
+  min-height: 310px;
+  margin: 16px;
+  background: rgba(250, 247, 241, 0.62);
+  border: 1px dashed rgba(17, 24, 39, 0.2);
+  border-radius: 8px;
+  cursor: pointer;
+  font-family: inherit;
+  transition: background 0.16s ease, border-color 0.16s ease, box-shadow 0.16s ease, transform 0.16s ease;
+
+  &:hover,
+  &.archive-dropzone--dragging {
+    background: rgba(240, 253, 244, 0.7);
+    border-color: rgba(21, 128, 61, 0.42);
+    box-shadow: 0 10px 24px rgba(21, 128, 61, 0.08);
+    transform: translateY(-1px);
+  }
+}
+
+.archive-editor__status {
+  position: absolute;
+  right: 16px;
+  bottom: 16px;
+  padding: 8px 10px;
+  color: #374151;
+  background: rgba(255, 255, 255, 0.92);
+  border: 1px solid rgba(17, 24, 39, 0.12);
+  border-radius: 7px;
+  box-shadow: 0 8px 18px rgba(15, 23, 42, 0.06);
+  font-size: 0.8rem;
+  font-weight: 700;
+}
+
+.archive-editor__status--error {
+  color: #b91c1c;
+  border-color: rgba(185, 28, 28, 0.22);
+}
+
+.audit-code-editor {
+  width: 100%;
+  height: 100%;
+  min-height: 546px;
+  overflow: hidden;
+  background: #fffdfa;
+
+  .monaco-editor,
+  .monaco-editor-background,
+  .monaco-editor .margin {
+    background: #fffdfa;
+  }
+
+  .monaco-editor .view-lines {
+    font-weight: 600;
+  }
+}
+
+.audit-code-editor--loading {
+  background:
+    linear-gradient(90deg, rgba(17, 24, 39, 0.04), rgba(17, 24, 39, 0.08), rgba(17, 24, 39, 0.04)),
+    #fffdfa;
+  background-size: 220% 100%;
+  animation: auditCodeLoading 1.1s ease-in-out infinite;
+}
+
+@keyframes auditCodeLoading {
+  from {
+    background-position: 100% 0;
+  }
+
+  to {
+    background-position: -100% 0;
+  }
+}
+
+.audit-code-editor__line--flagged {
+  background: rgba(239, 68, 68, 0.14);
+}
+
+.audit-code-editor__line-decoration--flagged {
+  border-left: 0;
+}
+
+.audit-code-editor__glyph--flagged {
+  position: relative;
+
+  &::before {
+    content: "";
+    position: absolute;
+    top: 8px;
+    left: 7px;
+    width: 10px;
+    height: 10px;
+    background: #ff1d2e;
+    border: 2px solid #fffdfa;
+    border-radius: 50%;
+    box-shadow: 0 0 0 1px rgba(239, 68, 68, 0.12);
+  }
+}
+
+.scan-upload-footnote {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  margin: 0;
+  padding: 30px 1rem 54px;
+  color: #4b5563;
+  font-size: 0.91rem;
+  font-weight: 500;
 
   a {
-    color: var(--extensionshield-accent);
+    color: inherit;
     text-decoration: none;
+    transition: color 0.16s ease;
 
     &:hover {
-      text-decoration: underline;
-    }
-  }
-}
-
-.scan-upload-feature-strip {
-  list-style: none;
-  padding: 0;
-  margin: 0 0 2rem;
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: center;
-  gap: 0.5rem 1rem;
-  font-size: 0.8125rem;
-  color: var(--extensionshield-text-secondary);
-
-  li {
-    &::before {
-      content: "✓ ";
       color: var(--extensionshield-accent);
-      font-weight: 600;
     }
   }
 }
 
-/* Light mode: gate overlay matches page background */
-.light .scan-upload-gate {
-  background: rgba(255, 255, 255, 0.88);
-  box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.06);
+@media (max-width: 980px) {
+  .scan-upload-hero-card {
+    grid-template-columns: 44px minmax(0, 1fr);
+    gap: 14px 16px;
+  }
+
+  .scan-upload-hero-card__actions {
+    grid-column: 2 / -1;
+    justify-content: flex-start;
+  }
+
+  .scan-report-preview__body {
+    grid-template-columns: 235px minmax(0, 1fr);
+  }
+
+  .scan-report-preview__details {
+    grid-column: 1 / -1;
+    grid-template-columns: minmax(0, 1fr) minmax(260px, 0.82fr);
+    border-top: 1px solid rgba(17, 24, 39, 0.1);
+  }
+
+  .archive-workspace__body {
+    grid-template-columns: 240px minmax(0, 1fr);
+  }
 }
 
-.scan-upload-privacy {
-  font-size: 0.8125rem;
-  color: var(--extensionshield-text-muted);
-  margin: 2rem 0 0;
-  line-height: 1.4;
+@media (max-width: 760px) {
+  .scan-upload-hero {
+    padding: 1.25rem 0 0;
+  }
+
+  .scan-upload-hero-card {
+    grid-template-columns: 44px minmax(0, 1fr);
+    justify-items: start;
+    gap: 14px;
+    padding: 18px;
+    text-align: left;
+  }
+
+  .scan-upload-hero-card__actions {
+    grid-column: 1 / -1;
+    width: 100%;
+    justify-content: flex-start;
+  }
+
+  .scan-report-preview {
+    padding: 18px 0 0;
+  }
+
+  .scan-report-preview__tabs {
+    min-height: auto;
+    align-items: stretch;
+    flex-direction: column;
+    gap: 10px;
+    padding: 0 12px 12px;
+
+    nav {
+      min-height: 52px;
+    }
+  }
+
+  .scan-report-preview__actions {
+    justify-content: flex-end;
+  }
+
+  .scan-report-preview__body {
+    display: block;
+  }
+
+  .scan-report-preview__files {
+    border-right: 0;
+    border-bottom: 1px solid rgba(17, 24, 39, 0.1);
+  }
+
+  .scan-report-preview__tree {
+    max-height: 265px;
+    overflow: auto;
+  }
+
+  .scan-report-preview__editor {
+    border-right: 0;
+
+    .audit-code-editor {
+      min-height: 430px;
+    }
+  }
+
+  .scan-report-preview__editor-header {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 8px;
+    padding: 12px;
+  }
+
+  .scan-report-preview__breadcrumbs {
+    width: 100%;
+    overflow-x: auto;
+    padding-bottom: 2px;
+  }
+
+  .scan-report-preview__details {
+    display: grid;
+    grid-template-columns: 1fr;
+  }
+
+  .archive-workspace {
+    padding: 18px 0 0;
+  }
+
+  .archive-workspace__topbar {
+    align-items: flex-start;
+    flex-direction: column;
+    padding: 12px;
+
+    > div:first-child {
+      width: 100%;
+      align-items: flex-start;
+      flex-direction: column;
+      gap: 4px;
+    }
+  }
+
+  .archive-workspace__meta {
+    width: 100%;
+    justify-content: flex-start;
+    flex-wrap: wrap;
+    text-align: left;
+  }
+
+  .archive-workspace__body {
+    display: block;
+  }
+
+  .archive-explorer {
+    border-right: 0;
+    border-bottom: 1px solid rgba(17, 24, 39, 0.1);
+  }
+
+  .archive-explorer__tree {
+    max-height: 280px;
+  }
+
+  .archive-editor__header {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 8px;
+    padding: 12px;
+  }
+
+  .archive-editor__breadcrumbs {
+    width: 100%;
+    overflow-x: auto;
+    padding-bottom: 2px;
+  }
+
+  .archive-editor__chips {
+    flex-wrap: wrap;
+  }
+
+  .archive-dropzone {
+    width: calc(100% - 24px);
+    margin: 12px;
+  }
+
+  .audit-code-editor {
+    min-height: 430px;
+  }
+}
+
+@media (max-width: 520px) {
+  .scan-upload-hero-card__copy h1 {
+    font-size: 0.98rem;
+  }
+
+  .scan-upload-hero-card__copy p {
+    font-size: 0.81rem;
+  }
+
+  .scan-upload-hero-card__actions {
+    align-items: stretch;
+    flex-direction: column;
+    gap: 10px;
+    width: 100%;
+  }
+
+  .scan-upload-primary {
+    width: 100%;
+    justify-content: center;
+  }
+
+  .scan-upload-ghost {
+    width: 100%;
+  }
+
+  .scan-report-preview__action span {
+    display: none;
+  }
+
+  .scan-report-preview__action {
+    width: 40px;
+    padding: 0;
+  }
+
+  .scan-report-preview__details {
+    padding: 12px;
+  }
+
+  .scan-report-preview__version-row {
+    grid-template-columns: 68px 62px minmax(0, 1fr);
+    gap: 8px;
+  }
+
+  .archive-tree-row {
+    min-height: 30px;
+  }
+
+  .archive-editor__empty,
+  .archive-dropzone {
+    min-height: 260px;
+  }
+
 }


### PR DESCRIPTION
- Rewrites the private build upload page with a full file workspace
- JSZip-based CRX/ZIP parsing, Monaco code editor, collapsible file tree
- Save file + export edited ZIP flow
- Signed-out hero card with sample extension preview
- `?preview=uploaded` dev mode for testing the workspace without login